### PR TITLE
Support content:encoded elements, the RSS equivalent to Atom's content

### DIFF
--- a/lib/gluttony/handlers/rss2_standard.ex
+++ b/lib/gluttony/handlers/rss2_standard.ex
@@ -149,6 +149,9 @@ defmodule Gluttony.Handlers.RSS2Standard do
       ["description", "item" | _] ->
         {:entry, :description, chars}
 
+      ["content:encoded", "item" | _] ->
+        {:entry, :content, chars}
+
       ["author", "item" | _] ->
         {:entry, :author, chars}
 


### PR DESCRIPTION
Some feeds provide the full text of the post. In RSS, there is an optional element called content:encoded that roughly parallels Atom's content element, except that Atom does not prescribe HTML encoding of the text. This adds support for the content:encoded element.