### PR TITLE
Support the common <dc:creator> author name element

### DIFF
--- a/lib/gluttony/handlers/rss2_standard.ex
+++ b/lib/gluttony/handlers/rss2_standard.ex
@@ -149,6 +149,9 @@ defmodule Gluttony.Handlers.RSS2Standard do
       ["description", "item" | _] ->
         {:entry, :description, chars}
 
+      ["dc:creator", "item" | _] ->
+        {:entry, :author, chars}
+
       ["author", "item" | _] ->
         {:entry, :author, chars}
 


### PR DESCRIPTION
The < author > element is spec'ed to be the author's email address. In practice, this is undesirable so many feeds use the < dc:creator > element which is just the author's name instead. Technically, an item should not have both an < author > and a < dc:creator > element. If it does, last value will overwrite and win.

< author > element definition: https://www.rssboard.org/rss-profile#element-channel-item-author
< dc:creator > element definition: https://www.rssboard.org/rss-profile#namespace-elements-dublin-creator