### PR TITLE
Support content and dc namespaces

### DIFF
--- a/lib/gluttony/handlers/rss2_content.ex
+++ b/lib/gluttony/handlers/rss2_content.ex
@@ -1,0 +1,31 @@
+defmodule Gluttony.Handlers.RSS2Content do
+  @moduledoc false
+
+  @behaviour Gluttony.Handler
+
+  @impl true
+  def handle_element(attrs, stack) do
+    case stack do
+      _ ->
+        {:cont, attrs}
+    end
+  end
+
+  @impl true
+  def handle_content(chars, stack) do
+    case stack do
+      ["content:encoded", "item" | _] ->
+        {:entry, :content, chars}
+
+      _ ->
+        {:cont, chars}
+    end
+  end
+
+  @impl true
+  def handle_cached(cached, stack) do
+    case stack do
+      _ -> {:cont, cached}
+    end
+  end
+end

--- a/lib/gluttony/handlers/rss2_dc.ex
+++ b/lib/gluttony/handlers/rss2_dc.ex
@@ -1,0 +1,31 @@
+defmodule Gluttony.Handlers.RSS2DC do
+  @moduledoc false
+
+  @behaviour Gluttony.Handler
+
+  @impl true
+  def handle_element(attrs, stack) do
+    case stack do
+      _ ->
+        {:cont, attrs}
+    end
+  end
+
+  @impl true
+  def handle_content(chars, stack) do
+    case stack do
+      ["dc:creator", "item" | _] ->
+        {:entry, :author, chars}
+
+      _ ->
+        {:cont, chars}
+    end
+  end
+
+  @impl true
+  def handle_cached(cached, stack) do
+    case stack do
+      _ -> {:cont, cached}
+    end
+  end
+end

--- a/lib/gluttony/parser.ex
+++ b/lib/gluttony/parser.ex
@@ -16,6 +16,8 @@ defmodule Gluttony.Parser do
   @feedburner_namespace "http://rssnamespace.org/feedburner/ext/1.0"
   @googleplay_namespace "http://www.google.com/schemas/play-podcasts/1.0"
   @atom_namespace "http://www.w3.org/2005/Atom"
+  @content_namespace "http://purl.org/rss/1.0/modules/content/"
+  @dc_namespace "http://purl.org/dc/elements/1.1/"
 
   @doc false
   def handle_event(:start_document, _prolog, opts) do
@@ -96,6 +98,12 @@ defmodule Gluttony.Parser do
 
         {"xmlns:googleplay", @googleplay_namespace}, acc ->
           [Gluttony.Handlers.RSS2Googleplay | acc]
+
+        {"xmlns:content", @content_namespace}, acc ->
+          [Gluttony.Handlers.RSS2Content | acc]
+
+        {"xmlns:dc", @dc_namespace}, acc ->
+          [Gluttony.Handlers.RSS2DC | acc]
 
         _kv, acc ->
           acc

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,10 @@ defmodule Gluttony.MixProject do
       description: description(),
       package: package(),
       docs: docs(),
-      deps: deps()
+      deps: deps(),
+      preferred_cli_env: [
+        vcr: :test, "vcr.delete": :test, "vcr.check": :test, "vcr.show": :test
+      ],
     ]
   end
 

--- a/test/fixtures/other/rss2_njmonitor.rss
+++ b/test/fixtures/other/rss2_njmonitor.rss
@@ -1,0 +1,5390 @@
+<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:atom="http://www.w3.org/2005/Atom"
+	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+	>
+
+<channel>
+	<title>New Jersey Monitor</title>
+	<atom:link href="https://newjerseymonitor.com/feed/" rel="self" type="application/rss+xml" />
+	<link>https://newjerseymonitor.com/</link>
+	<description>A Watchdog for the Garden State</description>
+	<lastBuildDate>Fri, 06 Sep 2024 18:19:38 +0000</lastBuildDate>
+	<language>en-US</language>
+	<sy:updatePeriod>
+	hourly	</sy:updatePeriod>
+	<sy:updateFrequency>
+	1	</sy:updateFrequency>
+	<generator>https://wordpress.org/?v=6.3.5</generator>
+
+<image>
+	<url>https://newjerseymonitor.com/wp-content/uploads/2021/07/cropped-NJ-Sq-2-32x32.png</url>
+	<title>New Jersey Monitor</title>
+	<link>https://newjerseymonitor.com/</link>
+	<width>32</width>
+	<height>32</height>
+</image> 
+	<item>
+		<title>Trump sentencing in New York hush money case postponed until after presidential election</title>
+		<link>https://newjerseymonitor.com/2024/09/06/trump-sentencing-in-new-york-hush-money-case-postponed-until-after-presidential-election/</link>
+		
+		<dc:creator><![CDATA[Ashley Murray]]></dc:creator>
+		<pubDate>Fri, 06 Sep 2024 18:19:38 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Alvin Bragg]]></category>
+		<category><![CDATA[Donald Trump]]></category>
+		<category><![CDATA[Judge Juan Merchan]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14717</guid>
+
+					<description><![CDATA[A judge set a sentencing date for former President Donald Trump in his New York hush money case for Nov. 26 — three weeks after the election.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/09/TrumpMay30-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" fetchpriority="high" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/09/TrumpMay30-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/09/TrumpMay30-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/09/TrumpMay30-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/09/TrumpMay30-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/09/TrumpMay30-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Former U.S. President Donald Trump speaks to the media as he arrives to court for his hush money trial at Manhattan Criminal Court on May 30, 2024, in New York City. (Steven Hirsch-Pool | Getty Images)</p><p>WASHINGTON — Former President Donald Trump will not face criminal sentencing in New York for his state felony convictions ahead of the November election, according to a decision released Friday by New York Judge Juan Merchan.</p>
+<p>The New York judge said Friday the new sentencing date will be Nov. 26,  according to a <a href="https://www.nycourts.gov/LegacyPDFS/press/pdfs/PeoplevDJT-Letter-Adjournment-Dec9-6-24.pdf" target="_blank">letter</a> he issued Friday.</p>
+<p>Merchan wrote that the court is “now at a place in time that is fraught with complexities,” referring to the fast-approaching presidential election and the consequential U.S. Supreme Court ruling on presidential immunity that Trump’s legal team has now brought to the center of the New York case.</p>
+<p>“Adjourning decision on the motion and sentencing, if such is required, should dispel any suggestion that the Court will have issued any decision or imposed sentence either to give an advantage to, or to create a disadvantage for, any political party and/or any candidate for any office,” Merchan wrote.</p>
+<p>“This is not a decision the court makes lightly but it is the decision which in this court’s view best advances the interests of justice,” Merchan later concluded.</p>
+<p>Trump, vying again for the Oval Office as the Republican nominee, is the first-ever former president to become a felon.</p>
+<p>He was <a href="https://www.newsfromthestates.com/article/trump-found-guilty-34-felony-counts-ny-hush-money-trial-10" target="_blank">convicted</a> on 34 counts of falsifying business records in May after a weeks-long Manhattan trial that centered on hush money payments to a porn star ahead of the 2016 presidential election.</p>
+<p>Trump <a href="https://www.nycourts.gov/LegacyPDFS/press/pdfs/2024-08-14-Letter-re-sentencing-adjournment.pdf" target="_blank">asked</a> the New York court to delay the sentencing until after the 2024 election, arguing that the question of presidential immunity as it related to the New York conviction remains unresolved.</p>
+<p>Friday’s decision marks the second time Merchan has delayed Trump’s sentencing.</p>
+<p>Merchan <a href="https://www.newsfromthestates.com/article/trump-ny-sentencing-delayed-after-us-supreme-court-presidential-immunity-ruling-3" target="_blank">delayed</a> Trump’s initial July sentencing <a href="https://www.nycourts.gov/LegacyPDFS/press/PDFs/People%20v.%20DJT%207-2-24%20Letter.pdf" target="_blank">date</a>, just one day after the U.S. Supreme Court <a href="https://www.newsfromthestates.com/article/presidential-immunity-covers-some-official-acts-supreme-court-rules-trump-case" target="_blank">ruled</a> that former presidents enjoy criminal immunity for official “core constitutional” acts and at least presumptive immunity for “outer perimeter” activities, but not for personal ones.</p>
+<p>Trump’s lawyers <a href="https://www.nycourts.gov/LegacyPDFS/press/PDFs/Letter-to-JusticeMerchan-immunity-decision.pdf" target="_blank">argued</a> the Supreme Court’s presidential immunity decision nullified his New York state convictions, particularly because the evidence presented at trial could now be considered subject to immunity.</p>
+<p>Manhattan District Attorney Alvin Bragg <a href="https://www.nycourts.gov/LegacyPDFS/press/PDFs/PML-Response-on-Immunity.pdf" target="_blank">agreed</a> to a delay while the parties filed legal arguments on the issue of immunity, which Bragg ultimately <a href="https://www.nycourts.gov/LegacyPDFS/press/PDFs/Memo-of-law-in-opposition2-post-trial-motion.pdf" target="_blank">argued</a> had “no bearing” on Trump’s convictions and evidence examined by the jury.</p>
+<p>Trump, who has been entangled on several legal fronts, escalated his separate federal criminal case alleging 2020 election interference all the way to the Supreme Court, arguing presidential immunity for any criminal charges stemming from his time in office.</p>
+<p>The case alleging Trump schemed to overturn the 2020 presidential election results was returned to federal trial court. U.S. District Judge Tanya Chutkan on Thursday <a href="https://www.newsfromthestates.com/article/trumps-jan-6-case-extend-beyond-election-day-under-timeline-laid-out-judge%C2%A0-2" target="_blank">released</a> a pre-trial calendar that extends beyond this November’s election.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>5 things to know about the Harris-Trump presidential debate</title>
+		<link>https://newjerseymonitor.com/2024/09/06/5-things-to-know-about-the-harris-trump-presidential-debate/</link>
+		
+		<dc:creator><![CDATA[Shauneen Miranda]]></dc:creator>
+		<pubDate>Fri, 06 Sep 2024 14:48:31 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Politics]]></category>
+		<category><![CDATA[Donald Trump]]></category>
+		<category><![CDATA[Kamala Harris]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14701</guid>
+
+					<description><![CDATA[Vice President Kamala Harris and former President Donald Trump will square off Tuesday in the only planned presidential pre-election debate.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/09/redandbluewhitehouse-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/09/redandbluewhitehouse-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/09/redandbluewhitehouse-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/09/redandbluewhitehouse-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/09/redandbluewhitehouse-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/09/redandbluewhitehouse-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Vice President Kamala Harris, the Democratic presidential nominee, and former President Donald Trump, the Republican nominee, will debate Sept. 10 in Philadelphia. (Getty stock photo)</p><p>Vice President Kamala Harris and former President Donald Trump will take the stage next week in the only planned debate between the respective Democratic and GOP presidential candidates between now and November.</p>
+<p>It’s the first presidential debate since President Joe Biden bowed out of the race following his own disastrous debate performance in late June against Trump. Biden, who faced mounting calls to resign, <a href="https://www.newsfromthestates.com/article/pass-torch-biden-addresses-nation-why-he-wont-seek-second-term" target="_blank">passed the torch</a> to Harris back in July.</p>
+<p>The veep has embarked on an unprecedented and expedited campaign as she and Trump vie for the Oval Office. The election is just two months away.</p>
+<p>Though the Harris and Trump campaigns clashed over debate procedures in recent weeks, both candidates have agreed to the finalized rules. ABC News, host of the debate, released the rules Wednesday.</p>
+    <h4 class="editorialSubhed">When and where is the debate? </h4>
+
+	
+<p>The debate will be Tuesday, Sept. 10, at 9 p.m. Eastern time at the National Constitution Center in Philadelphia, Pennsylvania. The debate will be 90 minutes long and include two commercial breaks, <a href="https://abc.com/news/5e38600c-4732-4cd2-a99c-3dedfa81beb0/category/1138628" target="_blank">according to ABC</a>.</p>
+<p>The Keystone State — where both Harris and Trump have spent a lot of time campaigning — could determine the outcome of the presidential election. The battleground state has narrowly flip-flopped in recent elections, with Biden <a href="https://www.politico.com/2020-election/results/pennsylvania/" target="_blank">turning Pennsylvania blue</a> in 2020 after Trump <a href="https://www.politico.com/2016-election/results/map/president/pennsylvania/" target="_blank">secured a red win</a> in 2016.</p>
+    <h4 class="editorialSubhed">How can I watch the debate?</h4>
+
+	
+<p>The debate will air live on ABC News and will also be streaming on ABC News Live, Disney+ and Hulu.</p>
+<p>ABC News’ David Muir and Linsey Davis will moderate the debate.</p>
+<p>Harris and Trump will each have two minutes to answer questions and two minutes to give rebuttals. They will also be granted one additional minute to clarify or follow up on anything.</p>
+    <h4 class="editorialSubhed">Will the mics be muted? </h4>
+
+	
+<p>Microphones will be muted when it’s not a candidate’s turn to speak, just like the previous debate between Biden and Trump in June.</p>
+<p>The candidates will not give opening statements. Trump won a coin flip to determine the order of closing statements and podium placement. Trump, who selected the statement order, will give the final closing statement.</p>
+<p>Each closing statement will be two minutes long.</p>
+<p>Harris and Trump are not allowed to bring any props or prewritten notes to the debate stage. They will each receive a pen, a pad of paper and a water bottle.</p>
+    <h4 class="editorialSubhed">Will there be a live audience?</h4>
+
+	
+<p>There will be no live audience at the National Constitution Center, as was the case in the last presidential debate.</p>
+<p>Harris and Trump are not permitted to interact with their campaign staff during the two commercial breaks.</p>
+    <h4 class="editorialSubhed">Trump slams ABC ahead of debate</h4>
+
+	
+<p>Trump went on the attack over the details of the debate, telling <a href="https://www.newsfromthestates.com/article/town-hall-no-questions-trump-grouses-about-polls-attacks-debate-host" target="_blank">Fox News’ Sean Hannity</a> during an interview Wednesday in Pennsylvania that “ABC is the worst network in terms of fairness” and “the most dishonest network, the meanest, the nastiest.”</p>
+<p>He accused the network of releasing poor polls on purpose ahead of a previous election to drive down voter turnout.</p>
+<p>Trump also claimed, without evidence, that Harris would get the questions in advance of the debate. ABC’s debate rules state that no candidates or campaigns will receive any topics or questions ahead of the event.</p>
+<p>Meanwhile, Democratic Minnesota Gov. Tim Walz and Ohio Republican Sen. J.D. Vance will battle it out at the <a href="https://www.newsfromthestates.com/article/mark-your-calendar-vp-candidates-walz-and-vance-debate-oct-1" target="_blank">vice presidential debate</a> hosted by CBS News on Oct. 1 in New York City.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Canada trip part of Gov. Murphy&#8217;s effort to create &#8216;long-term investments&#8217; in N.J., allies say</title>
+		<link>https://newjerseymonitor.com/2024/09/06/canada-trip-part-of-gov-murphys-effort-to-create-long-term-investments-in-n-j-allies-say/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Fri, 06 Sep 2024 11:00:24 +0000</pubDate>
+				<category><![CDATA[Economy]]></category>
+		<category><![CDATA[Gov + Legislature]]></category>
+		<category><![CDATA[Choose NJ]]></category>
+		<category><![CDATA[Economic Development Authority]]></category>
+		<category><![CDATA[Ingrid Austin]]></category>
+		<category><![CDATA[Phil Murphy]]></category>
+		<category><![CDATA[Robert Scott]]></category>
+		<category><![CDATA[Tim Sullivan]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14618</guid>
+
+					<description><![CDATA[Gov. Phil Murphy will depart this weekend on the latest in a series of trade missions, which sometimes yield job gains.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="667" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/Murphy-and-Fukui-GO-1-crop-1024x667.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/Murphy-and-Fukui-GO-1-crop-1024x667.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Murphy-and-Fukui-GO-1-crop-300x195.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Murphy-and-Fukui-GO-1-crop-768x500.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Murphy-and-Fukui-GO-1-crop.jpg 1536w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Gov. Phil Murphy and Fukui Prefecture Lt. Gov. Yasuhiro Nakamura sign a memorandum of understanding during Murphy's trade trip to Japan in October 2023. (Courtesy of the New Jersey Governor's Office)</p><p style="font-weight: 400;">Gov. Phil Murphy will embark this weekend on the latest in a series of international trade missions that administration officials say have helped secure global investment in the Garden State.</p>
+<p style="font-weight: 400;">Trade missions like the one that begins Saturday are meant to draw new firms to the state or expand the presence of global companies already operating in New Jersey.</p>
+<p style="font-weight: 400;">The governor’s upcoming trip to Canada is intended to bolster investment in state industries on film and fintech — financial technology to enable digital banking, investment, and other services.</p>
+<p style="font-weight: 400;">“Our efforts to bolster New Jersey’s thriving film and fintech industries must extend beyond both state lines and national borders. It is only fitting that we deepen our economic ties with Canada while exploring new opportunities to solidify our status as a global leader in these fields,” Murphy said in a statement.</p>
+<p style="font-weight: 400;">Past economic missions have taken the governor to India, South Korea, Taiwan, Japan, Germany, Ireland, and Israel.</p>
+<p style="font-weight: 400;">Robert Scott, a professor of economics at Monmouth University, said such trade missions can benefit the state, even though they are expensive, requiring airfare, work hours, and hotel rooms for sizable groups.</p>
+<p style="font-weight: 400;">“If they are able to convince even one large company to move some operations to NJ, then I’m sure the return on investment is significant and well worth the effort,” he said in an email.</p>
+<p style="font-weight: 400;">Ingrid Austin is a spokeswoman for Choose New Jersey, a nonprofit that works with the state to boost global investment here. She said past trips had secured 2,558 new jobs from international firms and generated 50 memorandums of understanding encouraging future investment.</p>
+<p style="font-weight: 400;">These memorandums are not typically legally binding, though they may encourage connectivity between parties, Scott said.</p>
+<p style="font-weight: 400;">Some of those job gains stem from commitments obtained during the trade missions. Tata Consultancy Services, a multinational IT services and consulting firm based in India, committed to expanding New Jersey operations by 1,000 jobs during a 2019 trade mission to India.</p>
+<p style="font-weight: 400;">“They&#8217;ve actually overdelivered on that promise,” Economic Development Authority CEO Tim Sullivan told the New Jersey Monitor.</p>
+<p style="font-weight: 400;">Scott said the job gains were likely beneficial, but the degree of the benefit depended on the type of jobs created and cautioned some job gains might be unrelated to the trade missions.</p>
+<p style="font-weight: 400;">&#8220;Would these companies have come to New Jersey anyway? Maybe not, but I&#8217;m skeptical by nature,&#8221; he said.</p>
+<p style="font-weight: 400;">Interest from global firms also spiked following these trips, Austin said. In 2018, 20 Indian companies expressed a desire to establish or expand operations in New Jersey, compared to 369 in 2024.</p>
+<p style="font-weight: 400;">Scott said the trips could make New Jersey appear a more favorable business environment. The state has the fourth-highest corporate tax rate in the nation, and the highest for firms with more than $10 million in annual profit.</p>
+<p style="font-weight: 400;">“So, while it’s probably an expensive endeavor, at least they are experimenting and making efforts to increase NJ’s visibility to other nations,” he said in an email.</p>
+<p style="font-weight: 400;">New Jersey’s broad and varied diaspora communities can also help the state win gains from the international trips, Sullivan said, noting business and government leaders in the host nations often have family, friends, or other acquaintances in New Jersey.</p>
+<p style="font-weight: 400;">“We&#8217;re an international state. I don&#8217;t think it&#8217;s ideological to recognize — or unique to Phil Murphy — to recognize that we are an international gateway, an international crossroads. We have diaspora communities from everywhere in the world,” he said.</p>
+<p style="font-weight: 400;">Sullivan said the trips are meant mainly to establish relationships and boost investment in New Jersey over the long run.</p>
+<p style="font-weight: 400;">Though, he noted, investments in film tend to have a quick turnaround.</p>
+<p style="font-weight: 400;">“There&#8217;s lots of specifics that come from every trip, for sure, but they usually take some time to deliver it,” Sullivan said. “These aren&#8217;t the kind of things where it&#8217;s a first meeting or a first visit and you should expect to transact. These are long-term relationship building and long-term investments as well.”</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>‘License plate flippers’ help drivers evade police, tickets and tolls</title>
+		<link>https://newjerseymonitor.com/2024/09/06/license-plate-flippers-help-drivers-evade-police-tickets-and-tolls/</link>
+		
+		<dc:creator><![CDATA[Amanda Hernández]]></dc:creator>
+		<pubDate>Fri, 06 Sep 2024 10:59:11 +0000</pubDate>
+				<category><![CDATA[Criminal Justice]]></category>
+		<category><![CDATA[Transportation]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14688</guid>
+
+					<description><![CDATA[“License plate flippers” are devices that allow drivers to conceal their license plates at the press of a button. Cops are cracking down.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="682" src="https://newjerseymonitor.com/wp-content/uploads/2024/09/plate-flippers.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/09/plate-flippers.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/09/plate-flippers-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/09/plate-flippers-768x512.jpg 768w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Law enforcement personnel in New York examine a license plate during a multi-agency operation at the Robert F. Kennedy Bridge in March 2024. The operation marked the launch of a new city-state task force aimed at identifying and removing “ghost cars” — vehicles that evade detection by traffic cameras and toll readers due to forged or altered license plates — from New York City streets. (Courtesy of Marc A. Hermann | Metropolitan Transportation Authority)</p><p>State and local legislators in Tennessee and Pennsylvania are cracking down on the use of “license plate flippers,” devices that allow drivers to obscure or conceal their license plates at the press of a button.</p>
+<p>License plate flippers are commonly used for aesthetic purposes at auto shows, where they allow drivers to switch between custom or decorative plates. But across the country, thousands of drivers also flip or cover their license plates to evade detection — whether by law enforcement, toll systems or automated speed cameras.</p>
+<p><a href="https://statutes.capitol.texas.gov/Docs/TN/htm/TN.504.htm#:~:text=LICENSE%20PLATE%20FLIPPER%3B%20OFFENSE" target="_blank" rel="noopener">Texas</a> and <a href="https://app.leg.wa.gov/rcw/default.aspx?cite=46.37.685" target="_blank" rel="noopener">Washington</a> explicitly banned the devices in 2013. Nonetheless, it’s generally illegal across the United States to alter or obstruct a license plate, no matter the method.</p>
+<p>In Tennessee, a <a href="https://wapp.capitol.tn.gov/apps/BillInfo/Default.aspx?BillNumber=HB2145&amp;GA=113" target="_blank" rel="noopener">law</a> that went into effect in July bans the purchase, sale, possession of and manufacture of plate flippers. Lawmakers said they worried about drivers trying to evade law enforcement.</p>
+<p><iframe class="wp-embedded-content" title="“Car thefts and carjackings are up. Unreliable data makes it hard to pinpoint why.” — Stateline" src="https://stateline.org/2024/02/09/car-thefts-and-carjackings-are-up-unreliable-data-makes-it-hard-to-pinpoint-why/embed/#?secret=ZhxkprEOh4#?secret=JCi5bWaFEK" width="500" height="416" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" sandbox="allow-scripts" data-secret="JCi5bWaFEK" data-mce-fragment="1"></iframe></p>
+<p>“We don’t have any toll roads today, but we do have criminals today,” Tennessee state Republican Rep. Greg Martin, who sponsored the legislation in the House, said in an interview. “This [measure] is to make sure that everyone is playing on the same playing field.”</p>
+<p>Under the new law, anyone who purchases a license plate flipper could face up to six months in jail and a fine of up to $500. Those caught manufacturing or selling these devices could face up to 11 months and 29 days in jail, along with a fine of up to $2,500.</p>
+<p>The Pennsylvania House passed, with bipartisan support, <a href="https://www.legis.state.pa.us/cfdocs/billinfo/billinfo.cfm?syear=2023&amp;sInd=0&amp;body=H&amp;type=B&amp;bn=2426" target="_blank" rel="noopener">legislation</a> that would ban license plate flippers and impose a $2,000 penalty on those caught using or selling them. The bill now goes to the Senate.</p>
+<p>“With speed cams and red-light cams becoming more and more prevalent around, there are technologies that are coming out for people to evade safety on the roads,” Pennsylvania state Democratic Rep. Pat Gallagher, the bill’s lead sponsor in the House, said in an interview.</p>
+    <h4 class="editorialSubhed">Cities take action</h4>
+
+	
+<p>Some cities also are looking to crack down on these devices.</p>
+<p>In April, Philadelphia Mayor Cherelle Parker, a Democrat, signed a bill into <a href="https://phila.legistar.com/LegislationDetail.aspx?ID=6509975&amp;GUID=925E1AC0-D5C7-49A6-8E4B-254029D5D743&amp;Options=ID%7CText%7C&amp;Search=240089-A" target="_blank" rel="noopener">law</a> banning the purchase, installation, possession of and sale of “manual, electric, or mechanical” license plate flippers, with violations punishable by a $2,000 fine.</p>
+<p>“Tag flipping belongs in a James Bond movie, not on our city streets,” Philadelphia Councilmember Mike Driscoll, a Democrat, said in an interview with Stateline. “It’s not just a problem in the city of Philadelphia; this sense of entitlement and lawlessness is going on all over the country.</p>
+<p>“Every municipality has got to take these things seriously,” Driscoll said.</p>
+<p><iframe class="wp-embedded-content" title="“Less driving but more deaths: Spike in traffic fatalities puzzles lawmakers” — Stateline" src="https://stateline.org/2023/11/10/less-driving-but-more-deaths-spike-in-traffic-fatalities-puzzles-lawmakers/embed/#?secret=Dco36HlaZ7#?secret=j0xdmJbIAN" width="500" height="325" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" sandbox="allow-scripts" data-secret="j0xdmJbIAN" data-mce-fragment="1"></iframe></p>
+<p>In March, New York state and city officials <a href="https://new.mta.info/press-release/icymi-governor-hochul-and-mayor-adams-launch-largest-interagency-city-state-task" target="_blank" rel="noopener">launched</a> a multi-agency task force dedicated to identifying and removing so-called “ghost cars” — vehicles that are untraceable by traffic cameras and toll readers due to their forged or altered license plates — from New York City streets.</p>
+<p>In 2022, New York City Mayor Eric Adams, a Democrat, reached an <a href="https://www.nyc.gov/office-of-the-mayor/news/623-22/mayor-adams-amazon-collaborate-crack-down-ghost-vehicles-illicit-license-plates-nyc" target="_blank" rel="noopener">agreement</a> with Amazon to help search for and restrict the sale of smokescreen and tinted license plate covers to customers with a New York state address. This collaboration followed the passage of a city law earlier that year prohibiting the sale of products designed to conceal or obscure vehicle license plates to New York City residents.</p>
+    <h4 class="editorialSubhed">Criminal activity and toll revenue</h4>
+
+	
+<p>Recent discussions around license plate flippers have largely focused on their role in criminal activity and the loss of revenue from tolls and traffic tickets.</p>
+<p>Obstructing license plates is a common violation, with some drivers using plate flippers, duct tape or bogus paper tags to avoid detection. In some cases, the obstruction may be unintentional, such as when bike racks partially block the plate.</p>
+<p>Chad Bruckner, a retired police detective who is now the president of the private investigation firm Intercounty Investigations &amp; Solutions, said that while he supports legislation banning tag flippers, it’s important to balance protecting citizens’ rights with providing law enforcement the tools needed to promote public safety.</p>
+<p>“If you can’t identify a vehicle, you don’t have the legal tooth or authority to execute a stop or something,” Bruckner said in an interview. “There’s just no law and order. That’s not safe for people.”</p>
+<p>License plate flippers are widely accessible online, with devices available for as little as $50 and as much as a few hundred dollars, though most typically sell for around $200.</p>
+<p>Other devices, such as license plate covers that obscure letters and numbers from certain angles, are already illegal in most states. These covers, whether clear or tinted, can affect visibility for traffic and tolling cameras.</p>
+<div>
+<div>
+<div class=" newsroomBlockQuoteContainer  ">
+	<div class="newsroomBlockQuoteSVGContainer">
+		<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12.81 9">
+			<g>
+				<path d="M2.7,0A3,3,0,0,0,.7.8,2.64,2.64,0,0,0,0,2.7,2.14,2.14,0,0,0,.8,4.4a2.84,2.84,0,0,0,1.7.7,1.45,1.45,0,0,0,.7-.2,1.45,1.45,0,0,1,.7-.2q.3,0,.3.6A3.47,3.47,0,0,1,3,7.6a4.21,4.21,0,0,1-2.6,1V9a5.51,5.51,0,0,0,4-1.6A5.06,5.06,0,0,0,6,3.7a3.92,3.92,0,0,0-.9-2.6A3.19,3.19,0,0,0,2.7,0Z"/>
+				<path d="M11.8,1.1A2.84,2.84,0,0,0,9.5,0a2.79,2.79,0,0,0-2,.8,2.64,2.64,0,0,0-.7,1.9,2.06,2.06,0,0,0,.7,1.7,2.41,2.41,0,0,0,1.8.7,1.85,1.85,0,0,0,.7-.2,1.45,1.45,0,0,1,.7-.2q.3,0,.3.6A2.94,2.94,0,0,1,9.8,7.6a4.21,4.21,0,0,1-2.6,1V9a5.51,5.51,0,0,0,4-1.6,4.6,4.6,0,0,0,1.6-3.8A3.47,3.47,0,0,0,11.8,1.1Z"/>
+			</g>
+		</svg>
+	</div>
+	<div class="newsroomBlockQuoteQuoteContainer">
+		<p class="newsroomBlockQuote ">If you can’t identify a vehicle, you don't have the legal tooth or authority to execute a stop or something. There's just no law and order. That's not safe for people.</p>
+	</div>
+		<div class="newsroomBlockQuoteAuthorContainer">
+		<p style="font-size:13px"><b>– Chad Bruckner, retired detective and president of Intercounty Investigations &amp; Solutions</b></p>
+	</div>
+	</div>
+
+	</div>
+<div></div>
+</div>
+<p>Most tolling agencies aren’t significantly affected by these violations financially because the majority of drivers comply with the law. But MTA Bridges and Tunnels in New York City, one of the busiest toll agencies in the United States, reported a loss of more than $21 million in 2023 due to obstructed plates, a more than 140% increase from 2020, according to Aaron Donovan, the agency’s deputy communications director.</p>
+<p>The agency projects a slightly lower revenue loss of nearly $19 million for 2024, thanks to the new task force dedicated to cracking down on untraceable vehicles. The task force <a href="https://www.fox5ny.com/news/toll-dodgers-illegally-altered-obscured-license-plates" target="_blank" rel="noopener">has seized</a> over 2,100 vehicles and made more than 450 arrests since mid-March. Those arrests often reveal that evaders are involved in other criminal activities, such as possessing illegal firearms or driving stolen vehicles, according to MTA Bridges and Tunnels President Catherine Sheridan.</p>
+<p>“This is a larger regional issue where these same people who are avoiding tolls are also not paying parking tickets. They’re violating school cameras, speed cameras,” Sheridan said in an interview. “We’re also finding that these folks are committing other crimes in our region.”</p>
+<p>The losses represent less than 1% of the agency’s total toll revenue, but they’re still significant, she said, because they reduce the agency’s ability to subsidize mass transit in New York City, which in turn affects residents who rely on public transportation.</p>
+<p>“Every dollar we don’t collect is $1 off of that subsidy,” Sheridan said. “This is about everyone paying their fair share.”</p>
+<p><iframe class="wp-embedded-content" title="“Dark highways, fast cars, few sidewalks — and more pedestrian deaths” — Stateline" src="https://stateline.org/2024/08/30/dark-highways-fast-cars-few-sidewalks-and-more-pedestrian-deaths/embed/#?secret=IiPBODkOfY#?secret=DGrd9JClks" width="500" height="388" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" sandbox="allow-scripts" data-secret="DGrd9JClks" data-mce-fragment="1"></iframe></p>
+<p>The Port Authority of New York and New Jersey, which manages several bridges and tunnels connecting the two states and is part of the multi-agency task force dedicated to cracking down on untraceable vehicles, lost about $40 million in toll revenue from obscured and missing plates in 2022, according to Lenis Valens, a public information officer with the agency.</p>
+<p>In that same year, the agency <a href="https://www.panynj.gov/port-authority/en/press-room/press-release-archives/2023-press-releases/-port-authority-issued-nearly-4-700-summonses-in-full-year-2022-.html" target="_blank" rel="noopener">issued</a> more than 2,300 summonses for obstructed, missing and fictitious license plates, and <a href="https://www.panynj.gov/port-authority/en/press-room/press-release-archives/2024-Press-Releases/port-authority-recovers-more-than--25-million-from-toll-evaders-.html" target="_blank" rel="noopener">recovered</a> more than $21 million in past-due tolls and fees. In 2023, the agency recovered over $25 million from toll evaders. During the first six months of 2024, it <a href="https://www.panynj.gov/port-authority/en/press-room/press-release-archives/2024-Press-Releases/port-authority-turns-up-heat-on-toll-cheats-in-2024--number-of-s.html" target="_blank" rel="noopener">issued</a> 4,836 summonses for toll-related violations, with the majority — 3,940, or 81% — for obstructed, missing or fictitious license plates.</p>
+<p>On the Pennsylvania Turnpike, a major toll highway that connects western and eastern Pennsylvania, at least 3 in 10,000 people intentionally obstructed their license plates between April 2023 and March 2024, press secretary Marissa Orbanek wrote in an email.</p>
+<p>“While the percentage of intentional plate obstruction on the turnpike is very, very small, we are grateful for any additional support and legislation that helps us address toll evasion,” Orbanek wrote. “It’s really a priority to ensure a fair and equitable toll road system.”</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Trump promotes raising tariffs, corporate tax cut in battle over economy with Harris</title>
+		<link>https://newjerseymonitor.com/2024/09/05/trump-promotes-raising-tariffs-corporate-tax-cut-in-battle-over-economy-with-harris/</link>
+		
+		<dc:creator><![CDATA[Jacob Fischler]]></dc:creator>
+		<pubDate>Thu, 05 Sep 2024 22:56:12 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Economy]]></category>
+		<category><![CDATA[Donald Trump]]></category>
+		<category><![CDATA[Kamala Harris]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14709</guid>
+
+					<description><![CDATA[Former President Donald Trump vowed to protect U.S. industries, if elected, by increasing import tariffs and cutting other taxes and regulations.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="663" src="https://newjerseymonitor.com/wp-content/uploads/2024/09/Tax-2048x1326-1-1024x663.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/09/Tax-2048x1326-1-1024x663.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/09/Tax-2048x1326-1-300x194.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/09/Tax-2048x1326-1-768x497.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/09/Tax-2048x1326-1-1536x995.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/09/Tax-2048x1326-1.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Taxes and the economy are taking center stage in the 2024 presidential campaign. (Getty Images)</p><p>Former President Donald Trump said Thursday he would protect American industries if he is reelected by increasing tariffs on imports while cutting other taxes and regulations, in a speech to the Economic Club of New York.</p>
+<p>The GOP presidential candidate’s remarks came as the economy has taken center stage in the run-up to the 2024 presidential election. Both Trump and the Democratic nominee, Vice President Kamala Harris, have criticized a ballooning national deficit, high housing costs and increasingly expensive groceries.</p>
+<p>In a wide-ranging speech that also framed his hardline immigration position in economic terms and blasted Harris for what he said were the policy shortcomings of the Biden administration, Trump laid out several planks of an economic platform focused on corporate tax cuts and protectionist policies that he predicted would boost domestic manufacturing.</p>
+<p>“Some might say it’s economic nationalism,” he said. “I call it common sense. I call it America First … We have to take care of our own nation and our industries first.”</p>
+<p>Trump’s speech came one day after Harris delivered new <a href="https://www.newsfromthestates.com/article/harris-roll-out-new-plan-tax-relief-small-businesses" target="_blank">proposals to cut taxes on small businesses</a> during a <a href="https://newhampshirebulletin.com/2024/09/04/harris-unveils-tax-cut-proposal-for-small-businesses-at-new-hampshire-rally/" target="_blank">speech</a> at a brewery in New Hampshire.</p>
+<p>While Trump would cut corporate taxes and extend the tax cut for high earners that he signed during his first term, he said he would raise tariffs, which are taxes on foreign goods. Doing so would compel U.S. companies to keep their production jobs in the country, he said.</p>
+<p>Tariffs would also seed a new “sovereign wealth fund” that would “return a gigantic profit,” he said.</p>
+<p>He told the economists and business professionals in the room that he would lean on them to advise on the fund, and that it would be flush with cash from tariffs on foreign imports.</p>
+<p>The “greatest sovereign wealth fund,” he said, would also pay for infrastructure, defense capabilities and “cutting-edge medical research,” as well as pay down the nation’s debt.</p>
+<p>“We’ll create America’s own sovereign wealth fund to invest in great national endeavors for the benefit of all of the American people,” he said. “Why don’t we have a wealth fund? Other countries have wealth funds. We have nothing. We have nothing. We’re going to have a sovereign wealth fund or we can name it something different.”</p>
+    <h4 class="editorialSubhed">Tax battle</h4>
+
+	
+<p>Trump told the group that Harris would raise taxes, including on unrealized gains on investments before they are sold.</p>
+<p>“Unbelievably, she will seek a tax on unrealized capital gains,” he said.</p>
+<p>Trump would lower the corporate tax rate from 21% to 15%, he said, while Harris would raise it to 28%.</p>
+<p>He also said he would appoint Elon Musk, the billionaire owner of X who has endorsed Trump and regularly posts about the election, to lead a government efficiency commission.</p>
+<p>Trump would seek to make permanent the tax cuts he signed into law in 2017. Taxes have featured prominently on the campaign trail ahead of the 2025 expiration of the law that cut individual tax rates, reduced the corporate tax rate and doubled the child tax credit.</p>
+<p>In her remarks in New Hampshire, Harris promised to increase deductions tenfold on business start-up costs, up to $50,000 from $5,000. She also vowed to simplify the tax filing process for entrepreneurs by allowing them to claim a standard deduction, similar to what’s available for individual income taxpayers.</p>
+<p>Harris also drew attention to her New Hampshire speech when she broke with President Joe Biden’s tax plan for capital gains, promising “a rate that rewards investment in America’s innovators, founders and small businesses.”</p>
+<p>Harris told the crowd that anyone earning $1 million or more would see a 28% rate on long-term capital gains under her administration, if elected. The proposal deviates from Biden’s plan to raise revenue by taxing capital gains over $1 million at 39.6%. Biden also proposed a 5% Medicare surcharge on long-term capital gains for high earners.</p>
+<p>The current rate for high earners is 20%.</p>
+<p>A long-term capital gain tax is applied to any profit made on the sale of an asset, like stocks, bonds, or real estate, held by the owner for more than a year.</p>
+    <h4 class="editorialSubhed">Immigration</h4>
+
+	
+<p>Trump also sought to make his signature policy issue — an ultra-hardline immigration stance — an economic one.</p>
+<p>An increasing number of migrants entering the country through the border with Mexico are taking jobs from Americans, he said, singling out Americans of color.</p>
+<p>“Hispanic American jobs are under massive threat from the invasion taking place at our border,” Trump said. “They’re taking jobs from Hispanic Americans, African Americans.”</p>
+<p>He added, falsely, that all jobs created during the Biden administration were filled by immigrants in the country illegally.</p>
+<p>Trump has called for an <a href="https://www.newsfromthestates.com/article/trump-promises-mass-deportations-undocumented-people-how-would-work" target="_blank">unprecedented deportation program</a> of undocumented immigrants and has placed the blame for record migrant crossings on Biden and Harris.</p>
+    <h4 class="editorialSubhed">‘Like nobody’s ever grown before’</h4>
+
+	
+<p>Trump promised “tremendous growth,” mostly attributing that growth to a yet unnamed percentage tariff on foreign imports. He signaled his target for tariffs will be higher than any percentage floated so far.</p>
+<p>“We’re gonna grow like nobody’s ever grown before,” he said. “We will be bringing in billions and billions of dollars, which will reduce our deficit.”</p>
+<p>He also suggested during the question-and-answer portion that funds raised through tariffs could help families reduce the cost of child care, but offered little detail.</p>
+<p>But economists and critics say Trump’s major economic plans to raise tariffs and extend his signature tax cuts will put additional costs on consumers and add trillions to the deficit.</p>
+<p>Trump’s plan to extend the 2017 tax cuts would add between $4.1 and $5.8 trillion to the national deficit over the next decade, <a href="https://budgetmodel.wharton.upenn.edu/issues/2024/8/26/trump-campaign-policy-proposals-2024?te=1&amp;nl=the-morning&amp;emc=edit_nn_20240903" target="_blank">according</a> to the University of Pennsylvania’s Wharton Budget Model.</p>
+    <h4 class="editorialSubhed">Rule of law</h4>
+
+	
+<p>Trump said the country has suffered economically under Biden and Harris because of his legal issues.</p>
+<p>Trump has faced four criminal prosecutions, including two federal cases related to his <a href="https://www.newsfromthestates.com/article/federal-judge-dismisses-trump-classified-documents-criminal-case" target="_blank">mishandling</a> of classified documents following his presidency and his <a href="https://www.newsfromthestates.com/article/trumps-jan-6-case-extend-beyond-election-day-under-timeline-laid-out-judge%C2%A0-2" target="_blank">conduct</a> to provoke the Jan. 6, 2021 attack on the U.S. Capitol.</p>
+<p>He was also <a href="https://www.newsfromthestates.com/article/trump-found-guilty-34-felony-counts-ny-hush-money-trial-10" target="_blank">convicted</a> of New York state felonies related to an illegal hush money arrangement during his first White House campaign and is charged in Georgia with election interference related to the 2020 campaign.</p>
+<p>He said Thursday the prosecutions were politically motivated, making investors lose faith in the country’s governance. He hinted that he would retaliate and said that he would eliminate political prosecutions.</p>
+<p>“They always have to remember that two can play that game,” he said. “Nobody ever thought this was possible. This is how you create massive capital flight and turn once prosperous nations into absolute ruins. I will have no higher priority as president than to restore the fair, equal and impartial rule of law in America. We have lost the rule of law.”</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>New Jersey joins fight to defend new rule expanding protections for LGBTQ students</title>
+		<link>https://newjerseymonitor.com/briefs/new-jersey-joins-fight-to-defend-new-rule-expanding-protections-for-lgbtq-students/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Thu, 05 Sep 2024 20:51:44 +0000</pubDate>
+				<category><![CDATA[Courts]]></category>
+		<category><![CDATA[Education]]></category>
+		<category><![CDATA[Gov + Legislature]]></category>
+		<category><![CDATA[Matt Platkin]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14704</guid>
+
+					<description><![CDATA[In briefs, the states argued rules to expand Title IX to bar discrimination on gender identity and sexual orientation should take effect.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2022/11/Platkin-2-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2022/11/Platkin-2-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2022/11/Platkin-2-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2022/11/Platkin-2-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2022/11/Platkin-2-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2022/11/Platkin-2-2048x1365.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Attorney General Matt Platkin and other attorneys general argued blocked federal rule would not endanger student privacy. (Photo courtesy of New Jersey Attorney General's Office)</p><p>New Jersey Attorney General Matt Platkin and attorneys general from 17 other states and the District of Columbia are defending a federal rule that would extend sex discrimination protections in education to cover sexual orientation and gender identity.</p>
+<p>In new <a href="https://www.nj.gov/oag/newsreleases24/2024-0904_Amicus-Brief.pdf" target="_blank">briefs</a> filed Wednesday, the states pushed to reverse injunctions against the rule issued by federal judges in Louisiana and Kansas, who found <a href="https://www.ed.gov/news/press-releases/us-department-education-releases-final-title-ix-regulations-providing-vital-protections-against-sex-discrimination" target="_blank">the rule</a> exceeded the executive branch’s authority.</p>
+<p>“In a free and fair country, all students should be protected from discrimination based on sexual orientation and gender identity,” Platkin said in a statement. “All students deserve and are entitled to protection from harassment and harm in school.”</p>
+<p>The Department of Education in April <a href="https://newjerseymonitor.com/2024/04/19/biden-administration-to-roll-back-the-betsy-devos-title-ix-rules/">announced changes</a> to Title IX rules that would bar discrimination based on sexual orientation and gender, expanding the 1972 civil rights law beyond strictly sex-based discrimination — and undoing changes made by former Education Secretary Betsy DeVos.</p>
+<p>The new provisions would bar discrimination or disparate treatment based on sexual orientation and gender identity in most circumstances, subjecting violators to a loss of federal funds. It would not affect sex-separated living spaces or athletics, which the department said it would address in a separate rules change.</p>
+<p>The rule was due to go into effect Aug. 1, but the Louisiana and Kansas judges issued injunctions in July blocking it.</p>
+<p>In the amicus briefs, Platkin said the rule provisions allowing students to use certain facilities, like bathrooms, would improve those students’ health and not harm the privacy of others.</p>
+<p>“As another school year begins, New Jersey families should know that they will always have the protection of my office when it comes to safeguarding their rights to learn in educational environments free of harassment, threats, bias, and intimidation,” Platkin said.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Developer convicted with ex-senator Bob Menendez pleads guilty in related bank fraud case</title>
+		<link>https://newjerseymonitor.com/briefs/developer-convicted-with-ex-senator-bob-menendez-pleads-guilty-in-related-bank-fraud-case/</link>
+		
+		<dc:creator><![CDATA[Dana DiFilippo]]></dc:creator>
+		<pubDate>Thu, 05 Sep 2024 20:11:17 +0000</pubDate>
+				<category><![CDATA[Courts]]></category>
+		<category><![CDATA[Criminal Justice]]></category>
+		<category><![CDATA[Menendez on trial]]></category>
+		<category><![CDATA[Bob Menendez]]></category>
+		<category><![CDATA[Fred Daibes]]></category>
+		<category><![CDATA[Philip Hellinger]]></category>
+		<category><![CDATA[Sidney H. Stein]]></category>
+		<category><![CDATA[Susan D. Wigenton]]></category>
+		<category><![CDATA[Vikas Khanna]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14700</guid>
+
+					<description><![CDATA[Developer Fred Daibes, convicted of bribing Bob Menendez, pleaded guilty Thursday in the bank fraud case he paid the former senator to squash.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/06/GettyImages-2157124026.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/06/GettyImages-2157124026.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/06/GettyImages-2157124026-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/06/GettyImages-2157124026-768x512.jpg 768w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Fred Daibes arrives for trial at Manhattan federal court on June 11, 2024. He was convicted in July of bribing former Sen. Bob Menendez with cash and gold bars to help him dodge a criminal prosecution. (Michael M. Santiago | Getty Images)</p><p style="font-weight: 400;">Edgewater developer Fred Daibes pleaded guilty Thursday in the bank fraud case he bribed former Sen. Bob Menendez to squash.</p>
+<p style="font-weight: 400;">Daibes, 67, faces up to 30 months in prison and $1 million in fines for fraudulently obtaining a $1.8 million loan in 2008 from Mariner’s Bank in Edgewater, where he was CEO and board chairman, according to the U.S. Attorney’s Office of New Jersey.</p>
+<p style="font-weight: 400;">Daibes pleaded guilty in federal court in Newark to making false entries to deceive the bank. U.S. District Judge Susan D. Wigenton set sentencing for Jan. 23.</p>
+<p style="font-weight: 400;">He was <a href="https://www.justice.gov/usao-nj/media/1366446/dl?inline" target="_blank">indicted</a> in 2018 and later agreed to a plea deal that would have gotten him probation, instead of prison time. But Wigenton <a href="https://www.nbcnewyork.com/news/local/crime-and-courts/judge-throws-out-daibes-fraud-plea-that-has-been-part-of-menendez-bribery-probe/4742708/" target="_blank">rejected</a> the deal last October, after federal prosecutors in New York City <a href="https://newjerseymonitor.com/2023/09/22/sen-menendez-faces-bribery-related-offenses-in-second-criminal-case/">indicted</a> Menendez, Daibes, and three others in the bribery scheme.</p>
+<p style="font-weight: 400;">In that scheme, prosecutors said Daibes paid Menendez tens of thousands of dollars in cash and gold bars, and in exchange, the former senator intervened in an attempt to derail Daibes’ bank fraud case. Testimony about the scheme dominated several days of the 10-week bribery trial in Manhattan where Menendez, Daibes, and a third co-defendant, Wael Hana, were <a href="https://newjerseymonitor.com/2024/07/16/sen-menendez-convicted-of-bribery-other-charges-in-corruption-trial/">convicted</a> in July.</p>
+<p style="font-weight: 400;">Philip Sellinger, U.S. Attorney for New Jersey, <a href="https://newjerseymonitor.com/2024/06/12/official-testifies-sen-menendez-asked-him-to-look-at-criminal-case-targeting-his-friend/">testified</a> that Menendez, his longtime friend, called him in late 2020 to complain about Daibes’ prosecution. Sellinger was just being considered for the post at that time; Menendez, a Democrat and New Jersey’s senior senator, got to recommend candidates for federal posts to the White House. Sellinger testified that Menendez said Daibes was being treated unfairly and urged him to “look at it carefully,” should he get the job.</p>
+<p style="font-weight: 400;">Sellinger, though, told Menendez he likely would be recused from the case because of a conflict of interest, prompting Menendez to recommend another candidate for the job.</p>
+<p style="font-weight: 400;">Sellinger later got the job anyway when the White House dropped the other candidate, and his new bosses ordered him off Daibes&#8217; bank fraud case.</p>
+<p style="font-weight: 400;">Vikas Khanna, Sellinger&#8217;s first assistant, took over the case — but he also got a call from Menendez. Khanna <a href="https://newjerseymonitor.com/2024/06/26/as-feds-closed-in-sen-menendezs-wife-cashed-out-jeweler-tells-jury-in-bribery-trial/">testified</a> that Menendez made no direct demand about the Daibes case in that 2022 call but instead praised Daibes’ defense attorney.</p>
+<p style="font-weight: 400;">Menendez, Daibes and Hana are scheduled for sentencing Oct. 29 in Manhattan for their bribery convictions. Any sentence Wigenton decrees for Daibes&#8217; bank fraud case could run concurrent to whatever sentence federal Judge Sidney H. Stein orders in the bribery case.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Nursing homes sue New Jersey over &#8216;unconstitutional&#8217; staffing mandate</title>
+		<link>https://newjerseymonitor.com/briefs/nursing-homes-sue-new-jersey-over-unconstitutional-staffing-mandate/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Thu, 05 Sep 2024 17:19:17 +0000</pubDate>
+				<category><![CDATA[Courts]]></category>
+		<category><![CDATA[Health]]></category>
+		<category><![CDATA[Kaitlan Baston]]></category>
+		<category><![CDATA[Long-term Care]]></category>
+		<category><![CDATA[Phil Murphy]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14694</guid>
+
+					<description><![CDATA[Nursing homes say in a new lawsuit N.J. has too few workers to meet state-mandated staffing minimums, leaving them at risk of $1,000 daily fines.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2022/07/GettyImages-755651227-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2022/07/GettyImages-755651227-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2022/07/GettyImages-755651227-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2022/07/GettyImages-755651227-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2022/07/GettyImages-755651227-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2022/07/GettyImages-755651227-2048x1365.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Several nursing homes and an industry group have sued the state of New Jersey over a 2020 law mandating minimum staffing levels, saying a worker shortage makes compliance impossible. (Getty Images)</p><p>Half a dozen nursing homes and an industry lobbying group have sued the state over staffing mandates, claiming worker shortages exacerbated by the pandemic make it impossible to comply, leaving the 2020 law setting staff minimums unconstitutional.</p>
+<p>The Health Care Association of New Jersey, a long-term care industry group, says the $1,000 daily fines levied against nursing homes that fail to meet statutory staffing minimums ran afoul of constitutional protections on due process and against excessive fines.</p>
+<p>“It is impossible for the Nursing Home industry to comply with the Staffing Law — there are not enough workers available in the system,” they said in <a href="https://newjerseymonitor.com/wp-content/uploads/2024/09/DoH-lawsuit-staffing.pdf">a complaint</a> filed last week in state Superior Court in Mercer County.</p>
+<p><a href="https://pub.njleg.gov/bills/2020/PL20/112_.PDF" target="_blank">The law</a> at question — approved early in the pandemic after COVID-19 raged through the state’s long-term care centers, <a href="https://newjerseymonitor.com/2024/03/11/new-jersey-collectively-failed-to-prepare-for-pandemic-long-awaited-report-says/">leaving thousands dead</a> — required such facilities to staff at least one certified nursing aide for every eight residents on the day shift, 10 on evening shifts, and 14 on night shifts.</p>
+<p>In their lawsuit, the nursing homes said the staffing shortages forced long-term care centers to compete with each other for workers, including from staffing agencies, to maintain their workforces.</p>
+<p>But they said even those measures would leave some facilities understaffed and facing fines.</p>
+<p>“The result is a classic zero-sum game with guaranteed losers. If on a given day one Nursing Home is lucky enough to have sufficient staff show up for work, by necessity other Nursing Homes will fail to comply with the Staffing Law’s mandate,” they said in their filing.</p>
+<p>It’s unclear how much long-term care centers have been fined over insufficient staffing. The suit charged some facilities had been assessed fines totaling more than $100,000.</p>
+<p>The Department of Health, which is named as a defendant alongside Health Commissioner Kaitlan Baston, did not immediately respond to a request for comment on the lawsuit or the total fines assessed over subpar staffing.</p>
+<p>A spokesperson for Gov. Phil Murphy declined to comment on the litigation, to which the department has yet to file a formal reply.</p>
+<p>The nursing homes aren’t the only ones concerned about long-term care staffing.</p>
+<p>In <a href="https://www.nj.gov/health/ltc/documents/nj-task-force-ltc-quality-and-safety-report.pdf" target="_blank">an April report,</a> the New Jersey Task Force on Long-Term Care Quality and Safety warned the industry’s workforce was shrinking and would be unable to meet the state’s needs as its population ages.</p>
+<p>They cited poor pay, a lack of advancement opportunities, training costs, and ageism as hurdles for the industry, adding New Jersey’s graying population would make the shortages more dire over time.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Trump’s Jan. 6 case to extend beyond Election Day under timeline laid out by judge</title>
+		<link>https://newjerseymonitor.com/2024/09/05/judge-in-trumps-jan-6-case-says-it-wont-be-delayed-by-upcoming-presidential-election/</link>
+		
+		<dc:creator><![CDATA[Ashley Murray]]></dc:creator>
+		<pubDate>Thu, 05 Sep 2024 17:15:11 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14697</guid>
+
+					<description><![CDATA[The case accusing former President Donald Trump of subverting the 2020 presidential election results will move ahead, a judge said Thursday.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/09/TRUMPIOWA-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/09/TRUMPIOWA-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/09/TRUMPIOWA-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/09/TRUMPIOWA-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/09/TRUMPIOWA-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/09/TRUMPIOWA-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Republican presidential candidate former President Donald Trump speaks during a rally at Clinton Middle School on Jan. 6, 2024, in Clinton, Iowa. (Scott Olson | Getty Images)</p><p>WASHINGTON — Exactly two months out from the presidential election, U.S. District Judge Tanya Chutkan plans to move ahead with the case accusing former President Donald Trump of subverting the 2020 presidential election results, telling Trump’s attorneys that she is “not concerned with the electoral schedule.”</p>
+<p>Chutkan released a timeline for the case late Thursday afternoon setting several deadlines for evidence, briefs and replies for the weeks prior to November’s election, and ultimately stretching beyond Election Day.</p>
+<p>While it had been evident for some time that the Republican presidential nominee likely would not face a trial before Nov. 5 on election interference charges, Chutkan’s calendar made it certain.</p>
+<p>Trump did not appear in federal court for Thursday morning’s hearing in Washington, D.C., but his lawyers pleaded not guilty on his behalf to the four charges that remained unchanged in U.S. special counsel Jack Smith’s new indictment, filed last week.</p>
+<p>The case had been in a holding pattern for eight months as Trump appealed his claim of presidential immunity all the way to the U.S. Supreme Court.</p>
+<p>U.S. prosecutors say they are ready to restart the case in the coming weeks, while Trump’s team has argued for more time to review evidence and dismiss the superseding indictment.</p>
+<p>The Supreme Court returned Trump’s case to the trial court after <a href="https://www.newsfromthestates.com/article/presidential-immunity-covers-some-official-acts-supreme-court-rules-trump-case" target="_blank">ruling</a> that former presidents are immune from criminal charges for official “core constitutional” acts while in office and hold at least presumptive immunity for “outer perimeter” activities, but not for personal actions.</p>
+<p>This gave Chutkan, an Obama administration appointee, the major task of parsing Smith’s indictment, deciding which allegations against Trump fall under the umbrella of official acts and which relate to actions taken in a personal capacity.</p>
+<p>Chutkan set the following deadlines on the pre-trial calendar:</p>
+<ul>
+<li>The government must complete all mandatory evidentiary disclosures by Sept. 10, with other disclosures ongoing afterward.</li>
+<li>Trump’s reply briefs to certain evidence matters are due Sept. 19.</li>
+<li>The government’s opening brief on presidential immunity is due Sept. 26, and the Trump legal team’s reply is due on Oct. 17. The government’s opposition is thereafter due on Oct. 29.</li>
+<li>Trump is also scheduled to provide a supplement to his original motion to dismiss based on statutory grounds by Oct. 3, and the government must reply by Oct. 17.</li>
+<li>Trump’s request to file a motion based on his argument that Smith was illegally appointed to his special prosecutor position is due on Oct. 24, with the government’s reply due on Oct. 31. The due date for Trump’s opposition to the government’s reply is Nov. 7, stretching the pre-trial calendar beyond the presidential election.</li>
+</ul>
+    <h4 class="editorialSubhed">Chutkan skeptical</h4>
+
+	
+<p>Chutkan did not issue any decisions on immunity at the Thursday hearing but rather spent significant time grilling Trump’s attorney John Lauro on why he believes it is “unseemly” for Smith’s office to lay out its case this month in an opening brief. Thomas Windom, a federal prosecutor in Smith’s office, said the government would be ready to file the brief by the end of September.</p>
+<p>Lauro argued that Smith wanting to file “at breakneck speed” is “incredibly unfair that they are able to put in the public record (evidence) at this sensitive time in our nation’s history.”</p>
+<p>“I understand there’s an election impending,” Chutkan snapped back, reminding him that it “is not relevant here.”</p>
+<p>“Three weeks is not exactly breakneck speed,” Chutkan added.</p>
+<p>Lauro argues that Chutkan should examine parts of the indictment that accuse Trump of pressuring then-Vice President Mike Pence to accept false slates of electors leading up to Pence’s ceremonial role in certifying the election results on Jan. 6, 2021.</p>
+<p>“The problem with that issue is if in fact the communications are immune, then the entire indictment fails,” Lauro argued.</p>
+<p>“I’m not sure that’s my reading of the case,” Chutkan replied.</p>
+<p>The government maintains that all actions and communications by Trump described in the new indictment were “private in nature,” Windom argued.</p>
+<p>Chutkan also spent time during the roughly 75-minute hearing questioning Lauro on the Trump legal team’s numerous plans to request the case’s dismissal. One anticipated plan is to try its successful play in Florida, where a Trump-appointed federal judge <a href="https://www.newsfromthestates.com/article/federal-judge-dismisses-trump-classified-documents-criminal-case" target="_blank">tossed</a> his classified documents case after Trump argued Smith was illegally appointed as special counsel.</p>
+<p>Chutkan said she will allow the defense to file that motion but warned that attorneys must provide convincing arguments on why “binding precedent doesn’t hold” for the time-tested position of special prosecutor.</p>
+    <h4 class="editorialSubhed">New indictment, same charges</h4>
+
+	
+<p>Trump is <a href="https://www.courtlistener.com/docket/67656595/226/united-states-v-trump/" target="_blank">charged</a> with conspiracy to defraud the United States; conspiracy to obstruct an official proceeding; obstruction of, and attempt to obstruct, an official proceeding; and conspiracy against rights for his alleged role in conspiring to create false electors from seven states and spreading knowingly false information that whipped his supporters into a violent attack on the U.S. Capitol on Jan. 6, 2021.</p>
+<p>A federal grand jury handed up a <a href="https://www.newsfromthestates.com/article/special-counsel-smith-files-new-indictment-trumps-jan-6-case" target="_blank">revised indictment</a> Aug. 27 in an effort to tailor the charges to the Supreme Court’s July 1 immunity <a href="https://www.supremecourt.gov/opinions/23pdf/23-939_e2pg.pdf" target="_blank">ruling</a>. The fresh indictment omitted any references to Trump’s alleged pressure campaign on Justice Department officials to meddle in state election results.</p>
+<p>But the document added emphasis on Trump’s personal use of social media outside of his actions as president, and said he and several co-conspirators schemed outside of his official duties. The new indictment also stressed Trump’s pressure on Pence to accept the fake electors in his role outside of the executive branch as president of the Senate.</p>
+<p>If Trump wins the Oval Office in November, he would have the power to hinder or altogether shut down the Department of Justice’s election interference case against him.</p>
+<p>If he loses to Democratic nominee Vice President Kamala Harris, the case is sure to be set back by further delays, as the Trump team plans numerous challenges and will almost certainly appeal — likely to the Supreme Court again — Chutkan’s decisions on which allegations against Trump are or are not subject to immunity.</p>
+<p>According to Friday’s <a href="https://storage.courtlistener.com/recap/gov.uscourts.dcd.258149/gov.uscourts.dcd.258149.229.0_4.pdf" target="_blank">joint filing</a> in which each side laid out plans for the case going forward, Trump’s team also warned they will challenge that Trump’s tweets and communication about the 2020 presidential results should be considered all official acts.</p>
+<p>Additionally, Trump plans to file a motion to dismiss the case based on the Supreme Court’s June <a href="https://www.newsfromthestates.com/article/us-supreme-court-ruling-obstruction-law-helps-cases-jan-6-defendants" target="_blank">ruling</a> that a Jan. 6 rioter could not be charged with obstructing an official proceeding — a charge that Trump also faces.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Senator preparing bill that could mandate school consolidation, shared services</title>
+		<link>https://newjerseymonitor.com/2024/09/05/senator-preparing-bill-that-could-mandate-school-consolidation-shared-services/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Thu, 05 Sep 2024 11:01:35 +0000</pubDate>
+				<category><![CDATA[Education]]></category>
+		<category><![CDATA[Gov + Legislature]]></category>
+		<category><![CDATA[Phil Murphy]]></category>
+		<category><![CDATA[Regionalization]]></category>
+		<category><![CDATA[School Funding]]></category>
+		<category><![CDATA[Vin Gopal]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14662</guid>
+
+					<description><![CDATA[Mandated mergers considered after years of incentives make little progress to consolidate schools and cut local property tax bills.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2023/02/Gopal5-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/02/Gopal5-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/02/Gopal5-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/02/Gopal5-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2023/02/Gopal5-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2023/02/Gopal5-2048x1365.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Sen. Vin Gopal (D-Monmouth) is drafting legislation that could require certain schools merge with neighbors to save costs and drive down property taxes. (Hal Brown for New Jersey Monitor)</p><p>A top Senate Democrat is preparing legislation that could force some of New Jersey’s more than 600 school districts to merge or share services in an effort to control ever-rising school costs and the property taxes that pay for them.</p>
+<p>School consolidation can save districts money by reducing administrative costs as well as those for professional services, like those offered by attorneys and engineers. But Sen. Vin Gopal (D-Monmouth), the chamber’s education chairman, said state efforts to incentivize mergers had seen little uptake, including in districts with tumbling enrollment and static costs.</p>
+<p>“We&#8217;re going to look toward seeing what we can do to mandate regionalization and shared services to see if we can keep the great quality of education that New Jersey has but, at the same time, lower costs for taxpayers and save money,” he told the New Jersey Monitor. “We can&#8217;t operate 600 individual school districts anymore.”</p>
+<p>School regionalization has long been a goal for state lawmakers looking to rein in property taxes, but relatively few districts have moved to merge with their neighbors, and school funding remains a top cost driver at both the local and state levels.</p>
+<p>During the 2022 tax year, $17 billion of the more than $32.2 billion towns and counties collected in property taxes went to schools, according to statistics maintained by the Department of Community Affairs.</p>
+<p>New Jersey&#8217;s current $56.7 billion budget provided for roughly $11.7 billion in school aid, the single largest pool of expenses on the state’s ledger for the 2025 fiscal year.</p>
+<p>The specifics of Gopal’s plan remain unclear. The senator said it could include regionalization ballot initiatives showing property tax savings such mergers could secure or mandates to share services across districts rather than force them to consolidate, but mandated regionalization was also an option.</p>
+<p>“We need to put everything on the table,” Gopal said. “We need to say how do we continue and expand on New Jersey&#8217;s quality of education, support our teachers and professionals, but also figure out how we can share some of these services so we&#8217;re cutting out some of the professional expenses.”</p>
+<p>The proposal is all but guaranteed to face opposition, especially from wealthy districts with less well-funded neighbors, and could be stalled by resistance within the state government.</p>
+<p>Gov. Phil Murphy, who has generally favored school mergers in the past, said he was “not wild about compulsory” consolidation and cautioned home rule — a constitutional framework that gives local governments broad authority over the administration of municipal services, including schools — could limit such efforts.</p>
+<p>“I want to incent districts as opposed to jam districts,” he said during a press gaggle following an unrelated event Friday, adding, “If there&#8217;s an opportunity to stay excellent, keep the pride high, give the kids the best education in America — which is what we do now — and figure out a way to do it more efficiently, I&#8217;m open to that.”</p>
+<p>Recent pushes toward school consolidation have been voluntary, and the state in 2022 enacted a law that extended grants for districts to study the feasibility of regionalization efforts. <a href="https://www.njspotlightnews.org/2024/08/more-nj-school-districts-consider-regional-approach-consolidation-amid-budget-concerns/#:~:text=The%20feasibility%20studies%20will%20look,diversity%20enhancement%20and%20debt%20obligations." target="_blank">Few districts</a>, most of them small, have moved to explore such mergers so far.</p>
+<p>Lawmakers would work to ensure districts are involved in regionalization decisions, Gopal said.</p>
+<p>“It&#8217;s going to be with a lot of input from the local level. We&#8217;re not trying to put anything over. We&#8217;re going to engage,” he said.</p>
+<p>Gopal said he hoped to have a consolidation bill drafted by October or November, meaning it would come after separate legislation reworking New Jersey’s school funding formula that is expected to be introduced in mid-September.</p>
+<p>The school funding bill could include incentives for regionalization and shared services agreements, he said, but the proposals are moving separately for now.</p>
+<p>Some New Jersey districts have lost state school aid under a 2018 law that phased out aid meant to keep districts whole after the state enacted the current funding formula in 2008, and some districts have continued to lose aid amid falling enrollment.</p>
+<p>School regionalization could help stabilize budgets in such districts, but consolidation has been an option for years and rarely utilized over that time.</p>
+<p>“This is the start of a conversation that I think desperately needs to happen in New Jersey,” Gopal said. “Everybody loves the idea of consolidation. They just don&#8217;t want it in their back yard. It&#8217;s like everybody hates Congress, but they always vote for their congressperson.”</p>
+    <a href="https://newjerseymonitor.com/donate" style="text-decoration:none;">
+    <div class="donateContainer">
+        <div class="donateTextContainer">
+            <p>SUPPORT NEWS YOU TRUST.</p>
+        </div>
+        <div class="donateButtonContainer">
+            <button>DONATE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>New Jersey offering millions in tax credits for NBA team, rankling progressive advocates</title>
+		<link>https://newjerseymonitor.com/2024/09/05/new-jersey-offering-millions-in-tax-credits-for-nba-team-rankling-progressive-advocates/</link>
+		
+		<dc:creator><![CDATA[Sophie Nieto-Munoz]]></dc:creator>
+		<pubDate>Thu, 05 Sep 2024 11:00:55 +0000</pubDate>
+				<category><![CDATA[Economy]]></category>
+		<category><![CDATA[Camden]]></category>
+		<category><![CDATA[EDA]]></category>
+		<category><![CDATA[Josh Shapiro]]></category>
+		<category><![CDATA[Maura Collinsgru]]></category>
+		<category><![CDATA[New Jersey Citizen Action]]></category>
+		<category><![CDATA[New Jersey Policy Perspective]]></category>
+		<category><![CDATA[Peter Chen]]></category>
+		<category><![CDATA[Philadelphia]]></category>
+		<category><![CDATA[sports]]></category>
+		<category><![CDATA[Tim Sullivan]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14675</guid>
+
+					<description><![CDATA[While the state frames its offer as cost-free for New Jersey taxpayers, advocates fear it could be substantially costly in other ways.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="682" src="https://newjerseymonitor.com/wp-content/uploads/2024/09/Tim-Sullivan-EDA-1024x682.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/09/Tim-Sullivan-EDA-1024x682.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/09/Tim-Sullivan-EDA-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/09/Tim-Sullivan-EDA-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/09/Tim-Sullivan-EDA-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/09/Tim-Sullivan-EDA-2048x1365.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Tim Sullivan, who heads the New Jersey Economic Development Authority, sent a letter this week trying to persuade the Philadelphia 76ers build a new $1.5 billion arena in Camden on the site of the old Riverfront State Prison. (Edwin J. Torres | NJ Governor’s Office)</p><p><span style="font-weight: 400;">As New Jersey shoots its shot in courting the Philadelphia 76ers to this side of the Delaware River, progressive activists are crying foul over state officials offering hundreds of millions in tax breaks to attract a billionaire to one of the state’s lowest-income cities. </span></p>
+<p><span style="font-weight: 400;">“I think Jersey really wants to land the Sixers, and this sweetens the pot. That’s not so much of a surprise — but is it the right thing to do for the people of Camden?” said Maura Collinsgru, policy director with New Jersey Citizen Action, a progressive nonprofit.</span></p>
+<p><span style="font-weight: 400;">As the Sixers explore their options for a $1.5 billion arena the team aims to </span>build by 2031, New Jersey Economic Development Authority CEO Tim Sullivan <a href="https://newjerseymonitor.com/wp-content/uploads/2024/09/Sixers-Letter-NJ-EDA-.pdf">sent a letter</a> to Tad Brown, CEO of Sixers owner Harris Blitzer Sports and Entertainment, laying out what New Jersey can offer the basketball team.</p>
+<p><span style="font-weight: 400;">New Jersey would give the Sixers two Aspire tax credits of $400 million each (one to offset the costs of the arena and infrastructure like parking, and another to support surrounding residential, retail and office development), the state-owned site of the former Riverfront State Prison “for low or no cost,” and another $500 million in bonds that would be repaid by fees on tickets, concessions and parking, Sullivan wrote. </span></p>
+<p><span style="font-weight: 400;">“We envision a multibillion-dollar, privately led comprehensive mixed-use development north of the Ben Franklin Bridge that would serve as a transformative catalyst for Camden and New Jersey,” Sullivan wrote in the letter, <a href="https://www.roi-nj.com/2024/09/02/real_estate/state-in-aggressive-push-to-give-sixers-details-of-massive-camden-arena-project-proposal-and-huge-incentives-that-come-with-it/" target="_blank">which ROI-NJ first reported.</a></span></p>
+<p><span style="font-weight: 400;">But activists say that money would be better spent in other ways, like funding schools in South Jersey or the state’s <a href="https://newjerseymonitor.com/2024/07/25/nj-transit-approves-3b-budget-amid-outcry-over-fare-hikes/">struggling transportation agency.</a></span></p>
+<p><span style="font-weight: 400;">Sports arenas in particular are a bad use for these subsidies, said Peter Chen, policy analyst with left-leaning think tank New Jersey Policy Perspective.</span></p>
+<figure id="attachment_8772" class="wp-caption alignleft" style="max-width:100%;width:400px;"><a href="https://newjerseymonitor.com/2023/07/28/a-surprising-lawbreaker-in-mandated-public-reporting-the-government/_o1a6713_1/" rel="attachment wp-att-8772"><img decoding="async" loading="lazy" class="wp-image-8772" src="https://newjerseymonitor.com/wp-content/uploads/2023/06/O1A6713_1-300x199.jpg" alt="" width="400" height="265" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/06/O1A6713_1-300x199.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/06/O1A6713_1-1024x678.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/06/O1A6713_1-768x509.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2023/06/O1A6713_1-1536x1018.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2023/06/O1A6713_1-2048x1357.jpg 2048w" sizes="(max-width: 400px) 100vw, 400px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  Peter Chen of New Jersey Policy Perspective testifies before the Assembly budget committee on June 28, 2023. (Dana DiFilippo | New Jersey Monitor)</p></figure>
+<p><span style="font-weight: 400;">While the state frames its offer as cost-free for New Jersey taxpayers, Chen fears it could be substantially costly in other ways. Just because the costs won’t appear as a line item in the state’s budget next year doesn’t mean they’ve disappeared into thin air, he said. </span></p>
+<p><span style="font-weight: 400;">“It’s a shocking amount of money for subsidizing a very profitable corporation owned by a billionaire. The subsidizing of private profits with public money — especially when the benefits to New Jersey residents and particularly sports arenas is so small — it just does not hold water,” he said.</span></p>
+<p><span style="font-weight: 400;">Other than offering tax credits and a parcel of land for the mixed-use arena, there’s very little detail surrounding the proposal. All Aspire residential projects, including mixed-use development, require 20% to be allocated for affordable housing. Aspire projects also require Community Benefits Agreements that lay out provisions like local hiring requirements and union labor provisions, the letter states. </span></p>
+    <h4 class="editorialSubhed">A troubled city</h4>
+
+	
+<p><span style="font-weight: 400;">Camden is a city of nearly 75,000 people across the river from Philadelphia, with a median annual household income of just over $28,000, compared to the state’s median income of about $96,300. The city has been long plagued by crime and wealth disparities, and attempts to revitalize the waterfront city with big tax breaks have <a href="https://www.inquirer.com/business/camden-budget-property-taxes-nj-tax-credits-20190711.html" target="_blank">largely fallen flat</a>. Other times, shady dealings between developers and powerful officials along the waterfront </span><a href="https://newjerseymonitor.com/2024/06/17/democratic-power-broker-george-norcross-indicted-on-racketeering-charges/"><span style="font-weight: 400;">have led to criminal charges. </span></a></p>
+<p><span style="font-weight: 400;">In 2016, the 76ers opened a training facility in Camden after the Economic Development Authority <a href="https://www.njspotlightnews.org/2014/06/14-06-11-82-million-eda-subsidy-to-76ers-spurs-debate-on-tax-breaks/" target="_blank">approved $82 million in tax breaks.</a></span></p>
+<p><span style="font-weight: 400;">The Sixers have proposed putting a new arena in Philadelphia&#8217;s Chinatown, which is centrally located in the city and near major highways and mass transit. But that plan has prompted community protests.</span></p>
+<p><span style="font-weight: 400;">A Sixers spokesperson told ROI-NJ that they will give New Jersey’s proposal a “serious” look. </span></p>
+<figure id="attachment_14678" class="wp-caption alignright" style="max-width:100%;width:400px;"><a href="https://newjerseymonitor.com/2024/09/05/new-jersey-offering-millions-in-tax-credits-for-nba-team-rankling-progressive-advocates/shapiro-sept-3-2024-1/" rel="attachment wp-att-14678"><img decoding="async" loading="lazy" class="wp-image-14678" src="https://newjerseymonitor.com/wp-content/uploads/2024/09/shapiro-sept-3-2024-1-300x207.jpeg" alt="" width="400" height="277" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/09/shapiro-sept-3-2024-1-300x207.jpeg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/09/shapiro-sept-3-2024-1-1024x708.jpeg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/09/shapiro-sept-3-2024-1-768x531.jpeg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/09/shapiro-sept-3-2024-1.jpeg 1500w" sizes="(max-width: 400px) 100vw, 400px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  Gov. Josh Shapiro said Tuesday he was confident the 76ers would remain in Philadelphia. (Commonwealth Media Services photo)</p></figure>
+<p><span style="font-weight: 400;">Still, Pennsylvania Gov. Josh Shapiro told reporters Tuesday that he’s “confident” the team will remain in Philadelphia. </span></p>
+<p><span style="font-weight: 400;">If the Sixers come to the Garden State under the terms Sullivan offered, activists want to see plans clearly laid out for what Camden residents stand to gain. Collinsgru also wants to ensure Camden residents are brought into the conversation, considering they may have to live near a noisy, congested sports arena. </span></p>
+<p><span style="font-weight: 400;">“What kind of an investment are they going to make in the people of Camden, which currently still has great needs in their housing stock, in their public school system? How about we fund things for the people of Camden that really allow them to thrive and flourish?” she said. </span></p>
+<p><span style="font-weight: 400;">A spokeswoman for New Jersey Gov. Phil Murphy declined to comment, referring questions to the EDA.</span></p>
+<p><span style="font-weight: 400;">EDA spokesman Chris Flores said the proposed project stands to have “major economic impact on Camden,” and the agency is “committed to ensuring its residents reap the benefits.” </span></p>
+<p><span style="font-weight: 400;">“A project of this size is complex, but we intend to do this right from the perspective of local benefits and community support. We are ready to work collaboratively with city officials and community advocates to ensure the residents of Camden are put first,” Flores said. </span></p>
+<p><span style="font-weight: 400;">Tom Bracken, head of the New Jersey Chamber of Commerce, stressed that New Jersey is a long way from luring the arena to Camden. </span></p>
+<p><span style="font-weight: 400;">He believes it would benefit “everybody in the Camden area, and everybody in the state of New Jersey.” The state would see major gains, too, both economically and in its business reputation. </span></p>
+<p><span style="font-weight: 400;">It’s too soon to have answers to all the concerns around the project, Bracken added, like how many jobs would go to Camden residents, whether there’s a need for a new transportation center or what the economic impact would be. </span></p>
+<p><span style="font-weight: 400;">“Nobody’s drilled down that deeply on day one,” he said. “It gets real old when all these progressive organizations try to throw cold water on everything that is done to make New Jersey a higher profile state and a more attractive state for businesses and residents.”</span></p>
+<p><span style="font-weight: 400;">But Chen </span><span style="font-weight: 400;">thinks business and state officials consider their proposal a “magic bullet” rather than putting money toward greater investments.</span></p>
+<p><span style="font-weight: 400;">“Somebody’s gonna be on the hook for all this, because they’re going to be paying the extreme fees anytime they go to a Sixers game,” he said, “and a lot of those people might be New Jersey residents.”</span></p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>In a ‘town hall’ with no questions, Trump grouses about polls, attacks debate host</title>
+		<link>https://newjerseymonitor.com/2024/09/05/in-a-town-hall-with-no-questions-trump-grouses-about-polls-attacks-debate-host/</link>
+		
+		<dc:creator><![CDATA[Jacob Fischler]]></dc:creator>
+		<pubDate>Thu, 05 Sep 2024 10:45:22 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14684</guid>
+
+					<description><![CDATA[Former President Donald Trump promised mass deportations and attacked Vice President Kamala Harris on fracking during a stop in Pennsylvania.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="712" src="https://newjerseymonitor.com/wp-content/uploads/2024/09/TrumpSept42024-scaled-1-1024x712.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/09/TrumpSept42024-scaled-1-1024x712.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/09/TrumpSept42024-scaled-1-300x208.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/09/TrumpSept42024-scaled-1-768x534.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/09/TrumpSept42024-scaled-1-1536x1067.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/09/TrumpSept42024-scaled-1-2048x1423.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Republican presidential nominee, former U.S. President Donald Trump participates in a Fox News Town Hall with Sean Hannity at the New Holland Arena on Sept. 4, 2024, in Harrisburg, Pennsylvania. Trump and Democratic presidential nominee, U.S. Vice President Kamala Harris continue to campaign across swing states as polls show a tight race prior to next week’s presidential debate in Philadelphia. (Kevin Dietsch | Getty Images)</p><p>Former President Donald Trump questioned polls showing a close race against Vice President Kamala Harris and complained about the conditions of an upcoming debate during a Fox News interview Wednesday in Pennsylvania.</p>
+<p>Under questioning from a friendly interviewer, Sean Hannity of Fox News, in front of an arena of cheering supporters in Harrisburg, the Republican presidential nominee also reiterated a pledge to conduct <a href="https://oregoncapitalchronicle.com/2024/08/27/trump-promises-mass-deportations-of-undocumented-people-how-would-that-work/" target="_blank">a massive deportation operation</a> if elected to another term and attacked Harris for her former position to ban the natural gas extraction technique known as fracking.</p>
+<p>Trump agreed to the interview, which had been advertised as a town hall but did not include audience questions, after Harris rejected his proposal for a Fox News debate on the same date. He said Wednesday he would have preferred to be meeting Harris on stage.</p>
+<p>“I think he’s a nice guy, but I would have preferred a debate,” Trump said of Hannity. “But this is the best we could do, Sean.”</p>
+<p>But Trump spent part of the hour Wednesday criticizing <a href="https://abc.com/news/5e38600c-4732-4cd2-a99c-3dedfa81beb0/category/1138628" target="_blank">the details of the 90-minute debate</a> the campaigns have agreed to, in Philadelphia on Sept. 10 on ABC.</p>
+<p>He called ABC News “the most dishonest network, the meanest, the nastiest,” claimed the network purposely released poor polls ahead of the 2016 election to suppress turnout and said, without evidence, executives would share questions with Harris ahead of the event.</p>
+<p>Hannity said he should host the debate instead.</p>
+<p>Trump also claimed the family of Minnesota Gov. Tim Walz, the Democratic vice presidential candidate, endorsed him. Charles Herbster, who sought the GOP nomination for Nebraska governor in 2022, posted to X a photograph of a group of Walz’s second cousins wearing Trump shirts.</p>
+<p>Walz’s sister, Sandy Dietrich, <a href="https://apnews.com/article/walz-family-nebraska-trump-elelction-2f2e29586b0e9ebe094ff2cf546e1ae4" target="_blank">told</a> The Associated Press the family was not particularly close with that branch, and said she would be voting for the ticket that included her brother.</p>
+<p>Walz’s brother, Jeff Walz, made disparaging remarks about the Minnesota governor on Facebook, but later told NewsNation he would not comment further.</p>
+    <h4 class="editorialSubhed">Bad polls</h4>
+
+	
+<p>Hannity’s introduction Wednesday noted polls showed a tight race, but Trump said the enthusiasm among his supporters made that seem unlikely.</p>
+<p>“I hear the polls are very close and we have a little lead,” he said. “I just find it hard to believe, because first of all, they’ve been so bad.”</p>
+<p>Trump has sought to delegitimize polls and even election results that have not shown him ahead, including during the 2020 campaign, when he said he could only lose by fraud. After his loss to Biden, he made a series of spurious fraud allegations that led to the Jan. 6, 2021, attack on the U.S. Capitol.</p>
+<p>He said Wednesday he did well in 2016, when he won the election, but “much better” in 2020, which he lost. The enthusiasm for the current campaign tops either, he said.</p>
+<p>Trump also complained that Harris’ entry into the race, after President Joe Biden dropped out following a bad debate performance in June, was “a coup” against Biden.</p>
+    <h4 class="editorialSubhed">Immigration claims</h4>
+
+	
+<p>Trump spent much of the hour talking about immigration, an issue he has highlighted throughout his time in politics.</p>
+<p>He repeated claims, without evidence, that immigrants entering the country illegally were largely coming from prisons and “insane asylums” and said terrorists were entering the country through the southern border.</p>
+<p>He described immigrants as a threat to public safety and to safety net programs like Medicare and Social Security.</p>
+<p>“These people are so bad,” he said. “They’re so dangerous. What they’ve done to our country is they’re destroying our country. And we can’t let this happen.”</p>
+<p>He seemed to reference a viral claim that Venezuelan immigrants had “taken over” an apartment in Aurora, Colorado. Residents of the building have<a href="https://coloradonewsline.com/2024/09/04/disputing-claims-of-gang-takeover-aurora-tenants-protest-slumlord-owner/" target="_blank"> disputed</a> that description.</p>
+    <h4 class="editorialSubhed">Fracking and Pennsylvania</h4>
+
+	
+<p>Playing to the audience of supporters in Pennsylvania’s state capital, Trump also attacked Harris for her former position on hydraulic fracturing, or fracking, a technique for extracting natural gas that is a major industry in the commonwealth.</p>
+<p>Harris said during her short-lived campaign for the Democratic presidential nomination in the 2020 election she supported an end to fracking. Trump and Hannity brought that up several times Wednesday, with Trump saying it should disqualify her for voters in Pennsylvania, whose 19 electoral votes will be key in deciding the election.</p>
+<p>“You have no choice,” he said. “You’ve got to vote for me, even if you don’t like me.”</p>
+<p>Harris has said this year she does not support a ban on fracking.</p>
+    <h4 class="editorialSubhed">More to come</h4>
+
+	
+<p>The event was advertised as a town hall and Hannity several times said audience questions would be upcoming, but no members of the pro-Trump audience were given an opportunity to ask a question.</p>
+<p>During the interview, Hannity acknowledged Dave McCormick, the Republican challenger to Democratic U.S. Sen. Bob Casey in one of the nation’s most competitive Senate races, in the crowd.</p>
+<p>Hannity indicated at the end of the broadcast that taping would continue, with McCormick asking “the first question,” and air Thursday night. In an email following the event, Fox News spokeswoman Sofie Watson said the portion of the event with audience questions would air “later this week.”</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Pocketbook issues rank high for Latino voters in 2024 election, survey finds</title>
+		<link>https://newjerseymonitor.com/2024/09/04/pocketbook-issues-rank-high-for-latino-voters-in-2024-election-survey-finds/</link>
+		
+		<dc:creator><![CDATA[Ariana Figueroa]]></dc:creator>
+		<pubDate>Wed, 04 Sep 2024 19:44:24 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[UnidosUS]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14671</guid>
+
+					<description><![CDATA[The high cost of living, minimum wage and housing costs top Latino voters' concerns heading into the November elections, a new survey shows.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/09/Floridapolls-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/09/Floridapolls-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/09/Floridapolls-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/09/Floridapolls-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/09/Floridapolls-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/09/Floridapolls-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">A poll worker walks past voting booths as he waits for voters to arrive at the Miami Beach Fire Station 4 to cast their ballot during the primary on March 19, 2024, in Miami Beach, Florida. (Joe Raedle | Getty Images)</p><p>WASHINGTON — Latino voters are concerned with the high cost of living, the minimum wage and rising housing costs heading into the November elections, according to a comprehensive survey released Wednesday by UnidosUS, the largest Hispanic civil rights and advocacy center in the nation.</p>
+<p>“Laying out a coherent economic policy agenda that will resonate with Latinos … would go a long way, I think, for our community,” Janet Murguía, the president and CEO of UnidosUS, said on a call with reporters detailing the <a href="https://unidosus.org/wp-content/uploads/2024/09/Natl-deck-UnidosUS-2024-Pre-Election-Poll-of-Hispanic-Electorate.pdf" target="_blank">results of the survey.</a></p>
+<p>The <a href="https://unidosus.org/wp-content/uploads/2024/09/National-crosstabs-UnidosUS-2024-Pre-Election-Poll-of-the-Hispanic-Electorate.pdf" target="_blank">survey included 3,000 eligible Hispanic voters</a> who were interviewed in either English or Spanish, from Aug. 5-23, with oversampling of residents of Georgia, North Carolina, Arizona, Pennsylvania, Nevada, Florida, Texas and California. The poll, conducted by BSP Research, had a margin of error of plus or minus 1.8 percentage points.</p>
+<p>Murguía said Latinos are the second-largest voting-age population and 1 in 5 of them will be casting ballots for the first time in a presidential election this November.</p>
+<p>“Top of mind are pocketbook issues,” she said. “Hispanic voters are most deeply concerned, like many of their fellow Americans, about the rising cost of living.”</p>
+<p>Another issue that Latinos strongly supported is access to abortion. By a 71% to 21% margin, Latinos oppose abortion bans, according to the survey.</p>
+<p>“They do not support making it illegal,” Murguía said.</p>
+    <h4 class="editorialSubhed">Minimum-wage workers</h4>
+
+	
+<p>Wages and jobs that provide economic security are a top priority for Latino voters, Gary Segura, who conducted the research poll for UnidosUS, said.</p>
+<p><a href="https://www.epi.org/publication/swa-wages-2022/#:~:text=Low%2Dwage%20workers%20are%20disproportionately%20women%20and%20Black%20and%20Hispanic" target="_blank">Latino workers are disproportionately workers</a> who earn the federal minimum wage of $7.25 an hour, which has not increased since 2009. If the federal minimum wage had kept pace with inflation, it would be around $24 an hour, <a href="https://aflcio.org/what-unions-do/social-economic-justice/minimum-wage#:~:text=Since%20then%2C%20it%20has%20lost,would%20be%20%2424%20an%20hour." target="_blank">according to the AFL-CIO.</a></p>
+<p>“The lived economy for Latinos is different than the lived economy for the nation as a whole,” Segura said.</p>
+<p>Segura said during the poll, interviewers followed up with respondents on their concerns about jobs and wages and found that being able to afford necessities like food and housing were top issues.</p>
+<p>“People are struggling to make ends meet,” he said.</p>
+<p>The number one response was that “jobs don’t pay enough, or I have to take a second job to make ends meet,” Segura said. “We talk a lot about the low levels of unemployment in this society now, which is certainly good news, but the issue is that many of those jobs do not pay enough for the holder of that job to essentially pay their basic living expenses.”</p>
+    <h4 class="editorialSubhed">Opinions on immigration</h4>
+
+	
+<p>Murguía noted that immigration, which the Republican presidential nominee, former President Donald Trump, has made a core campaign issue, ranks fifth in priorities among Latino voters, tied with concern about gun violence and too-easy access to assault weapons.</p>
+<p>“We want to be crystal clear that Latino voters overall are not buying into campaign tactics that demonize immigrants,” Murguía said. “They know the difference between those who mean us harm and those who are contributing to the fabric of our nation.”</p>
+<p>Latino voters strongly support a legal pathway to citizenship for those in the  Deferred Action for Childhood Arrivals program, referred to as Dreamers, and for long-term undocumented immigrants, the survey found.</p>
+<p><a href="https://www.newsfromthestates.com/article/trump-promises-mass-deportations-undocumented-people-how-would-work" target="_blank">Trump has promised mass deportations</a> should he win a second term, a policy issue that has “virtually no support” by Latino voters sampled in the survey, Segura said.</p>
+<p>Segura added that while Trump has campaigned on the issue, his promise to launch mass deportations is not particularly well known in Latino communities.</p>
+<p>“Many of the people we speak to believe that (Trump) will do it if he can, but they just don’t actually believe that he can pull that off,” Segura said. “So there’s both a lack of awareness of these really draconian measures or proposals and then a lack of belief that they would actually come to pass.”</p>
+<p>He added that he thinks it’s an opportunity for Democrats to campaign on the issue, but Vice President Kamala Harris has mainly criticized Trump for tanking a bipartisan border security deal.</p>
+<p>“Our own results suggest that the primary border concern comes from voters who lean in the GOP direction in the first place, and so I don’t see a lot of movement there or a lot of risk for (Democrats), particularly in targeted advertisements and Hispanic voters,” Segura said.</p>
+    <h4 class="editorialSubhed">‘Dismissive and diminishing language’</h4>
+
+	
+<p>The poll found that 55% of those Latinos had not been contacted by either political party this year.</p>
+<p>“We often hear a really dismissive and diminishing language about Latino participation in elections,” Segura said. “‘Latinos don’t vote as often as they should. Latinos will let you down’ and so forth, and no one ever wants to address the elephant in the room, which is that no one is asking Latinos to vote.”</p>
+<p>The Harris campaign last month launched a bilingual WhatsApp campaign to target Latino voters. Michelle Villegas, the national Latino engagement director for the Harris campaign, said during a Hispanic Caucus meeting at the Democratic National Convention that <a href="https://www.newsfromthestates.com/article/harris-campaign-launches-bilingual-whatsapp-channel-draw-latino-voters-swing-states" target="_blank">the Latino vote is key to victory in three battleground states</a> — Arizona, Nevada and Pennsylvania.</p>
+<p>The survey also found that running mates had an impact on Latino voters. Harris’ running mate, Minnesota Gov. Tim Walz, gave her a 3-point boost, Trump’s running mate, Ohio Sen. J.D. Vance, made his rating drop by 3 points.</p>
+<p>“Vance has (a) negative impact on the Republican ticket, which is consistent with his low favorability among Latino voters,” according to the survey.</p>
+<p>While Democrats have an advantage with Latino voters, and Harris has seen a boost in support compared to when President Joe Biden was in the race, she is still not reaching the levels of Latino support seen in previous elections, Clarissa Martinez De Castro, the vice president of the Latino Vote Initiative at UnidosUS, said.</p>
+<p>“There is work to be done to reach the levels of support Democrats need and had achieved in previous elections, and more intense communication with these voters is needed, particularly on economic issues and immigration,” Martinez De Castro said.</p>
+<p>Equis Research, which conducts research and polling specifically about Latino voters, <a href="https://www.weareequis.us/research/xssaug2024bgmemo" target="_blank">found in a recent poll t</a>hat Harris has gained significant support from Latinos but that Harris “remains a few points shy of what Biden received in 2020” across battleground states.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Temp workers prevail after judge denies staffing agencies a &#8216;second bite at the apple&#8217;</title>
+		<link>https://newjerseymonitor.com/2024/09/04/temp-workers-prevail-after-judge-denies-staffing-agencies-a-second-bite-at-the-apple/</link>
+		
+		<dc:creator><![CDATA[Sophie Nieto-Munoz]]></dc:creator>
+		<pubDate>Wed, 04 Sep 2024 19:15:32 +0000</pubDate>
+				<category><![CDATA[Economy]]></category>
+		<category><![CDATA[Labor]]></category>
+		<category><![CDATA[Christine O'Hearn]]></category>
+		<category><![CDATA[Gov. Phil Murphy]]></category>
+		<category><![CDATA[staffing agencies]]></category>
+		<category><![CDATA[temp workers]]></category>
+		<category><![CDATA[Temp Workers Bill of Right]]></category>
+		<category><![CDATA[temporary workers]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14668</guid>
+
+					<description><![CDATA[Worker advocates celebrated Friday’s ruling as one that “certainly seems to be the most embarrassing loss for the staffing industry lobby to date.”]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="665" src="https://newjerseymonitor.com/wp-content/uploads/2022/12/Screen-Shot-2022-12-19-at-6.37.11-PM-1024x665.png" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2022/12/Screen-Shot-2022-12-19-at-6.37.11-PM-1024x665.png 1024w, https://newjerseymonitor.com/wp-content/uploads/2022/12/Screen-Shot-2022-12-19-at-6.37.11-PM-300x195.png 300w, https://newjerseymonitor.com/wp-content/uploads/2022/12/Screen-Shot-2022-12-19-at-6.37.11-PM-768x499.png 768w, https://newjerseymonitor.com/wp-content/uploads/2022/12/Screen-Shot-2022-12-19-at-6.37.11-PM-1536x997.png 1536w, https://newjerseymonitor.com/wp-content/uploads/2022/12/Screen-Shot-2022-12-19-at-6.37.11-PM.png 1774w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Temporary workers and advocates rallied outside the Statehouse in Trenton on Dec. 19, 2022, to urge support for a bill that would provide protections to temporary workers. (Courtesy of Make the Road New Jersey)</p><p><span style="font-weight: 400;">A federal judge has denied another effort by staffing agencies to stop the enforcement of a landmark state law requiring them to pay temporary workers the same in benefits and pay as full-time staff. </span></p>
+<p><span style="font-weight: 400;">After more than a year of legal battles that failed to stop the law from going into effect, temporary staffing agencies filed another motion this past spring, taking a “proverbial second bite at the apple,” U.S. District Court Judge Christine O’Hearn <a href="https://newjerseymonitor.com/wp-content/uploads/2024/09/8.30.24-Temp-Workers-decision.pdf">wrote in a Friday ruling. </a></span></p>
+<p><span style="font-weight: 400;">Staffing agencies argue the law, which <a href="https://newjerseymonitor.com/2023/05/08/sweeping-protections-for-temp-workers-go-into-effect/">first went into effect</a> in May 2023, <a href="https://newjerseymonitor.com/2023/07/14/staffing-agencies-fighting-to-kill-new-jerseys-temp-worker-bill/">was unconstitutional.</a> The court denied their bid to halt it, and the Third Circuit Court of Appeals affirmed that decision. But the agencies filed another motion last May with a new claim. </span></p>
+<p><span style="font-weight: 400;">Granting a preliminary injunction now would “needlessly disrupt the status quo,” since the law has been in effect for over a year, O&#8217;Hearn said. The Department of Labor is finalizing regulations, and nonprofit groups have begun training affected workers on the law’s provisions — all of which would come to an “abrupt halt,” temporarily changing the staffing landscape in New Jersey for the third time in a year, the judge wrote.</span></p>
+<p><span style="font-weight: 400;">Many workers and families depending on their increased wages and benefits have already made important life decisions, like buying a car or enrolling a child in school, she notes. Enforcing an injunction would “undoubtedly cause substantial harm” to workers, and not serve the public interest, the ruling states. </span></p>
+<p><span style="font-weight: 400;">Immigrant advocates celebrated Friday’s ruling as one that “certainly seems to be the most embarrassing loss for the staffing industry lobby to date.”</span></p>
+<p><span style="font-weight: 400;">“Being required to actually follow the law may be a bitter pill for staffing agencies, particularly, to swallow, but that’s reality for the rest of us, and is for them now too. It’s time to drop the schemes and games and accept that the Temp Workers’ Bill of Rights is not going away,” said Garrett O’Connor of Make the Road New Jersey, a group that fought for years to pass the law. </span></p>
+<p><span style="font-weight: 400;">The law was signed by Gov. Phil Murphy in <a href="https://newjerseymonitor.com/2023/02/06/governor-murphy-signs-temporary-worker-protections-into-law/">February 2023.</a> It&#8217;s intended to protect an estimated 127,000 temporary workers, some of whom work at the same job site for years, by improving working conditions, requiring equal pay and benefits as full-time workers with similar responsibilities, and mandating companies to provide basic work information in the worker’s native language. All provisions took effect August 2023.</span></p>
+<figure id="attachment_6725" class="wp-caption alignright" style="max-width:100%;width:300px;"><a href="https://newjerseymonitor.com/2023/02/02/bill-to-protect-temporary-workers-narrowly-passes-in-senate/r6__1507/" rel="attachment wp-att-6725"><img decoding="async" loading="lazy" class="size-medium wp-image-6725" src="https://newjerseymonitor.com/wp-content/uploads/2023/02/R6__1507-300x200.jpg" alt="" width="300" height="200" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/02/R6__1507-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/02/R6__1507-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/02/R6__1507-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2023/02/R6__1507-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2023/02/R6__1507-2048x1365.jpg 2048w" sizes="(max-width: 300px) 100vw, 300px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  Reynalda Cruz celebrates after the Senate approved a bill to expand job protections for temporary workers on Feb. 2, 2023. (Hal Brown for New Jersey Monitor)</p></figure>
+<p><span style="font-weight: 400;">The New Jersey Staffing Association, American Staffing Association, and New Jersey Business and Industry Association claimed that the new law would drive companies out of business and agencies would be forced to move out of New Jersey, harming the state’s labor force. They lobbied aggressively against the bill for years before ultimately launching a legal battle. </span></p>
+<p><span style="font-weight: 400;">But the detrimental impacts the groups warned about haven’t occurred to the extent they predicted, O’Hearn said, leaving the court with “some skepticism.” </span></p>
+<p><span style="font-weight: 400;">The staffing agencies’ latest claim that the law is preempted by ERISA, a federal employment retirement law, came too late, O’Hearn said. That law has been consistently used to challenge state statutes since it went into effect in 1975, and the staffing agencies should have asserted this claim before the equal benefits provision <a href="https://newjerseymonitor.com/2023/08/04/new-protections-for-new-jerseys-temporary-workers-to-go-into-effect/">went into effect in August 2023,</a> the judge wrote.</span></p>
+<p><span style="font-weight: 400;">Because the groups waited to request injunctive relief, it diminishes their argument that they will continue to be irreparably harmed if the equal benefits provision remains in effect, the judge wrote. </span></p>
+<p><span style="font-weight: 400;">An injunction, O’Hearn added, would bring up new questions — does pay revert back to what it was prior to the law, and would benefits suddenly be rescinded? </span></p>
+<p><span style="font-weight: 400;">Because of the injunction’s impact on the status quo and lack of public interest, the groups haven’t shown irreparable harm, O’Hearn said. The plaintiffs are also unlikely to succeed on the merits that would outweigh public interest, she added. </span></p>
+<p><span style="font-weight: 400;">The ruling comes after a federal appeals court</span><a href="https://newjerseymonitor.com/2024/07/25/appeals-court-rules-in-favor-of-new-jersey-temp-worker-law/"><span style="font-weight: 400;"> declined in July to halt enforcement of the law’s wage and benefit provisions</span></a><span style="font-weight: 400;">. </span></p>
+<p><span style="font-weight: 400;">Adriana Alvarez, a temp worker in the logistics industry, said she’s glad to see the judge side with workers who have long endured late or docked pay, spent their own money for mandatory transportation to work sites, and been baffled by vague scheduling — all of which is illegal now under the new law. </span></p>
+<p><span style="font-weight: 400;">“The staffing agencies are probably so used to getting away with unjust and unfair treatment of its workers that they expected a judge to take their side and agree to reward their negligence and lack of preparation,” she said in a statement. “I’m glad to see a judge is setting a bar for the staffing agencies. They’re definitely not used to it.” </span></p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>After court loss, casino workers vow to renew fight in Trenton for smoke-free workplaces</title>
+		<link>https://newjerseymonitor.com/2024/09/04/after-court-loss-casino-workers-vow-to-renew-fight-in-trenton-for-smoke-free-workplaces/</link>
+		
+		<dc:creator><![CDATA[Dana DiFilippo]]></dc:creator>
+		<pubDate>Wed, 04 Sep 2024 18:52:58 +0000</pubDate>
+				<category><![CDATA[Courts]]></category>
+		<category><![CDATA[Gov + Legislature]]></category>
+		<category><![CDATA[Health]]></category>
+		<category><![CDATA[CEASE-NJ]]></category>
+		<category><![CDATA[Daniel Vicente]]></category>
+		<category><![CDATA[Joseph Vitale]]></category>
+		<category><![CDATA[Nancy Erika Smith]]></category>
+		<category><![CDATA[Patrick J. Bartels]]></category>
+		<category><![CDATA[Pete Naccarelli]]></category>
+		<category><![CDATA[William Moen Jr.]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14663</guid>
+
+					<description><![CDATA[Casino workers lost their court fight to force N.J. to add casinos to its 2006 Smoke-Free Air Act. They'll take their fight to the Statehouse.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="656" src="https://newjerseymonitor.com/wp-content/uploads/2024/04/IMG_6258-1024x656.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/04/IMG_6258-1024x656.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/04/IMG_6258-300x192.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/04/IMG_6258-768x492.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/04/IMG_6258-1536x985.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/04/IMG_6258-2048x1313.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Casino workers and labor activists gathered outside the Mercer County Civil Courthouse on April 5, 2024, after labor leaders announced a lawsuit they filed against the state that asks a judge to ban smoking in casinos, after years of legislative inaction. (Dana DiFilippo | New Jersey Monitor)</p><p style="font-weight: 400;">Casino workers and their union leaders warned Wednesday they&#8217;ll take “more militant actions” to end the casino carveout in New Jersey’s indoor-smoking ban after a state judge last week threw out <a href="https://newjerseymonitor.com/2024/04/05/casino-workers-sue-for-smoke-free-workplaces-amid-legislative-inaction/">a lawsuit</a> they hoped would force the issue in court.</p>
+<p style="font-weight: 400;">They wasted no time getting started.</p>
+<p style="font-weight: 400;">During a Wednesday news media call, they bashed an assemblyman who they blamed for failing to act on pending <a href="https://www.njleg.state.nj.us/bill-search/2024/S1493/bill-text?f=S1500&amp;n=1493_I1" target="_blank">legislation</a> that would end casinos’ long-time exemption from the <a href="https://www.nj.gov/health/fhs/tobacco/regulations/" target="_blank">New Jersey Smoke-Free Air Act</a>.</p>
+<p style="font-weight: 400;">They announced the UAW, the union that filed the lawsuit on behalf of 3,000 casino workers in Atlantic City, will break with the AFL-CIO, the umbrella organization of several other unions that sought a dismissal of the casino workers’ lawsuit.</p>
+<p style="font-weight: 400;">And they vowed to “drag out anyone who wants to stand against us, whether that&#8217;s other labor unions or elected officials.”</p>
+<p style="font-weight: 400;">“We&#8217;re like a cornered animal right now,” UAW-Region 9 director Daniel Vicente said. “We have labor protection, so if we want to, if we got to dust it up, let us dust it up. And we got bail money, we&#8217;ll be all right.”</p>
+<figure id="attachment_14665" class="wp-caption alignright" style="max-width:100%;width:300px;"><a href="https://newjerseymonitor.com/img_6277/"><img decoding="async" loading="lazy" class="size-medium wp-image-14665" src="https://newjerseymonitor.com/wp-content/uploads/2024/09/IMG_6277-300x200.jpg" alt="" width="300" height="200" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/09/IMG_6277-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/09/IMG_6277-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/09/IMG_6277-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/09/IMG_6277-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/09/IMG_6277-2048x1365.jpg 2048w" sizes="(max-width: 300px) 100vw, 300px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  Daniel Vicente, director of the UAW-Region 9, speaks out against the state&#8217;s casino carveout in the 2006 Smoke-Free Air Act during a rally in Trenton on April 5, 2024. (Dana DiFilippo | New Jersey Monitor)</p></figure>
+<p style="font-weight: 400;">The tough talk came five days after a state judge tossed a lawsuit UAW and CEASE NJ, a group of casino workers, filed in April asking the courts to do what the Legislature has <a href="https://newjerseymonitor.com/2024/01/30/bill-to-ban-smoking-in-atlantic-city-casinos-advances-in-senate/">refused to do for 18 years</a> — end casinos’ exemption from the state’s 2006 Smoke-Free Air Act.</p>
+<p style="font-weight: 400;">In <a href="https://newjerseymonitor.com/wp-content/uploads/2024/09/UAW-dismissal-order.pdf">that dismissal,</a> Judge Patrick J. Bartels wrote that the state constitution did not create a right to safety, but rather only a right to pursue safety.</p>
+<p style="font-weight: 400;">“While the court is sympathetic to the health hazards, it has determined that safety is not a fundamental right,” Bartels wrote. “The constitution guarantees individuals the right to make decisions regarding their own safety or alternatively, the ability to decide to take certain risks regarding their safety, such as the ability of individuals to choose to work in dangerous jobs despite the known safety risks in that line of work.”</p>
+<p style="font-weight: 400;">He rejected arguments that the carveout, narrowly tailored to apply to workers in the only New Jersey city that allows gaming houses, was unconstitutional special legislation that should have included other classes of people.</p>
+<p style="font-weight: 400;">The ruling was a victory for casinos and some worker unions that <a href="https://newjerseymonitor.com/2024/04/30/state-casinos-unions-ask-judge-to-dismiss-workers-smoking-carveout-lawsuit/">opposed the suit</a> over worries it would drive gamblers to gaming houses in neighboring states, costing revenue and jobs.</p>
+<p style="font-weight: 400;">But it infuriated casino workers, whose attorney, Nancy Erika Smith, told the New Jersey Monitor that she expects to file a motion for appeal within the coming week.</p>
+<p style="font-weight: 400;">On Wednesday, Vicente said all UAW chapters in New Jersey will leave the AFL-CIO in protest over the opposition by some unions under the AFL-CIO umbrella to their lawsuit.</p>
+<p style="font-weight: 400;">“We pay thousands of dollars to be a part of this organization, and that organization has been actively undermining our efforts to protect the health and safety of our members,” Vicente said. “Health and safety is one of the founding principles of unionism. So if you stand against that, you stand against exactly what we&#8217;re supposed to be.”</p>
+<figure id="attachment_14664" class="wp-caption aligncenter" style="max-width:100%;width:2560px;"><a href="https://newjerseymonitor.com/img_6286/"><img decoding="async" loading="lazy" class="wp-image-14664 size-full" src="https://newjerseymonitor.com/wp-content/uploads/2024/09/IMG_6286-scaled.jpg" alt="" width="2560" height="1707" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/09/IMG_6286-scaled.jpg 2560w, https://newjerseymonitor.com/wp-content/uploads/2024/09/IMG_6286-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/09/IMG_6286-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/09/IMG_6286-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/09/IMG_6286-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/09/IMG_6286-2048x1365.jpg 2048w" sizes="(max-width: 2560px) 100vw, 2560px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  Casino workers rallied in Trenton on April 5, 2024, against indoor smoking. (Dana DiFilippo | New Jersey Monitor)</p></figure>
+<p style="font-weight: 400;">Whether an appeal succeeds or not, casino workers said they would renew their efforts to get legislation passed in Trenton, saying secondhand smoke has driven up deadly diseases among casino workers.</p>
+<p style="font-weight: 400;">“We just want the same protections as everyone else in the state,” said Pete Naccarelli, a Borgota dealer and cofounder of CEASE-NJ. “We ask the lawmakers: Will you do the right thing, or do you agree with the ruling, with the judge quoted saying, ‘safety is not a fundamental right of the workers?’”</p>
+<p style="font-weight: 400;">The Senate’s health committee advanced a bill to end the carveout in January. Sen. Joseph Vitale (D-Middlesex), a prime sponsor of the bill, said Wednesday he will press for a full Senate vote when that body returns from its summer break later this month. Gov. Phil Murphy has said he would sign the bill, Vitale added.</p>
+<p style="font-weight: 400;">Vitale lashed out at the bill’s critics in the Statehouse, largely Republicans who have voiced concerns about the economic impact of ending the carveout. Banning indoor smoking didn’t hurt restaurants or other businesses, so that’s a “flawed argument,” Vitale said.</p>
+<p style="font-weight: 400;">“It&#8217;s really meant to deceive lawmakers and policymakers and frighten them, and we can&#8217;t stand for that,” Vitale said.</p>
+<p style="font-weight: 400;">Naccarelli and Vicente called on Assemblyman William Moen Jr. (D-Camden) to act, blaming him for the bill’s inertia in the Assembly this session. Moen is prime sponsor of the<a href="https://www.njleg.state.nj.us/bill-search/2024/A2143" target="_blank"> Assembly bill</a> to end the carveout and chairs that chamber’s gaming committee where it&#8217;s stalled.</p>
+<p style="font-weight: 400;">“We&#8217;re drawing a line in the sand on this,” Vicente said. “Our people&#8217;s lives are at risk. We have a moral obligation to take up this fight. … If you ain&#8217;t willing to do that, you&#8217;re not a friend of the labor movement.”</p>
+<p style="font-weight: 400;">Moen told the New Jersey Monitor he would work with legislative leadership this fall to &#8220;fix&#8221; the law&#8217;s casino loophole and said his goal, as prime sponsor, has been to &#8220;build as much support as possible for a smoke-free environment in New Jersey’s casinos.&#8221;</p>
+<p>Besides Moen and Vitale, the bill has two other prime sponsors, one in each chamber. Moen noted the &#8220;overwhelming number&#8221; of co-sponsors too — 40 in the Assembly and 15 in the Senate. A bill needs 21 votes in the Senate and 41 in Assembly to pass, after advancing through committees in both chambers.</p>
+<p>&#8220;We recognize that this issue is complex, emotional, and has pitted well-intentioned unions and some of their own members against each other, polling on the issue that reports differing conclusions, and local elected officials and state lawmakers on both sides of this issue,&#8221; Moen said in a statement. &#8220;Other states are working through this same, complex issue — this is not unique to New Jersey.&#8221;</p>
+<p>CEASE-NJ plans to launch a series of ads soon to persuade doubters. The ads will feature the children of casino workers who fear for their parents&#8217; health and safety.</p>
+<p style="font-weight: 400;">Twenty-one states include casinos in their statewide smoke-free workplace laws, said Cynthia Hallett, president and CEO of Americans for Nonsmokers’ Rights.</p>
+<p><em>Nikita Biryukov contributed.</em></p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>New Jersey joins fight against state bans on care for transgender minors</title>
+		<link>https://newjerseymonitor.com/briefs/new-jersey-joins-fight-against-state-bans-on-care-for-transgender-minors/</link>
+		
+		<dc:creator><![CDATA[Dana DiFilippo]]></dc:creator>
+		<pubDate>Wed, 04 Sep 2024 14:42:12 +0000</pubDate>
+				<category><![CDATA[Courts]]></category>
+		<category><![CDATA[Health]]></category>
+		<category><![CDATA[Social Justice]]></category>
+		<category><![CDATA[Matt Platkin]]></category>
+		<category><![CDATA[transgender youth]]></category>
+		<category><![CDATA[U.S. Supreme Court]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14659</guid>
+
+					<description><![CDATA[States that ban gender-affirming care for youth violate minors' constitutional right to equal protection under the law, attorneys argue.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2023/04/IMG_1456-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/04/IMG_1456-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/04/IMG_1456-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/04/IMG_1456-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2023/04/IMG_1456-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2023/04/IMG_1456-2048x1365.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">New Jersey has joined 19 other states in asking the U.S. Supreme Court to block Tennessee's ban on gender-affirming care for transgender youth. (Photo by Greg LaRose)</p><p style="font-weight: 400;">New Jersey has joined 19 other states in asking the U.S. Supreme Court to block a Tennessee law that bans gender-affirming care for transgender youth.</p>
+<p style="font-weight: 400;">In <a href="https://www.nj.gov/oag/newsreleases24/2024-0903_U.S-%20v.-Skrmetti-California-Amicus-Brief.pdf" target="_blank">a brief</a> filed to the court Tuesday, the states’ attorneys general argued that gender-affirming care is endorsed by every major medical organization and categorically denying youth access to it “departs from traditional norms of state medical regulation.”</p>
+<p style="font-weight: 400;">It also violates their constitutional right to equal protection of the laws, they wrote.</p>
+<p style="font-weight: 400;">“Gender-affirming care can provide highly beneficial — indeed, ‘potentially life-saving’ — treatment to transgender adolescents with gender dysphoria,” the attorneys wrote. “And clinical standards of care account for any limited risks of that treatment by requiring doctors to make individualized findings that gender-affirming care is medically necessary.”</p>
+<p style="font-weight: 400;">New Jersey Attorney General Matt Platkin seconded that sentiment on social media Tuesday, writing: “As the medical community recognizes, gender-affirming care saves lives.”</p>
+<p style="font-weight: 400;">Gov. Phil Murphy last year <a href="https://newjerseymonitor.com/briefs/governor-murphy-declares-n-j-safe-haven-for-transgender-nonbinary-people/">declared</a> New Jersey a “safe haven” for transgender and nonbinary people seeking gender-affirming care. New Jersey has more than 45,100 transgender and nonbinary residents, according to the <a href="https://williamsinstitute.law.ucla.edu/publications/trans-adults-united-states/" target="_blank">Williams Institute at UCLA.</a></p>
+<p style="font-weight: 400;">The other states joining the petition filed Tuesday include all of New Jersey’s nearest neighbors, Pennsylvania, Delaware, Maryland, New York and Connecticut.</p>
+<p style="font-weight: 400;">Tennessee’s 2023 law prohibits doctors from providing transgender care for minors, including puberty blockers, hormones and surgeries. Several families of transgender youth sued to block the law, and the U.S. 6th Circuit Court of Appeals <a href="https://tennesseelookout.com/briefs/federal-appeals-court-upholds-tennessee-law-banning-gender-affirming-care-for-minors/" target="_blank">upheld it.</a></p>
+<p style="font-weight: 400;">The American Civil Liberties Union and Lamba Legal asked the Supreme Court to review the case, and the high court <a href="https://newjerseymonitor.com/briefs/u-s-supreme-court-will-hear-challenge-to-tennessees-ban-on-care-for-transgender-minors/">agreed in June</a> to hear it this fall. A decision is expected next summer.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Immigration policy a key election issue in New Jersey races</title>
+		<link>https://newjerseymonitor.com/2024/09/04/immigration-policy-a-key-election-issue-in-new-jersey-races/</link>
+		
+		<dc:creator><![CDATA[Sophie Nieto-Munoz]]></dc:creator>
+		<pubDate>Wed, 04 Sep 2024 10:59:54 +0000</pubDate>
+				<category><![CDATA[Civil Rights + Immigration]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Anthony Valdes]]></category>
+		<category><![CDATA[Rob Menendez]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14638</guid>
+
+					<description><![CDATA[Congressional candidates running in New Jersey agree border security poses deep concerns but split on how to stem illegal immigration.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/02/immigrationphoto-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/02/immigrationphoto-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/02/immigrationphoto-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/02/immigrationphoto-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/02/immigrationphoto-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/02/immigrationphoto-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Congressional candidates running in New Jersey agree border security poses deep concerns but split on how to stem illegal immigration. (Photo by John Moore | Getty Images)</p><p><span data-preserver-spaces="true">As New Jersey voters begin to mull how to vote in November — when the White House, a Senate seat, and all 12 House seats will be on the ballot — immigration is a key issue dividing the two major parties.</span></p>
+<p><span data-preserver-spaces="true">Republicans nationwide have made the influx of migrants at the southern border a focal point of their campaigns, while Democrats have accused Republicans of blocking immigration reform so the GOP can campaign on chaos on the border.</span></p>
+<p><span data-preserver-spaces="true">Immigrant advocates, meanwhile, say Democrats have bowed to pressure from the right and are beginning to mirror Republicans’ tough-on-immigrants policies.</span></p>
+<p><span data-preserver-spaces="true">This is especially disappointing in New Jersey, a state where immigrants make up nearly a quarter of the population, said Erik Cruz Morales, policy manager with the New Jersey Alliance for Immigrant Justice.</span></p>
+<p><span data-preserver-spaces="true">“I think the candidates that are running for office should really stand up for their communities and their districts because the majority of people who live in some of these districts are immigrant populations,” he said. </span></p>
+<figure id="attachment_6696" class="wp-caption alignright" style="max-width:100%;width:300px;"><a href="https://newjerseymonitor.com/2023/07/25/biden-administration-should-not-support-n-j-ice-jail-senator-menendez-says/rob-menendez/" rel="attachment wp-att-6696"><img decoding="async" loading="lazy" class="size-medium wp-image-6696" src="https://newjerseymonitor.com/wp-content/uploads/2023/01/Rob-Menendez-300x200.jpg" alt="" width="300" height="200" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/01/Rob-Menendez-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/01/Rob-Menendez-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2023/01/Rob-Menendez.jpg 800w" sizes="(max-width: 300px) 100vw, 300px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Rep. Rob Menendez said Democrats should not allow Republicans to create the narrative on the nation&#8217;s immigration problems. (Edwin J. Torres/NJ Governor’s Office)</em></p></figure>
+<p><span data-preserver-spaces="true">His frustration is shared by Rep. Rob Menendez (D-08), who agreed that Democrats need to articulate their own vision of a better immigration policy. Menendez is seeking reelection in a majority Hispanic district that includes sections of Jersey City and Newark. </span></p>
+<p><span data-preserver-spaces="true">Democrats must lay out a clear vision of what comprehensive immigration reform looks like and show how it impacts the economy, Menendez said in an interview. The party should support work authorization so more people can find jobs and tout how much <a href="https://newjerseymonitor.com/2024/07/30/undocumented-immigrants-in-n-j-pay-1-3b-in-state-and-local-taxes-new-study-says/#:~:text=The%20estimated%20428%2C000%20undocumented%20immigrants,2022%2C%20according%20to%20the%20study.">immigrants contribute in tax dollars,</a> he added.</span></p>
+<p><span data-preserver-spaces="true">“That should be the message for Democrats — if we solve immigration and if we fix our broken system, we win in the future, and we’d be stronger because of it,” he said. “That, to me, is why we should all dedicate ourselves to figuring it out, and not allowing the Republican narrative be how we talk about this.”</span></p>
+    <h4 class="editorialSubhed">‘There has to be a better way’</h4>
+
+	
+<p><span data-preserver-spaces="true">This year’s Republican National Convention featured attendees holding signs </span><a class="editor-rtfLink" href="https://www.npr.org/2024/08/14/nx-s1-5037992/trump-immigrants-border-mass-deportation-presidential-race-migrants" target="_blank" rel="noopener"><span data-preserver-spaces="true">calling for mass deportation,</span></a><span data-preserver-spaces="true"> and the party’s presidential nominee, Donald Trump, has said he’d push for the deportation of 11 million undocumented immigrants nationwide.</span></p>
+<figure id="attachment_14598" class="wp-caption alignleft" style="max-width:100%;width:277px;"><a href="https://newjerseymonitor.com/?attachment_id=14598" rel="attachment wp-att-14598"><img decoding="async" loading="lazy" class="size-medium wp-image-14598" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/Anthony-Valdes-277x300.jpg" alt="" width="277" height="300" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/Anthony-Valdes-277x300.jpg 277w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Anthony-Valdes-947x1024.jpg 947w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Anthony-Valdes-768x831.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Anthony-Valdes.jpg 1080w" sizes="(max-width: 277px) 100vw, 277px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Anthony Valdes is the Republican House candidate in the 8th Congressional District. (Courtesy of Valdes)</em></p></figure>
+<p><span data-preserver-spaces="true">Those are not positions shared by Menendez’s Republican challenger, Anthony Valdes, a son of immigrants who works as a dwelling inspector. Valdes supports building the border wall that Trump championed and said more funds should go to securing the border, but he doesn’t support mass deportation and would rather see a push for working papers for some undocumented immigrants. </span></p>
+<p><span data-preserver-spaces="true">Valdes, a West New York native, said voters he speaks to take no issue with legal immigration, but they don’t believe what’s happening now is fair compared to how “they had to really suffer” when they immigrated to the United States decades ago. Immigrants who arrived legally believe undocumented immigrants are having an easier time accessing resources like housing and health care than legal immigrants, Valdes said.</span></p>
+<p><span data-preserver-spaces="true">“We’re a country of immigrants, but what’s happening at our southern border, in my opinion, is an invasion. These people are coming in illegally,” he said. </span></p>
+<p><span data-preserver-spaces="true">And the blame for that lies with the Biden-Harris administration, said GOP political consultant Alex Wilkes. The spike in border crossings has led to every state “becoming a border state,” Wilkes said, and that’s why the issue is top of mind even for New Jersey Republicans who live more than 2,000 miles away from the border with Mexico.</span></p>
+<p><span data-preserver-spaces="true">Since Biden took office, illegal border crossings have averaged 2 million per year, </span><a class="editor-rtfLink" href="https://wapo.st/4dIIslO" target="_blank" rel="noopener"><span data-preserver-spaces="true">according to the Washington Post</span></a><span data-preserver-spaces="true">, an average more than quadruple that of Donald Trump’s administration. Crossings plunged earlier this year after the Biden administration used emergency powers to suspend the entry of most migrants attempting to illegally enter the U.S., effectively cutting access to asylum seekers. </span></p>
+<p><span data-preserver-spaces="true">Wilkes hailed Trump’s “remain in Mexico” policy, which required migrants seeking asylum to stay in Mexico until their immigration court date, as a success. Now, she said, Republicans have a clear message to close the border, deport “the most dangerous undocumented migrants,” and create a legislative fix that removes bureaucratic hurdles from those seeking to immigrate legally. </span></p>
+<p><span data-preserver-spaces="true">“There has to be a better way between the system we have now and a completely open border where we don’t even know who’s coming through,” she said. “Most Republicans want to talk about this in terms of, how do we make this system work for people who want to legitimately better themselves, who fear for their safety in their home countries?” </span></p>
+<p><span data-preserver-spaces="true">Valdes’s contention that his views on immigration are more moderate than Trump’s does not convince Menendez, who said Republicans may publicly stray from Trump’s more hard-line immigration stances in a state like New Jersey — which hasn’t voted for a Republican presidential candidate since 1988 — but they still support a White House hopeful who is seeking to deport millions of people. </span></p>
+<p><span data-preserver-spaces="true">“That’s that election posturing, when we all know that sending another Republican down to Washington will be a ‘yes’ vote for every damn awful policy of the Republican Party and Trump administration, so let’s not lose sight of that,” Menendez said. </span></p>
+    <div class="snrsInfobox">
+		<div class="snrsInfoboxContainer">
+			<div class="snrsInfoboxSubContainer" style="padding-top:24px;">
+				
+<p><strong>8th Congressional District candidates</strong></p>
+<p>Rep. Rob Menendez (Democrat), incumbent</p>
+<p>Anthony Valdes (Republican)</p>
+<p>Pablo R. Olivera (Labour)</p>
+<p>Christian J. Robbins (Green)</p>
+<p>Lea Sherman (Socialist Workers Party)</p>
+			</div>
+		</div>
+    </div>
+
+	
+    <h4 class="editorialSubhed">‘Morally wrong’</h4>
+
+	
+<p><span data-preserver-spaces="true">Menendez&#8217;s thoughts aside, immigration advocates worry that Democrats by and large aren’t doing enough to oppose the Republican narrative on this issue.</span></p>
+<p><span data-preserver-spaces="true">Vice President Kamala Harris, the Democratic nominee for president, </span><a class="editor-rtfLink" href="https://www.youtube.com/watch?v=i2F9qGxTKcU&amp;t=30s" target="_blank" rel="noopener"><span data-preserver-spaces="true">has said if elected president</span></a><span data-preserver-spaces="true"> she would “hire thousands more border agents and crack down on fentanyl and human trafficking.” </span></p>
+<p><span data-preserver-spaces="true">“There hasn’t been much conversation around any other significant pieces of legislation that would fix the broken immigration system,” Morales said.</span></p>
+<p><a class="editor-rtfLink" href="https://www.aclu.org/battleground-polling/immigration" target="_blank" rel="noopener"><span data-preserver-spaces="true">Recent polling from the American Civil Liberties Union</span></a><span data-preserver-spaces="true"> found that voters in key battlegrounds nationwide prefer an immigration policy that would manage the border and provide a road to citizenship for long-time residents, rather than “fear-based policies.” The polling included voters in New Jersey’s 7th District, one of the nation’s most competitive, where Democrat Sue Altman will face incumbent Tom Kean Jr., who was elected in 2022. </span></p>
+<p><span data-preserver-spaces="true">Neither candidate was available to comment for this story. </span></p>
+<p><span data-preserver-spaces="true">In the 7th, 66% of voters said the United States “needs a balanced approach to immigration that addresses the challenges at the border and includes a pathway to citizenship for Dreamers and other long-time residents,” while 31% said it is “too dangerous to open up our country to more people from other countries.”</span></p>
+<p><span data-preserver-spaces="true">“The key to success in 2024&#8217;s electoral battlegrounds lies in presenting innovative, solution-focused approaches to immigration and public safety,” the ACLU’s report says.</span></p>
+<p><span data-preserver-spaces="true">Julie Flores-Castillo, an immigrant advocate from Red Bank and a local Democratic Party official, comes from a mixed-status family and has undocumented family members. She said there’s more fear in the community because the messaging coming from politicians on both sides isn’t humane. </span></p>
+<p><span data-preserver-spaces="true">She noted the emphasis on detaining undocumented immigrants. A 2021 New Jersey law bars public and private entities from entering into contracts to house immigrant detainees, but the law has been deemed partially unconstitutional by a federal judge. While the law is being challenged in court, private prison company GEO Group seeks to sign a contract with U.S. Immigration and Customs Enforcement to house detainees at Delaney Hall, a facility near the Essex County jail in Newark.</span></p>
+<p><span data-preserver-spaces="true">“I don’t see that being discussed at all here, and it’s creating more fear,” Flores-Castillo said. “We don’t want any more detention centers opening here, but I don’t see candidates calling for it not to happen.”</span></p>
+<p><span data-preserver-spaces="true">Menendez, who along with his Democratic colleagues in the House has <a href="https://newjerseymonitor.com/2024/06/10/new-jerseys-d-c-democrats-say-biden-administration-should-not-support-new-immigrant-jail/">been outspoken on closing detention centers in New Jersey</a>, said he plans to fight immigrant detention more if he wins another term in Congress. He said it’s a reflection of the broken system and echoed that Democrats should strive to present larger measures to fix immigration. </span></p>
+<p><span data-preserver-spaces="true">“Just because we haven’t come up with a holistic fix doesn’t mean we should allow these things to continue to exist when they do harm to our communities,” Menendez said. “I’ll never shy away from saying that because we know it’s morally wrong to rip people away from their families.&#8221;</span></p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Harris to roll out new plan on tax relief for small businesses</title>
+		<link>https://newjerseymonitor.com/2024/09/03/harris-to-roll-out-new-plan-on-tax-relief-for-small-businesses/</link>
+		
+		<dc:creator><![CDATA[Ashley Murray]]></dc:creator>
+		<pubDate>Tue, 03 Sep 2024 21:17:38 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Economy]]></category>
+		<category><![CDATA[Kamala Harris]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14655</guid>
+
+					<description><![CDATA[Vice President Kamala Harris wants to expand the tax deduction to $50,000 on business start-up costs and simplify tax filing for entrepreneurs.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="682" src="https://newjerseymonitor.com/wp-content/uploads/2024/09/HarrisDNC-scaled-1-1024x682.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/09/HarrisDNC-scaled-1-1024x682.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/09/HarrisDNC-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/09/HarrisDNC-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/09/HarrisDNC-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/09/HarrisDNC-scaled-1-2048x1365.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Democratic presidential candidate Vice President Kamala Harris speaks on stage during the final day of the Democratic National Convention at the United Center on Aug. 22, 2024, in Chicago, Illinois. (Justin Sullivan | Getty Images)</p><p>WASHINGTON — Vice President Kamala Harris is expected to announce economic policy proposals aimed at helping small businesses during a campaign speech Wednesday in New Hampshire.</p>
+<p>The Democratic presidential candidate will stump in Portsmouth for expanding the tax deduction to $50,000 on business start-up costs, up from $5,000, a campaign official said on background Tuesday. Harris will also propose a standard deduction for businesses as a way to simplify tax filing for entrepreneurs.</p>
+<p>Congress writes the nation’s tax laws, so any changes will hinge on which party <a href="https://www.newsfromthestates.com/article/struggle-control-congress-intensifies-presidential-contest-shifts" target="_blank">wins control</a> of the House and Senate in November. Many provisions enacted under the 2017 Trump-era tax law are set to expire at the end of 2025, teeing up for the next Congress the major task of reworking the tax code.</p>
+<p>The announcement comes as part of Harris’ pitch for what she calls an “opportunity economy” that would include an expanded child tax credit — up to $6,000 — for new parents, $25,000 in down payment assistance for first-time home buyers, and tools to combat “price gouging” by big businesses, whom Harris blames for high grocery prices, she <a href="https://www.newsfromthestates.com/article/harris-walz-defend-past-statements-promise-opportunity-economy-cnn-interview" target="_blank">told</a> CNN’s Dana Bash on Thursday.</p>
+    <h4 class="editorialSubhed">Middle-class message</h4>
+
+	
+<p>Harris, whose running mate is Minnesota Gov. Tim Walz, has in recent weeks largely homed in on helping the middle class.</p>
+<p>The former California attorney general and U.S. senator is also expected to announce a host of other proposals Wednesday to incentivize the creation of more small businesses — with her goal of 25 million new business applications under her administration, if elected.</p>
+<p>Among the proposals are easing licensing to allow businesses to expand across state lines and incentivizing state and local governments to “cut red tape” and reduce regulations. Harris will also pitch granting more federal contracts to small businesses and launching a fund that would allow community banks to pay interest costs for businesses expanding in regions that see little investment.</p>
+<p>Harris’ stop in New Hampshire is one of at least three presidential campaign events this week. On Thursday she will return to Pittsburgh, Pennsylvania, where she and President Joe Biden <a href="https://penncapital-star.com/election-2024/harris-and-biden-campaign-in-pittsburgh-as-presidential-race-enters-the-home-stretch/" target="_blank">campaigned</a> on their support for organized labor during Monday’s Labor Day holiday.</p>
+<p>The Republican presidential nominee, Donald Trump, is scheduled to attend a town hall in Harrisburg, Pennsylvania, with Fox News host Sean Hannity on Wednesday and a Saturday campaign rally in Mosinee, Wisconsin.</p>
+<p>Trump attacked Biden and Harris on his online platform Truth Social Monday, blaming the administration for high prices.</p>
+<p>Trump wrote in his signature mix of upper and lowercase letters that under Harris, whom he refers to as “comrade,” “all Americans are suffering during this Holiday weekend – High Gas Prices, Transportation Costs are up, and Grocery Prices are through the roof. We can’t keep living under this weak and failed ‘Leadership.’”</p>
+<p>U.S. presidents do not set transportation or grocery prices.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Appeals courts to expand public access by livestreaming hearings and posting briefs online</title>
+		<link>https://newjerseymonitor.com/briefs/appeals-courts-to-expand-public-access-by-livestreaming-hearings-and-posting-briefs-online/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Tue, 03 Sep 2024 18:40:00 +0000</pubDate>
+				<category><![CDATA[Courts]]></category>
+		<category><![CDATA[Stuart Rabner]]></category>
+		<category><![CDATA[Transparency]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14652</guid>
+
+					<description><![CDATA[New rules will require New Jersey intermediate courts to livestream oral arguments and post briefs at least five days before a hearing.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="684" src="https://newjerseymonitor.com/wp-content/uploads/2023/07/GettyImages-1416570415-1024x684.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/07/GettyImages-1416570415-1024x684.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/07/GettyImages-1416570415-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/07/GettyImages-1416570415-768x513.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2023/07/GettyImages-1416570415-1536x1026.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2023/07/GettyImages-1416570415-2048x1368.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">In an effort to expand transparency, New Jersey's Chief Justice Stuart Rabner has directed appellate courts to livestream hearings and post court briefs and other documents publicly online. (Getty Images)</p><p>New Jersey’s judiciary will begin livestreaming appellate hearings and publicly posting briefs filed in such cases in a pro-transparency turn enabled by new technologies, Chief Justice Stuart Rabner announced Tuesday.</p>
+<p>The intermediate court will begin <a href="https://www.njcourts.gov/courts/appellate/appellate-livestreams" target="_blank">broadcasting oral arguments</a> Monday and will be required to post complaints, responses, and reply briefs online five days ahead of such hearings unless the briefs are sealed or otherwise confidential.</p>
+<p>“An engaged and informed citizenry improves public trust in the courts and strengthens our justice system as a whole. And as technology evolves, it affords greater opportunities to expand public access to the courts,” Rabner said in a statement.</p>
+<p>The rules change brings a measure of transparency to influential intermediate courts that often create precedent but enjoyed laxer transparency rules than trial courts or the New Jersey Supreme Court.</p>
+<p>Trial court documents in civil proceedings are posted onto eCourts, the judiciary’s electronic case filing and management system, and proceedings at the trial court level may be livestreamed at the judge&#8217;s discretion.</p>
+<p>New Jersey’s Supreme Court has livestreamed oral arguments since 2005. Rabner said the judiciary would look to further expand access to “matters of public interest and importance at all levels of the court system.&#8221;</p>
+<p>Appellate briefs were obtainable under previous court rules, but securing them generally required a direct request to court staff, and viewing appellate proceedings typically required in-person attendance at hearings.</p>
+<p>The Judiciary already <a href="https://www.njcourts.gov/courts/appellate/argument-schedule" target="_blank">posted</a> some briefs filed in cases scheduled to be argued Monday.</p>
+<p>Those include a dispute over a pair of proposed warehouses between Manalapan Township and a developer, arguments over whether unlicensed lenders can act as debt collectors, and residents’ challenge to a proposed warehouse in Harrison Township.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>New Jersey districts still face teacher shortages as new school year begins</title>
+		<link>https://newjerseymonitor.com/2024/09/03/new-jersey-districts-still-face-teacher-shortages-as-new-school-year-begins/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Tue, 03 Sep 2024 11:06:07 +0000</pubDate>
+				<category><![CDATA[Education]]></category>
+		<category><![CDATA[Gov + Legislature]]></category>
+		<category><![CDATA[Chris Christie]]></category>
+		<category><![CDATA[Phil Murphy]]></category>
+		<category><![CDATA[Sean Spiller]]></category>
+		<category><![CDATA[teacher shortages]]></category>
+		<category><![CDATA[Teresa Ruiz]]></category>
+		<category><![CDATA[Vin Gopal]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14635</guid>
+
+					<description><![CDATA[The state has for years faced a shortage of educators, with particularly troubling vacancies in subjects like math, science, special education, and instruction for English language learners.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2022/09/DPR-back-to-school-2022-005-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2022/09/DPR-back-to-school-2022-005-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2022/09/DPR-back-to-school-2022-005-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2022/09/DPR-back-to-school-2022-005-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2022/09/DPR-back-to-school-2022-005.jpg 1200w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">The exact degree of the teacher shortage remains unknown despite recent efforts to quantify New Jersey’s educator workforce. (Danielle P. Richards for New Jersey Monitor)</p><p style="font-weight: 400;">When New Jersey students head back to classrooms this week, many will return to schools with too few teachers.</p>
+<p style="font-weight: 400;">The state has for years faced <a href="https://newjerseymonitor.com/2023/04/07/new-jersey-teacher-shortage-persists-but-severity-unclear/">a shortage of educators</a>, with particularly troubling vacancies in subjects like math, science, special education, and instruction for English language learners. And those vacancies persist despite legislators’ efforts to <a href="https://newjerseymonitor.com/briefs/governor-murphy-signs-bill-eliminating-test-for-would-be-teachers/">smooth the teacher pipeline</a> and steer more students toward careers in education.</p>
+<p style="font-weight: 400;">Sean Spiller, president of the New Jersey Education Association, the state’s largest teachers union, said schools are seeing the impact of the shortages.</p>
+<p style="font-weight: 400;">“We&#8217;re seeing class sizes increase. We&#8217;re seeing courses not being offered, and we&#8217;re seeing that the educators who are still remaining in the profession are being overburdened in terms of how to pick up some of the work because of unfilled classrooms. It’s a big concern,” Spiller said.</p>
+<p style="font-weight: 400;">The exact degree of the shortages remains unknown despite recent efforts to quantify New Jersey’s educator workforce, but the number of would-be teachers has fallen precipitously over the last decade.</p>
+<p style="font-weight: 400;">New Jersey’s teacher workforce has remained stable over the last decade at roughly 118,000 educators, according to <a href="https://newjerseymonitor.com/wp-admin/upload.php?item=14636">a February report</a> drafted by Rutgers University’s John J. Heldrich Center for Workforce Development.</p>
+<p style="font-weight: 400;">Researchers examined 11 years worth of data and found that for every teacher that left the profession in the 2022-2023 school year, the state issued just 1.1 provisional teaching certificates, compared to 2.9 certifications in the 2013-2014 school year. Less than a quarter of those pursuing education degrees in the 2013-2014 and 2014-2015 school years eventually became teachers, and only 43% earned a degree in education, the study says.</p>
+<p style="font-weight: 400;">The study warns that a ratio approaching one departure for one new teacher could quickly lead to more severe shortages because at least 10% of teachers leave the profession within their first three years.</p>
+<figure id="attachment_11259" class="wp-caption alignleft" style="max-width:100%;width:300px;"><a href="https://newjerseymonitor.com/2024/06/24/senate-democrats-push-new-protections-for-reproductive-rights-in-new-jersey/ruiz-2/" rel="attachment wp-att-11259"><img decoding="async" loading="lazy" class="size-medium wp-image-11259" src="https://newjerseymonitor.com/wp-content/uploads/2024/01/Ruiz-300x200.jpg" alt="" width="300" height="200" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/01/Ruiz-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/01/Ruiz-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/01/Ruiz-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/01/Ruiz-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/01/Ruiz-2048x1366.jpg 2048w" sizes="(max-width: 300px) 100vw, 300px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em><span data-preserver-spaces="true">Sen. Teresa Ruiz has pushed for ending the state&#8217;s requirement that public school teachers live in New Jersey. (Hal Brown for New Jersey Monitor)</span></em></p></figure>
+<p style="font-weight: 400;">Sen. Teresa Ruiz (D-Newark) is a former education chair who has remained active in the space following her ascent through the ranks of leadership (she’s the Senate’s majority leader). Ruiz said the state should do away with its residency requirement for teachers, at least while the shortages remain dire.</p>
+<p style="font-weight: 400;">“No one under any circumstance is saying &#8216;not New Jersey first,’” she said. “We always want to be New Jersey first, but when there isn&#8217;t enough New Jersey, as policymakers, administrators, and government entities, we should be responsible enough to say we need human capital in these spaces. Our students deserve better.”</p>
+<p style="font-weight: 400;">Sen. Vin Gopal (D-Monmouth), the current education chairman, agreed lifting the residency restriction would help bridge schools’ staffing gaps.</p>
+<p style="font-weight: 400;">The Senate in May approved a bill that would <a href="https://www.njleg.state.nj.us/bill-search/2022/S904" target="_blank">suspend the residency requirement</a> for three years in a unanimous vote, but the measure has not advanced in the Assembly, where it has the backing of Assemblywoman Pam Lampitt, the lower chamber’s education chairwoman. A similar bill <a href="https://newjerseymonitor.com/2023/07/11/bill-to-end-residency-requirement-for-n-j-teachers-in-limbo-for-the-summer/">failed to pass</a> in the last legislative session.</p>
+<p style="font-weight: 400;">Gopal said he was considering legilsation to boost teacher compensation but said the legislation is still in very early stages.</p>
+<p style="font-weight: 400;">A separate bill that would rework the state&#8217;s funding formula is expected to be introduced in mid-September, but Gopal cautioned that bill would likely see significant changes as it moves through committees to floor votes.</p>
+<p style="font-weight: 400;">A reworked formula should include provisions to extend school budget timelines to prevent last-minute staff cuts and allow districts to better plan their budgets, Ruiz said.</p>
+<p style="font-weight: 400;">Rolling back a Christie-era policy that doubled the state’s student teaching requirement from a semester to a full school year could also boost the state’s educator workforce, Spiller said.</p>
+<p style="font-weight: 400;">“We had the best schools in the nation before. We have the best schools now. Why did we double the length of time? That is something that we could bring back in line to what it was before and not cost any money,” he said.</p>
+<p style="font-weight: 400;">Policymakers said the state must also address teacher departures to stabilize the workforce. The Heldrich Center’s report found that while departures remained roughly level save for spikes during the pandemic, the share of teachers who left of their own accord — and not for budgetary reasons — has spiked over the 11-year period.</p>
+<p style="font-weight: 400;">Gopal pointed to the increased politicization as schools, noting workforce trends had reversed somewhat after Republican attacks over school gender policy and library collections ebbed.</p>
+<p style="font-weight: 400;">Gov. Chris Christie’s administration, which spurred school cuts amid the Great Recession and warred with teachers unions over health benefits and pensions, also slimmed the teaching candidate pool, Spiller said.</p>
+<p style="font-weight: 400;">“From the vitriol that we heard before to the fundamental changes to the systems that we see financially now, that has led to less people engaging in the process to become a teacher, and certainly less people choosing to continue moving forward to become an actual teacher,” he said.</p>
+<p style="font-weight: 400;">    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Summer ending with no action on bill to protect workers from heat</title>
+		<link>https://newjerseymonitor.com/2024/09/02/summer-ending-with-no-action-on-bill-to-protect-outdoor-workers-from-heat/</link>
+		
+		<dc:creator><![CDATA[Special to the New Jersey Monitor]]></dc:creator>
+		<pubDate>Mon, 02 Sep 2024 12:00:26 +0000</pubDate>
+				<category><![CDATA[Commentary]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14614</guid>
+
+					<description><![CDATA[The New Jersey Legislature failed to pass a workplace heat standard before the summer began despite bipartisan support.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/05/GettyImages-1574710415-2.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/05/GettyImages-1574710415-2.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/05/GettyImages-1574710415-2-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/05/GettyImages-1574710415-2-768x512.jpg 768w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">The New Jersey Legislature failed to pass a workplace heat standard before the summer began despite bipartisan support. (Photo by Anna Moneymaker/Getty Images)</p><p><em><span data-preserver-spaces="true">by Make the Road New Jersey member Elder Portillo</span></em></p>
+<p><span data-preserver-spaces="true">As we celebrate Labor Day today, with a barbeque on the patio or a final pool party, think of the workers like me who labored under extreme heat this summer.</span></p>
+<p><span data-preserver-spaces="true">For more than five years, I’ve worked as a mason, laying custom walkways, patios, driveways, and pools in backyards across New Jersey. My work allows our clients to enjoy their backyards or pools and cool off and relax during the summer. Almost every day, I work ten-plus hour shifts, even during extreme weather conditions. This is how I have been supporting my family for years.</span></p>
+<p><span data-preserver-spaces="true">However, what usually is a rewarding job has become a nightmare </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/07/12/amid-heat-wave-labor-groups-urge-n-j-to-enact-protections-for-outdoor-workers/" target="_blank" rel="noopener"><span data-preserver-spaces="true">during this summer’s record-breaking heatwaves.</span></a></p>
+<p><span data-preserver-spaces="true">Working under extreme heat conditions is not only uncomfortable, it can be deadly. Between the intense sun and the concrete magnifying heat back at me during a 10-plus hour shift, my skin broke and burned. I have burn scars over my forearms, my shoulders, and my back.</span></p>
+<p><span data-preserver-spaces="true">On the hottest days this summer, I felt dizzy and vomited from the heat. The effects of the intense heat stayed with me even after my shift. On my drive home, I often had a headache and couldn’t focus. Even when I got home, I didn’t have an appetite to eat the food my wife made for me, I was so nauseous.</span></p>
+<p><span data-preserver-spaces="true">There were plenty of warning signs, but my employer was under no obligation to provide any type of protection.</span></p>
+<p><span data-preserver-spaces="true">Workers’ lives are at risk. Last year,</span><a class="editor-rtfLink" href="https://www.hhs.gov/climate-change-health-equity-environmental-justice/climate-change-health-equity/climate-health-outlook/extreme-heat/index.html#:~:text=Extreme%20summer%20heat%20is%20already,2022%2C%20and%202%2C302%20in%202023." target="_blank" rel="noopener"><span data-preserver-spaces="true"> 2,300 </span></a><span data-preserver-spaces="true">heat-related fatalities were recorded in the United States, more than three times the annual average from 2004 to 2018. In New Jersey and surrounding areas, heat-related hospitalizations </span><a class="editor-rtfLink" href="https://www.nj.com/essex/2024/08/962-people-suffering-from-heat-in-nj-have-gone-to-the-er-and-summers-not-even-over.html" target="_blank" rel="noopener"><span data-preserver-spaces="true">rose dramatically</span></a><span data-preserver-spaces="true">, with nearly one thousand people seeking emergency room care between May and early August this year.</span></p>
+<p><span data-preserver-spaces="true">That’s why I’m fighting for a workplace heat standard — I want to make it home to my family every day.</span></p>
+<blockquote class="wp-embedded-content" data-secret="hDQm0ijV8m"><p><a href="https://newjerseymonitor.com/2021/09/07/extreme-heat-could-cost-n-j-s-outdoor-workers-2-2b-in-lost-earnings-researchers-warn/">Extreme heat could cost N.J.&#8217;s outdoor workers $2.2B in lost earnings, researchers warn</a></p></blockquote>
+<p><iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted" title="&#8220;Extreme heat could cost N.J.&#8217;s outdoor workers $2.2B in lost earnings, researchers warn&#8221; &#8212; New Jersey Monitor" src="https://newjerseymonitor.com/2021/09/07/extreme-heat-could-cost-n-j-s-outdoor-workers-2-2b-in-lost-earnings-researchers-warn/embed/#?secret=GaDJ7NDaf6#?secret=hDQm0ijV8m" data-secret="hDQm0ijV8m" width="500" height="282" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe></p>
+<p><span data-preserver-spaces="true">The New Jersey Legislature </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/07/18/truck-drivers-kitchen-workers-demand-extreme-heat-rules/" target="_blank" rel="noopener"><span data-preserver-spaces="true">failed to pass a workplace heat standard</span></a><span data-preserver-spaces="true"> before the summer began despite bipartisan support. The heat standard would provide basic protections to both outdoor and indoor workers working in extreme heat. Workers like me can stay safe working in the heat, but we need adequate protections: access to water, shade or cooling stations, water breaks, and</span> <span data-preserver-spaces="true">education on how to identify the symptoms of heat illness and heat stroke. Without all this, our health and safety is in jeopardy, even though heat-related illnesses are entirely preventable</span></p>
+<p><span data-preserver-spaces="true">This Labor Day, legislators will participate in parades and issue statements in support of workers&#8217; rights. But the hundreds of thousands of workers like me won’t be celebrating because we’re still waiting for them to pass the workplace heat standards that will keep us safe once the next summer season begins.</span></p>
+<p><span data-preserver-spaces="true">    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	</span></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Trump taps into culture war issues, seeks to energize base at Moms for Liberty event</title>
+		<link>https://newjerseymonitor.com/2024/08/31/trump-taps-into-culture-war-issues-seeks-to-energize-base-at-moms-for-liberty-event/</link>
+		
+		<dc:creator><![CDATA[Ariana Figueroa]]></dc:creator>
+		<pubDate>Sat, 31 Aug 2024 19:38:48 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Donald Trump]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14640</guid>
+
+					<description><![CDATA[“Our country is being poisoned,” Trump said of migrants and their children in public schools]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2169525412-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2169525412-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2169525412-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2169525412-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2169525412-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2169525412-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">WASHINGTON, DC - AUGUST 30: Republican presidential nominee, former U.S. President Donald Trump (L) speaks as Co-founder of Moms for Liberty Tiffany Justice (R) looks on during the 2024 Joyful Warriors National Summit on August 30, 2024 in Washington, DC. Trump continued to campaign for the upcoming presidential election on November 5, 2024. (Photo by Alex Wong/Getty Images)</p><p>WASHINGTON — Former President Donald Trump late Friday rarely touched on education issues during the third conference of Moms for Liberty, a conservative parental rights group that has ties to Project 2025, the far-right playbookTrump has tried to distance himself from.</p>
+<p>Instead, in a more than one-hour interview with Moms for Liberty co-founder Tiffany Justice, he gave lengthy commentary on immigration; the Afghanistan withdrawal; his false claim that he won the 2020 presidential election; his old T.V. show “The Apprentice;” and frustration at running against Democratic presidential nominee Kamala Harris instead of President Joe Biden.</p>
+<p>“Our country is being poisoned,” Trump said of migrants and their children in public schools. “And your schools and your children are suffering greatly because they’re going into the classrooms … they don’t even speak English.”</p>
+<p>Trump didn’t give details on how he would enact education policy changes at the federal level but said he was against public schools allowing transgender students to identify with their gender identity in the classroom.</p>
+<p>Trump added that he was supportive of “parental rights” and the mission of Moms for Liberty, which supports vouchers for private school tuition, running for local school boards and dismantling the U.S. Department of Education.</p>
+<p>“I’m for parental rights all the way,” Trump said. “I don’t even understand the concept of not being.”</p>
+<p>Across the campaign trail Trump has also floated the idea that parents should be <a href="https://www.edweek.org/leadership/trump-says-parents-should-elect-principals-what-would-that-look-like/2023/07" target="_blank">allowed to elect principals</a> in public schools.</p>
+<p>Trump attacked Harris, the Democratic presidential nominee, and called her a “Marxist.” He added that he looked forward to <a href="https://nebraskaexaminer.com/2024/08/08/trump-agrees-to-sept-10-debate-with-harris-claims-two-more-upcoming/" target="_blank">debating her on Sept. 10 on ABC News</a>.<a href="https://nebraskaexaminer.com/2024/08/08/trump-agrees-to-sept-10-debate-with-harris-claims-two-more-upcoming/" target="_blank"> </a></p>
+<p>The Harris campaign criticized Trump for speaking at the event.</p>
+<p>“Donald Trump is celebrating the new school year by pushing his frightening Project 2025 agenda that would hurt kids and dismantle public education as we know it, while Vice President Harris helped deliver the largest public education investment in American history and is fighting for every child to have access to a good school and a shot at the American dream,” Joseph Costello, a spokesperson for the Harris campaign, said in a statement.</p>
+<p>Harris has said little about education policy on the campaign trail. But during her campaign speeches she has opposed book bans and has stressed the need to address the student loan debt crisis, while touting some of the debt forgiveness initiatives of the Biden administration.</p>
+<p>During Friday’s interview, Justice took aim at the policies of Democratic vice presidential nominee Minnesota Gov. Tim Walz.</p>
+<p>Walz is a former geography teacher who was the teacher adviser for his school’s first gay, straight, alliance club in 1999. And as governor, he signed a bill into law making free school lunches available for students.</p>
+<p>Justice raised a question about a bill Walz signed into law making Minnesota a safe haven for access to gender-affirming care.</p>
+<p>Justice asked Trump what were some of the things he would be able to do as president because “there’s been an explosion in the number of children who identify as transgender, and children are being taught that they were born in the wrong body.”</p>
+<p>“Well, you can do everything,” Trump said. “President has such power.”</p>
+<p>Last month, the U.S. Supreme Court <a href="https://georgiarecorder.com/2024/07/01/presidential-immunity-extends-to-some-official-acts-supreme-court-rules-in-trump-case/" target="_blank">ruled that presidents have immunity</a> for some official acts in office.</p>
+<p>Justice asked Trump what policies he would enact at the federal level to protect “parental rights,” such as school choice, which gives parents an option to enroll their children in a school other than the assigned public one, often using public funding to do so.</p>
+<p><a href="https://virginiamercury.com/2023/03/27/gop-bill-establishing-a-federal-parental-bill-of-rights-passed-in-u-s-house/" target="_blank">House Republicans already passed a similar bill last year</a>, but it’s likely to go nowhere in the Senate where Democrats hold a slim majority.</p>
+<p>Trump said that Republicans are “the party of common sense.”</p>
+<p>“I mean we’re conservative,” he said. “All of these things we’re talking about, no men in women’s sports, no gender operation, I mean it’s these operations, it’s crazy.”</p>
+    <h4 class="editorialSubhed">Project 2025 ties</h4>
+
+	
+<p>This is the second time Trump has attended a Moms for Liberty conference, and while he embraces their culture war issues, the former present has not made “parental rights” a predominant issue in his reelection campaign.</p>
+<p>Instead, he has centered his campaign on immigration and on the <a href="https://floridaphoenix.com/2024/08/28/trump-promises-mass-deportations-of-undocumented-people-how-would-that-work/" target="_blank">promise of undertaking mass deportations</a> of undocumented people. During the interview, he mainly criticized the Biden administration over its immigration policies.</p>
+<p><a href="https://wisconsinexaminer.com/2024/07/17/conservative-gop-women-led-by-arkansas-gov-sarah-sanders-rally-at-convention/" target="_blank">Moms for Liberty has strong GOP ties</a>, appearing at the Republican National Convention this summer in Milwaukee. It has more than 130,000 members across 300 chapters in 48 states, according to the organization.</p>
+<p>The group considers the Heritage Foundation, a conservative think tank that wrote Project 2025, a key sponsor. Moms for Liberty also <a href="https://www.project2025.org/about/advisory-board/" target="_blank">sits on an advisory board for Project 2025</a>, which Trump has tried to distance from his campaign as Democrats highlight his ties to the aggressive conservative playbook.</p>
+<p>The Heritage Foundation put together several sessions during the Moms for Liberty summit, one by Lindsey Burke, the director of the Center for Education Policy at the think tank. She<a href="https://static.project2025.org/2025_MandateForLeadership_CHAPTER-11.pdf" target="_blank"> was the lead author on the Department of Education section of Project 2025</a> that calls to abolish the agency. Another Heritage session was titled: “Boyhood and the Changing Role of the Man in American Life.”</p>
+<p>While Moms for Liberty rose to prominence in 2021 amid the coronavirus pandemic, with a focus on public schools and culture war topics, its hold on local school board elections has started to wane.</p>
+<p>In school board election races last year, candidates endorsed by the group underperformed, <a href="https://www.brookings.edu/articles/how-did-school-board-candidates-endorsed-by-moms-for-liberty-perform-in-2023/" target="_blank">with fewer than one-third winning their races</a>, according to an analysis from the left-leaning think tank, the Brookings Institution.</p>
+<p>Moms for Liberty also announced a $3 million campaign and advertising blitz in key states with a focus on local school board elections in Arizona, Georgia, North Carolina and Wisconsin — all battleground states.</p>
+<p>The group, which is a nonprofit, started in Florida and was at the forefront of pushing against mask mandates during school reopenings, <a href="https://wisconsinexaminer.com/2022/04/19/lgbtq-community-people-of-color-in-the-crosshairs-of-banned-book-movement/" target="_blank">eliciting book bans and challenges</a>, and objections to structural racism being discussed in classrooms.</p>
+<p>With the new Title IX regulations from the Biden administration, <a href="https://wisconsinexaminer.com/2024/08/01/much-attacked-final-title-ix-rule-goes-into-effect-while-still-blocked-in-26-states/" target="_blank">the group filed lawsuits against the new rules</a>, which broaden sex discrimination to include gender ideology and sexual orientation, and give protections to transgender students.</p>
+<p>While Moms for Liberty quickly rose on the far right, the organization has had its share of controversy, from its co-founder to local chapters.</p>
+<p>Police records from a now-closed criminal investigation allege that Moms for Liberty co-founder Bridget Ziegler helped her husband, former Florida GOP chairperson Christian Ziegler, look for women the couple could have sexual relations with, <a href="https://www.tampabay.com/news/florida/2024/05/17/bridget-ziegler-helped-christian-ziegler-prowl-women-records-show/" target="_blank">according to the Tampa Bay Times</a>.</p>
+<p>Authorities were investigating Christian Ziegler for allegedly illegally filming a woman who accused him of sexual assault, but the state attorney’s office in Sarasota announced in March that it would not pursue charges.</p>
+<p>A local chapter in Indiana had to apologize for <a href="https://19thnews.org/2023/06/indiana-moms-for-liberty-hitler-quote/" target="_blank">using a quote by former Nazi leader Adolf Hilter</a> in a newsletter to members, and <a href="https://apnews.com/article/moms-for-liberty-proud-boys-kentucky-d073732a6bbf2a65e08dcc76bc53cf06" target="_blank">two Kentucky chapter leaders were removed</a> after posing in a photo with the Proud Boys, a far-right extremist group.</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Judges toss false-arrest claims against federal marshals in mistaken-identity case</title>
+		<link>https://newjerseymonitor.com/2024/08/30/judges-toss-false-arrest-claims-against-federal-marshals-in-mistaken-identity-case/</link>
+		
+		<dc:creator><![CDATA[Dana DiFilippo]]></dc:creator>
+		<pubDate>Fri, 30 Aug 2024 16:01:29 +0000</pubDate>
+				<category><![CDATA[Civil Rights + Immigration]]></category>
+		<category><![CDATA[Courts]]></category>
+		<category><![CDATA[Essex County]]></category>
+		<category><![CDATA[Thomas Ambro]]></category>
+		<category><![CDATA[U.S. Marshals]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14623</guid>
+
+					<description><![CDATA[A federal appeals court ruled that U.S. Marshals can't be held liable for arresting the wrong person on a 2019 warrant in a mistaken-identity case.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="768" src="https://newjerseymonitor.com/wp-content/uploads/2024/01/IMG_0995-1024x768.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/01/IMG_0995-1024x768.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/01/IMG_0995-300x225.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/01/IMG_0995-768x576.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/01/IMG_0995-1536x1152.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/01/IMG_0995-2048x1536.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">A federal appeals court ruled that U.S. Marshals can't be held liable for arresting the wrong person on a 2019 warrant in a mistaken-identity case. (Photo by New Jersey Monitor)</p><p><span data-preserver-spaces="true">A New Jersey woman who spent two weeks in jail for someone else’s decades-old parole violation has lost her bid to hold the federal marshals who arrested her accountable.</span></p>
+<p><span data-preserver-spaces="true">A three-judge appellate panel </span><a class="editor-rtfLink" href="https://www2.ca3.uscourts.gov/opinarch/231987p.pdf" target="_blank" rel="noopener"><span data-preserver-spaces="true">ruled</span></a><span data-preserver-spaces="true"> Thursday that the marshals who hauled Judith Maureen Henry to the Essex County Correctional Facility in 2019 acted on a “constitutionally valid” warrant and were entitled to qualified immunity, a legal protection that insulates law enforcement officers from liability.</span></p>
+<p><span data-preserver-spaces="true">“Their arrest of Henry relying on information attached to the warrant was a reasonable mistake, and therefore her arrest did not violate the Fourth Amendment,” wrote Judge Thomas Ambro of the U.S. Third Circuit Court of Appeals.</span></p>
+<p><span data-preserver-spaces="true">Henry shared the same name as a woman who had pled guilty to drug possession and then skipped parole in Pennsylvania in 1993, according to the ruling. In 2019, the director of the Pennsylvania Interstate Parole Services issued a warrant for the parole absconder’s arrest for violating parole 26 years earlier. The warrant, though, identified Henry as the marshals’ target, the ruling says.</span></p>
+<p><span data-preserver-spaces="true">Henry repeatedly told marshals they had the wrong person and asked officers to compare her fingerprints to the absconder’s, but no one did that until she was transferred to Pennsylvania 10 days after her arrest, according to the ruling. It took a few more days for her to be released.</span></p>
+<p><span data-preserver-spaces="true">“Henry’s complaint — that the Marshals failed to take her claims of innocence seriously — raises a host of policy questions about the role of the Marshals Service after they apprehend a suspect on a warrant for a crime they did not investigate,” Ambro wrote.</span></p>
+<p><span data-preserver-spaces="true">That includes questions about how strong a claim of innocence must be before a marshal investigates, who should investigate, and how in-depth of an investigation they should do, he added.</span></p>
+<p><span data-preserver-spaces="true">“A reasonable observer could conclude the answers are not hard to find and would impose minimal burdens on the Marshals,” he conceded.</span></p>
+<p><span data-preserver-spaces="true">Still, he noted, those are policy questions better left to lawmakers. The marshals weren’t involved in Henry’s continued detention, he added.</span></p>
+<p><span data-preserver-spaces="true">He also rejected Henry’s claim that her treatment resulted from her race, sex, national origin, and “lower economic status.” Henry is Black and from Jamaica, court paperwork shows.</span></p>
+<p><span data-preserver-spaces="true">“We need not accept this bare conclusion, and she offers no other allegations to support it,” Ambro wrote.</span></p>
+<p><span data-preserver-spaces="true">A district judge had refused the marshals&#8217; request to dismiss Henry&#8217;s claims against them. Ambro reversed that ruling and ordered the judge to drop the marshals from the suit.</span></p>
+<p><span data-preserver-spaces="true">Besides the marshals, Henry’s lawsuit names Essex County and about 30 named law enforcement officers and government officials in New Jersey and Pennsylvania as defendants. Henry accused them of abuse of process, false arrest and imprisonment, intentional infliction of emotional distress, failures to train and supervise, and conspiracy.</span></p>
+<p><span data-preserver-spaces="true">Henry&#8217;s attorneys did not respond Friday to a request for comment.</span></p>
+<p><span data-preserver-spaces="true">    <a href="https://newjerseymonitor.com/donate" style="text-decoration:none;">
+    <div class="donateContainer">
+        <div class="donateTextContainer">
+            <p>SUPPORT NEWS YOU TRUST.</p>
+        </div>
+        <div class="donateButtonContainer">
+            <button>DONATE</button>
+        </div>
+    </div>
+    </a>
+	</span></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Harris, Walz defend past statements, promise ‘opportunity economy’ in CNN interview</title>
+		<link>https://newjerseymonitor.com/2024/08/30/harris-walz-defend-past-statements-promise-opportunity-economy-in-cnn-interview/</link>
+		
+		<dc:creator><![CDATA[Ashley Murray]]></dc:creator>
+		<pubDate>Fri, 30 Aug 2024 10:40:33 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Donald Trump]]></category>
+		<category><![CDATA[Kamala Harris]]></category>
+		<category><![CDATA[Tim Walz]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14621</guid>
+
+					<description><![CDATA[Thursday's interview came a week after Harris formally accepted the party’s nomination at the Democratic National Convention in Chicago.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/Kamala-Harris-Georgia-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/Kamala-Harris-Georgia-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Kamala-Harris-Georgia-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Kamala-Harris-Georgia-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Kamala-Harris-Georgia-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Kamala-Harris-Georgia-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Democratic presidential nominee, U.S. Vice President Kamala Harris speaks at a campaign rally at the Enmarket Arena on Aug. 29, 2024 in Savannah, Georgia. Harris has campaigned in southeast Georgia for the past two days and on Thursday, she and running mate, Minnesota Gov. Tim Walz, sat for an interview with CNN’s Dana Bash. (Photo by Win McNamee/Getty Images)</p><p>WASHINGTON — Vice President Kamala Harris on Thursday defended her values and vowed, if elected, to appoint a Republican to her cabinet in her first major sit-down interview since her presidential campaign began just over a month ago.</p>
+<p>Harris, who rose to the top of the Democratic ticket after President Joe Biden dropped his bid in July, spoke to CNN’s Dana Bash in Savannah, Georgia, for roughly 30 minutes with her running mate Minnesota Gov. Tim Walz by her side.</p>
+<p>The interview came a week after Harris <a href="https://www.newsfromthestates.com/article/lets-fight-it-harris-vows-chart-new-way-forward-defeat-trump" target="_blank">formally accepted</a> the party’s nomination at the Democratic National Convention in Chicago. Harris had recently become the target of criticism for not yet participating in an unscripted interview with a major news outlet.</p>
+<p>Harris and Walz <a href="https://www.cnn.com/2024/08/29/politics/kamala-harris-tim-walz-cnntv/index.html" target="_blank">sat down</a> with the network anchor Thursday afternoon in Georgia during a pause in the pair’s two-day bus tour through the southeastern region of the battleground state.</p>
+<p>Harris told Bash that she envisions building an “opportunity economy” for the middle class, including expanding the child tax credit to up to $6,000, providing a $25,000 tax credit for first-time homebuyers, and combating “price gouging,” to which Harris attributed high grocery prices.</p>
+<p>The vice president ticked off Democratic accomplishments under Biden, including capping the price of insulin and reducing child poverty under a pandemic-era temporary expansion of the child tax credit that eliminated the work requirement and paid families in monthly installments.</p>
+<p>“I’ll say that that’s good work, there’s more to do, but that’s good work,” Harris said.</p>
+<p>The CNN anchor pressed Harris on her changes in policy positions, including immigration and fracking.</p>
+<p>Republicans have pounced on Harris’ past statements and accuse her of changing her tune to appeal to more centrist voters. Former President Donald Trump on Tuesday dubbed her “FLIP-FLOPPING KAMALA” on his Truth Social platform, where the current GOP presidential nominee posts numerous times a day.</p>
+<p>“​​Let’s be clear, in this race I’m the only person who has prosecuted transnational criminal organizations who traffic in guns, drugs and human beings,” Harris said when asked about her past position on decriminalizing the border. “I’m the only person in this race who actually served a border state as attorney general to enforce our laws, and I would enforce our laws as president going forward, I recognize the problem.”</p>
+<p>Harris also defended her switch from opposing fracking to supporting it.</p>
+<p>“I think the most important and most significant aspect of my policy perspective and decisions is my values have not changed. I have always believed, and I have worked on it, that the climate crisis is real,” Harris said.</p>
+<p>Despite attacks from Republicans, Bash noted that the Democratic National Convention featured quite a few speakers from the GOP side of the aisle.</p>
+<p>Prompted to the idea by Bash, Harris said “it would be a benefit to the American public” to appoint a Republican to her administration cabinet, if elected — though she didn’t name names.</p>
+<p>“I have spent my career inviting diversity of opinion. I think it’s important to have people at the table when some of the most important decisions are being made that have different views, different experiences,” she said.</p>
+    <h4 class="editorialSubhed">Harris brushes off Trump’s insults</h4>
+
+	
+<p>The interview revealed for many that Harris and Trump have never met face-to-face.They will do so for the first time on the <a href="https://www.newsfromthestates.com/article/trump-agrees-sept-10-debate-harris-claims-two-more-upcoming" target="_blank">debate stage</a> on Sept. 10, an event that will air on ABC News.</p>
+<p>As for her thoughts on Trump, Harris told Bash that the former president is “diminishing the character and the strength of who we are as Americans.”</p>
+<p>When Bash asked Harris to respond to Trump’s attacks, including <a href="https://www.newsfromthestates.com/article/trump-insults-harris-makes-false-claims-quarrels-black-journalists-conference" target="_blank">questioning her race</a>, the vice president only briefly addressed them.</p>
+<p>“Same old tired playbook, next question please,” she said.</p>
+<p>Bash then moved to the topic of the Israel-Hamas war to which Harris responded that she is “unequivocal and unwavering in my commitment to Israel’s defense and its ability to defend itself,” adding that “how it does so matters.”</p>
+<p>She reiterated her plea for a peace deal that includes rescuing hostages who remain in Hamas captivity.</p>
+<p>“​​A deal is not only the right thing to do to end this war, but will unlock so much of what must happen next. I remain committed, since I’ve been on October 8, to what we must do to work toward a two-state solution where Israel is secure, and in equal measure, the Palestinians have security and self-determination and dignity.”</p>
+    <h4 class="editorialSubhed">Walz defense</h4>
+
+	
+<p>Bash asked Walz to respond to controversy around how he described his military service that spanned more than two decades in the Army National Guard, but never included combat deployment. Questions arose when Walz said he carried weapons “in war” in a 2018 video where he was speaking about gun violence, <a href="https://apnews.com/article/walz-military-record-weapons-harris-video-89fc6fa0c5f51c0ba657b8f808afcd87" target="_blank">according</a> to The Associated Press.</p>
+<p>Walz, who also worked as a public school teacher and high school football coach, said he misspoke and that his “grammar is not always correct.”</p>
+<p>“I wear my emotions on my sleeve, I speak especially passionately about our children being shot in schools and around guns. So I think people know me. They know who I am. They know where my heart is, and again, my record has been out there for over 40 years to speak for itself,” Walz said.</p>
+<p>Bash also asked Walz about his mix-up when describing he and wife’s fertility method; he <a href="https://apnews.com/article/tim-walz-ivf-fertility-jd-vance-fc5ebf8f37adb28cf45d0af51224a938" target="_blank">said</a> it was in vitro fertilization — a <a href="https://oregoncapitalchronicle.com/2024/06/13/u-s-senate-republicans-reject-democrats-bill-on-ivf-protections/" target="_blank">topic</a> that has fractured anti-abortion voters — while in reality the couple used artificial insemination.</p>
+<p>Walz told Bash, “I certainly own my mistakes when I make them.”</p>
+<p>“I spoke about our infertility issues because it’s hell, and families know this. And I spoke about the treatments that were available to us, that had those beautiful children. That’s quite a contrast in folks that are trying to take those rights away from us,” he said.</p>
+<p>Just as the interview ended, Trump posted to his Truth Social platform the word “BORING!!!”</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Sen. Nellie Pou to replace late Rep. Bill Pascrell on November ballot</title>
+		<link>https://newjerseymonitor.com/briefs/sen-nellie-pou-to-replace-late-rep-bill-pascrell-on-november-ballot/</link>
+		
+		<dc:creator><![CDATA[Sophie Nieto-Munoz]]></dc:creator>
+		<pubDate>Fri, 30 Aug 2024 01:44:18 +0000</pubDate>
+				<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Politics]]></category>
+		<category><![CDATA[9th Congressional District]]></category>
+		<category><![CDATA[Bill Pascrell Jr.]]></category>
+		<category><![CDATA[Nellie Pou]]></category>
+		<category><![CDATA[Trend – Election 2024]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14619</guid>
+
+					<description><![CDATA[Sen. Nellie Pou, 68, has served in the Legislature since 1997, when she succeeded Pascrell in the Assembly after he left for Congress.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2023/02/Pou-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/02/Pou-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/02/Pou-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/02/Pou-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2023/02/Pou-1536x1025.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2023/02/Pou-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Sen. Nellie Pou (D-Passaic) will face Republican Billy Prempeh in November. (Hal Brown for New Jersey Monitor)</p><p>Democratic officials selected state Sen. Nellie Pou on Thursday to replace the late Rep. Bill Pascrell Jr. on the November ballot as the Democratic Party nominee in the 9th Congressional District.</p>
+<p><span data-preserver-spaces="true">Pou won the uncontested nomination by a voice vote of more than 400 Democratic committee members at a </span><span data-preserver-spaces="true">convention held at the</span><span data-preserver-spaces="true"> Passaic County Technical Institute.</span><span data-preserver-spaces="true"> She will face Republican Billy Prempeh in November. </span></p>
+<p><span data-preserver-spaces="true">If elected in November,</span><span data-preserver-spaces="true"> she would be the first Latina to represent New Jersey in Congress.</span><span data-preserver-spaces="true"> The 9th District is heavily Latino and Hispanic, with the community making up more than 40% of the population. </span></p>
+<p>She noted the &#8220;pivotal moment in history&#8221; in her acceptance speech.</p>
+<p>&#8220;As I take this step, the significance of being the first Latina to serve in Congress from New Jersey ignites my heart and lifts up my spirit reinforcing in me our most sacred pledge: to defend every person no matter where they come from, no matter who they are, or what they look like, or who they love,&#8221; she said.</p>
+<p><span data-preserver-spaces="true">Her nomination comes eight days after </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/08/21/rep-bill-pascrell-dies-after-prolonged-hospital-stays/" target="_blank" rel="noopener"><span data-preserver-spaces="true">the 87-year-old congressman</span></a><span data-preserver-spaces="true"> died following a prolonged hospital stay. Pascrell’s funeral </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/08/28/mourners-remember-the-late-rep-bill-pascrell-as-devoted-to-family-and-paterson/" target="_blank" rel="noopener"><span data-preserver-spaces="true">was held</span><span data-preserver-spaces="true"> Wednesday</span></a><span data-preserver-spaces="true">. </span></p>
+<p><span data-preserver-spaces="true">His death prompted a week-long scramble for a new candidate, with a deadline of Aug. 29 to fill primary nominee vacancies for the general election. It swiftly became a crowded field, with Pou, Paterson Mayor André Sayegh, Assemblyman Benjie Wimberly (D-Passaic), and Assemblywoman Shavonda Sumter (D-Passaic) jumping into the race. </span></p>
+<p><span data-preserver-spaces="true">Pou </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/briefs/state-sen-pou-gets-key-backing-to-replace-late-rep-pascrell-on-november-ballot/" target="_blank" rel="noopener"><span data-preserver-spaces="true">received the backing of the Democratic chairs</span></a><span data-preserver-spaces="true"> of Bergen, Passaic, and Hudson counties — parts of which make up the 9th District — over the weekend. Sayegh suspended his campaign Monday, and Sumter withdrew from the race Tuesday. Wimberly, who had picked up endorsements from labor groups and faith leaders, dropped his bid Wednesday. </span></p>
+<p><span data-preserver-spaces="true">Pou, 68, has served in the Legislature since 1997, when she succeeded Pascrell in the Assembly after he left for Congress. She joined the state Senate in 2012 and currently serves as the majority caucus chair. She has also served as chair of the state Legislative Latino Caucus since 2006 and was elected president of the National Hispanic Caucus of State Legislators in 2021. </span></p>
+<p><span data-preserver-spaces="true">This</span><span data-preserver-spaces="true"> is the second special convention Democrats have held in recent months to find successors for members of Congress who have died. In July, </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/briefs/democrats-choose-newark-council-president-to-replace-the-late-rep-payne-on-november-ballot/" target="_blank" rel="noopener"><span data-preserver-spaces="true">Democratic officials chose LaMonica McIver</span></a><span data-preserver-spaces="true"> to replace the late Rep. Donald Payne Jr. on the November ballot in the 10th Congressional District. </span></p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Some stumbles for NJ Transit during fare-free week</title>
+		<link>https://newjerseymonitor.com/briefs/some-stumbles-for-nj-transit-during-fare-free-week/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Thu, 29 Aug 2024 17:05:18 +0000</pubDate>
+				<category><![CDATA[Transportation]]></category>
+		<category><![CDATA[Amtrak]]></category>
+		<category><![CDATA[Jason Abrams]]></category>
+		<category><![CDATA[John Chartier]]></category>
+		<category><![CDATA[Mike Inganamort]]></category>
+		<category><![CDATA[Natalie Hamilton]]></category>
+		<category><![CDATA[NJ Transit]]></category>
+		<category><![CDATA[Phil Murphy]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14613</guid>
+
+					<description><![CDATA[Free train rides meant to compensate for earlier summer disruptions faced delays and some cancellation this week.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="746" src="https://newjerseymonitor.com/wp-content/uploads/2022/07/train-1024x746.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2022/07/train-1024x746.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2022/07/train-300x218.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2022/07/train-768x559.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2022/07/train-1536x1119.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2022/07/train-2048x1492.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Free train rides meant to compensate for earlier summer disruptions faced delays and some cancellation this week. (Dana DiFilippo/New Jersey Monitor)</p><p style="font-weight: 400;">NJ Transit riders seeking to take advantage of <a href="https://newjerseymonitor.com/2024/08/15/nj-transit-will-be-free-for-a-week-as-apology-for-ugly-summer-governor-says/" target="_blank" rel="noopener">fare-free trains</a> meant to make up for summer service disruptions have faced a series of delays and a handful of cancellations amid power, track, and signal issues this week.</p>
+<p style="font-weight: 400;">NJ Transit pointed to issues with Amtrak, which owns and maintains the rail tracks that host NJ Transit&#8217;s northeast corridor line, to explain some disruptions, while Gov. Phil Murphy’s administration repeated Murphy’s hope that the fare holiday will be of some consolation to riders.</p>
+<p style="font-weight: 400;">“As we work diligently with Amtrak to investigate and address the issues that have occurred this summer, especially on the Northeast Corridor, we hope this fare holiday offers commuters some relief,” Murphy spokeswoman Natalie Hamilton said.</p>
+<p style="font-weight: 400;">The fare holiday began Monday and ends on Labor Day.</p>
+<p style="font-weight: 400;">On Monday, power issues disrupted service between Hoboken and Secaucus, causing delays of up to 90 minutes late into the day.</p>
+<p style="font-weight: 400;">On Tuesday, Amtrak repairs to tracks running underneath the Hudson River caused delays spanning nearly an hour during the afternoon rush. A spokesperson for NJ Transit said Amtrak saw the need for additional repairs while performing track maintenance.</p>
+<p style="font-weight: 400;">Mechanical issues caused a series of train cancellations and some smaller delays Wednesday. Amtrak Signal issues and an unruly rider who needed to be removed by police at Princeton Junction Station caused delays Thursday morning.</p>
+<p style="font-weight: 400;">“When factoring out Amtrak-related delays, [Tuesday’s] NJ Transit on-time performance would have been 96.64%. We regret any inconvenience these delays caused our customers,” said John Chartier, a spokesperson for NJ Transit.</p>
+<p style="font-weight: 400;">Jason Abrams, a spokesperson for Amtrak, said trains in and out of New York Penn Station were halted because of repairs to a track defect.</p>
+<blockquote class="wp-embedded-content" data-secret="REpORE3rHX"><p><a href="https://newjerseymonitor.com/2024/08/16/nj-transit-needs-a-long-term-fix-not-a-weeklong-gimmick/">NJ Transit needs a long-term fix, not a weeklong gimmick</a></p></blockquote>
+<p><iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted" title="&#8220;NJ Transit needs a long-term fix, not a weeklong gimmick&#8221; &#8212; New Jersey Monitor" src="https://newjerseymonitor.com/2024/08/16/nj-transit-needs-a-long-term-fix-not-a-weeklong-gimmick/embed/#?secret=eXTXHYROUQ#?secret=REpORE3rHX" data-secret="REpORE3rHX" width="500" height="282" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe></p>
+<p style="font-weight: 400;">NJ Transit faced significant and repeated delays through much of the summer, especially during repeated and lengthy heat waves in June and July.</p>
+<p style="font-weight: 400;">Excessive heat can deform rail tracks and the overhead wires that power trains, and it can cause certain train parts to fail.</p>
+<p style="font-weight: 400;">Assemblyman Mike Inganamort (R-Morris), a member of the chamber&#8217;s transportation committee, repeated a call for an outside audit of NJ Transit in response to the latest disruptions. The state earlier this year awarded a $6.7 million contract to North Highland, a consulting firm, to cut costs and streamline agency operations.</p>
+<p style="font-weight: 400;">Inganamort added that federal officials at Amtrak and some others needed to provide answers on why that infrastructure has failed during the summer months.</p>
+<p style="font-weight: 400;">&#8220;My bottom line is we didn&#8217;t ask for a free ride. We asked for a full audit, and I think that&#8217;s where our attention needs to be,&#8221; he said. &#8220;These free rides are essentially an admission, an acknowledgment that New Jersey Transit has failed New Jerseyans for too long.&#8221;</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Biden’s newest student loan repayment plan temporarily blocked by Supreme Court</title>
+		<link>https://newjerseymonitor.com/2024/08/29/bidens-newest-student-loan-repayment-plan-temporarily-blocked-by-supreme-court/</link>
+		
+		<dc:creator><![CDATA[Shauneen Miranda]]></dc:creator>
+		<pubDate>Thu, 29 Aug 2024 15:27:24 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14615</guid>
+
+					<description><![CDATA[The plan was quickly met with a wave of legal challenges from a coalition of GOP-led states in two lawsuits stemming from Missouri and Kansas.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/graduation-1-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/graduation-1-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/graduation-1-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/graduation-1-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/graduation-1-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/graduation-1-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">The Saving on a Valuable Education (SAVE) plan provided lower monthly loan payments for borrowers and lessened the time it takes to pay off their debt. (Photo by Spencer Platt/Getty Images)</p><p>WASHINGTON — The U.S. Supreme Court on Wednesday slashed the Biden administration’s latest efforts to provide student debt relief to millions of borrowers to go forward while the appeals process unfolds.</p>
+<p>The Saving on a Valuable Education (SAVE) plan provided lower monthly loan payments for borrowers and lessened the time it takes to pay off their debt. The program came shortly after <a href="https://www.scotusblog.com/2023/06/supreme-court-strikes-down-biden-student-loan-forgiveness-program/" target="_blank">the Supreme Court struck down</a> an earlier student loan forgiveness plan from the administration in June 2023 that would have canceled more than $400 billion in debt.</p>
+<p>But the SAVE plan was quickly met with a wave of legal challenges from a coalition of GOP-led states in two lawsuits stemming from Missouri and Kansas.</p>
+<p>Arkansas, Florida, Georgia, North Dakota, Ohio and Oklahoma filed a <a href="https://missouriindependent.com/2024/04/09/missouri-attorney-general-leads-coalition-challenging-biden-student-debt-relief/" target="_blank">federal lawsuit</a> alongside Missouri in April against the administration over the plan.</p>
+<p>The Supreme Court on Wednesday allowed an August ruling from the <a href="https://www.cnn.com/2024/08/09/politics/student-loan-repayment-plan-court-blocks/index.html" target="_blank">U.S. Court of Appeals for the 8th Circuit</a> that temporarily halted the plan to remain in effect. The appellate decision followed a federal judge in Missouri <a href="https://missouriindependent.com/2024/06/25/federal-rulings-out-of-kansas-missouri-put-biden-student-loan-forgiveness-on-hold/" target="_blank">issuing a preliminary injunction</a> blocking the plan in late June.</p>
+<p>In its decision, the nation’s highest court said it expects the 8th Circuit to “render its decision with appropriate dispatch.”</p>
+<p>Missouri Attorney General Andrew Bailey praised the Supreme Court’s decision in a <a href="https://ago.mo.gov/supreme-court-upholds-attorney-general-baileys-court-order-blocking-biden-harris-student-loan-scheme/" target="_blank">statement</a> Wednesday, calling it a “huge win for every American who still believes in paying their own way.”</p>
+<p>On the other hand, a spokesperson for the U.S. Department of Education said “we are disappointed in this decision, particularly because lifting the injunction would have allowed for lower payments and other benefits for borrowers across the country,” per a statement shared with States Newsroom.</p>
+<p>The spokesperson said the department “will work to minimize further harm and disruption to borrowers as we await a final decision from the Eighth Circuit,” adding that “the Biden-Harris Administration remains committed to supporting borrowers and will continue to fight for the most affordable repayment options for millions of people across the country.”</p>
+<p>In a statement, Mike Pierce, executive director of the Student Borrower Protection Center, said “in rejecting this appeal, the Supreme Court perpetuates the 8th Circuit’s bogus legal fiction that pausing affordable payments is ‘preserving the status quo.’”</p>
+<p>“This is ludicrous. Millions of people were repaying their student loans. Now they are in limbo,” Pierce added.</p>
+<p>Meanwhile, Kansas, Alabama, Alaska, Idaho, Iowa, Louisiana, Montana, Nebraska, South Carolina, Texas and Utah also <a href="https://kansasreflector.com/2024/03/28/kobach-files-lawsuit-challenging-bidens-latest-effort-to-diminish-college-student-loan-debt/" target="_blank">filed a lawsuit over the plan</a> in March.</p>
+<p>A federal judge in Kansas dismissed eight of those states — allowing only Alaska, South Carolina and Texas to move forward with their challenge — and issued a preliminary injunction.</p>
+<p>In late June, the U.S. Court of Appeals for the 10th Circuit allowed parts of the SAVE plan to go forward — forcing Alaska, South Carolina and Texas to <a href="https://www.supremecourt.gov/DocketPDF/24/24A11/316401/20240705173618326_Alaska%20v%20Cardona%20Application%20to%20Vacate%20Stay%20final.pdf" target="_blank">file an emergency request</a> to the Supreme Court to vacate the stay.</p>
+<p>But the Supreme Court rejected this attempt from the states’ attorneys general on Wednesday, saying that “applicants represent that they do not require emergency relief from this Court as long as the Eighth Circuit’s injunction … is in place.”</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Americans’ perception of AI is generally negative, though they see ‘beneficial applications’</title>
+		<link>https://newjerseymonitor.com/2024/08/29/americans-perception-of-ai-is-generally-negative-though-they-see-beneficial-applications/</link>
+		
+		<dc:creator><![CDATA[Paige Gross]]></dc:creator>
+		<pubDate>Thu, 29 Aug 2024 11:09:42 +0000</pubDate>
+				<category><![CDATA[Economy]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14593</guid>
+
+					<description><![CDATA[Respondents to a new poll on AI report they don’t fully understand how and why the technology is currently being used.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1492420635-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1492420635-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1492420635-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1492420635-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1492420635-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1492420635-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">A new poll of Americans across nine states by Heartland Forward finds that Americans are generally wary of artificial intelligence but are more positive about the potential in specific economic sectors. (Getty Images) </p><p>A vast majority of Americans feel negatively about artificial intelligence and how it will impact their futures, though they also report they don’t fully understand how and why the technology is currently being used.</p>
+<p>The sentiments came from a survey conducted this summer by think tank <a href="https://heartlandforward.org/" target="_blank">Heartland Forward</a>, which used Aaru, an AI-powered polling group that uses news and social media to generate respondents.</p>
+<p>The poll sought to learn about the perceptions of AI for Americans across different racial, gender and age groups in Alabama, Illinois, Indiana, Louisiana, Michigan, North Dakota, Ohio, Oklahoma and Tennessee. Heartland Forward also held in-person dinners in Fargo, North Dakota and Nashville, Tennessee to collect sentiments.</p>
+<p>While more than 75% of respondents reported that they feel skeptical, scared or overall negatively about AI, they reported more positive feelings when they learned about specific uses in industries like healthcare, agriculture and manufacturing.</p>
+<p>Many of the negative feelings were about AI and work, with 83% of respondents saying they think it could negatively impact their job opportunities or career paths. Those respondents said they feel anxious about AI in their industries, and nearly 53% said they feel they should get AI training in the workplace. Louisiana respondents showed the highest level of concerns for job opportunities (91%), with Alabama showing highest levels of workplace anxiety (90%).</p>
+<p>Respondents also had huge doubts about AI’s ethical capabilities and data protection, with 87% saying they don’t think AI can make unbiased ethical decisions, and 89% saying it doesn’t have the ability to safeguard privacy.</p>
+<p>But when the pollsters told respondents about specific AI uses in healthcare, agriculture, manufacturing, education, transportation, finance and entertainment, they got positive responses. The majority of respondents believe AI can have “beneficial applications” across numerous industries.</p>
+<p>Nearly 79% of respondents felt AI could have a moderate or positive impact on healthcare, 77% said so about agriculture, manufacturing and education, 80% said so about transportation, 73% said so about finance and 70% said so about entertainment.</p>
+<p>Very strong positive feelings about AI were less common, but some states stood out, seeing applications in dominant local industries. North Dakota showed more interest than others when it came to agriculture, with 35% of people seeing “very high” potential, compared to 19% in Oklahoma and 18% in Louisiana.</p>
+<p>“It really shows us that one, education is important, and that two, we need to bring the right people around the table to talk about it,” said Angie Cooper, executive vice president of Heartland Forward.</p>
+<p>The negative and positive sentiments recorded by the poll found very little variation between the gender, age and racial groups. The negative sentiments of AI’s impact on society were held across the entire political spectrum, too, Cooper said.</p>
+<p>Another uniting statistic was that at least 93% of respondents believe that it’s at least “moderately important” for governments to regulate AI.</p>
+<p>Cooper said that during the organization’s dinners in Fargo and Nashville — which brought investors, entrepreneurs, business owners and policymakers together — it was clear that people had some understanding of how AI was being used in their sector, but they weren’t aware of policies and regulations introduced at the state level.</p>
+<p>Though there’s no federal AI legislation, <a href="https://www.newsfromthestates.com/article/states-strike-out-their-own-ai-privacy-regulation" target="_blank">so far this year, 11 new states </a>have enacted laws about how to use, regulate or place checks and balances on AI. There are now 28 states with AI legislation.</p>
+<p>“The data shows, and the conversations that we’ve had in Fargo and Nashville really are around that there’s still a lack of transparency,” Cooper said. “And so they believe policy can help play a role there.”</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Mourners remember the late Rep. Bill Pascrell as devoted to family and Paterson</title>
+		<link>https://newjerseymonitor.com/2024/08/28/mourners-remember-the-late-rep-bill-pascrell-as-devoted-to-family-and-paterson/</link>
+		
+		<dc:creator><![CDATA[Sophie Nieto-Munoz]]></dc:creator>
+		<pubDate>Wed, 28 Aug 2024 21:49:33 +0000</pubDate>
+				<category><![CDATA[Politics]]></category>
+		<category><![CDATA[bill pascrell]]></category>
+		<category><![CDATA[Phil Murphy]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14590</guid>
+
+					<description><![CDATA[Mourners remembered the late U.S. Rep. Bill Pascrell of Paterson at his funeral Mass Wednesday as a witty, fiercely dedicated public servant.]]></description>
+																						<content:encoded><![CDATA[<img width="800" height="542" src="https://newjerseymonitor.com/wp-content/uploads/2022/08/52296943731_3e90924d92_c.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2022/08/52296943731_3e90924d92_c.jpg 800w, https://newjerseymonitor.com/wp-content/uploads/2022/08/52296943731_3e90924d92_c-300x203.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2022/08/52296943731_3e90924d92_c-768x520.jpg 768w" sizes="(max-width: 800px) 100vw, 800px" /><p style="font-size:12px;">Mourners remembered the late U.S. Rep. Bill Pascrell of Paterson at his funeral Mass Wednesday as a witty, fiercely dedicated public servant. (OIT/NJ Governor’s Office)</p><p><span data-preserver-spaces="true">Despite holding many public titles throughout his life, Bill Pascrell was remembered by his family Wednesday as a lifelong Patersonian who had a fierce dedication to helping the working people of New Jersey. </span></p>
+<p><span data-preserver-spaces="true">Pascrell had endless energy, a witty sense of humor, spoke with conviction, and made friends with anyone, family members said at Pascrell’s funeral Mass in Paterson. His son David recalled two family friends the family referred to as Uncle Grasshopper — a truck driver who helped support his six siblings — and Uncle Larky, a sign painter who lost his arm when he fell off a moving train. </span></p>
+<p><span data-preserver-spaces="true">“Uncle Larky and Uncle Grasshopper were the kinds of people my parents, and my father especially, were drawn to and deeply admired, and they wanted us to learn from them as their children,” said David Pascrell at a packed Cathedral of St. John the Baptist in Paterson.</span></p>
+<p><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/08/21/rep-bill-pascrell-dies-after-prolonged-hospital-stays/" target="_blank" rel="noopener"><span data-preserver-spaces="true">Pascrell died Aug. 21</span></a><span data-preserver-spaces="true"> at 87 after a prolonged hospital stay. For more than a quarter-century, he represented the 9th Congressional District, which includes his native Paterson.</span></p>
+<p><span data-preserver-spaces="true">The first pews of the church were filled with prominent state and national politicians, including Rep. Nancy Pelosi (D-California), Rep. Hakeem Jeffries (D-NY), members of New Jersey’s House delegation, Gov. Phil Murphy, and Assembly Speaker Craig Coughlin.</span></p>
+<p><span data-preserver-spaces="true">But Pascrell’s decades-long career wasn’t the focus of his funeral — it was his commitment to Paterson (&#8220;spelled with only one ‘T,'&#8221; a remark Pascrell made many times).  </span></p>
+<p><span data-preserver-spaces="true">“I’m glad they really focused on the family, because in the end, that’s what it was really all about. He fought for our families. He fought for our future,” said Paterson Mayor André Sayegh. </span></p>
+<p><span data-preserver-spaces="true">Family and friends said Pascrell was a “late bloomer” when it came to his political career. He first entered the political sphere in his 50s after serving in the U.S. Army and working as a teacher. His son Bill Pascrell III said that meant he and his brothers were able to spend time with their dad throughout their entire childhood. </span></p>
+<p><span data-preserver-spaces="true">Pascrell was elected to the state Assembly in 1987, started serving as Paterson’s mayor in 1990, and was elected to the House of Representatives in 1996.</span></p>
+<p><span data-preserver-spaces="true">He was married to his wife, Elsie, who sat in the front pew, for more than 60 years. There would be no Bill Pascrell without Elsie, son Glenn Pascrell said during his eulogy, prompting hundreds of mourners to stand and give her a round of applause.  </span></p>
+<p><span data-preserver-spaces="true">“He loved people, their stories, their journeys, their struggles, and their humanity, and I think the most important achievements in his life came from those personal connections,” said Glenn Pascrell. </span></p>
+<figure id="attachment_14576" class="wp-caption aligncenter" style="max-width:100%;width:1024px;"><a href="https://newjerseymonitor.com/pascrell/"><img decoding="async" loading="lazy" class="wp-image-14576 size-large" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/pascrell-1024x683.jpeg" alt="" width="1024" height="683" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/pascrell-1024x683.jpeg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/pascrell-300x200.jpeg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/pascrell-768x512.jpeg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/pascrell-1536x1024.jpeg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/pascrell-2048x1366.jpeg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Mourners attended a funeral Mass for the late Rep. Bill Pascrell Jr. at the Cathedral of St. John the Baptist in Paterson on Aug. 28, 2024. (Courtesy of the New Jersey Governor&#8217;s Office)</em></p></figure>
+<p><span data-preserver-spaces="true">Pascrell became motivated to advocate for first responders after Paterson firefighter John Nicosia died while responding to a massive 1991 fire at the former Meyer Brothers department store.</span></p>
+<p><span data-preserver-spaces="true">As mayor, he helped modernize the city’s communication equipment and later spearheaded similar efforts in Congress. He spearheaded the Firefighter Investment and Response Enhancement Act of 2000, which delivers federal dollars directly to fire departments across the country. </span></p>
+<p><span data-preserver-spaces="true">As recently as March, more than $1.3 million was allocated to 25 fire departments in Pascrell’s district. </span></p>
+<p><span data-preserver-spaces="true">Monsignor Geno Sylva, who delivered the homily, remembered Pascrell as a “self-proclaimed tough guy” who was able to fight without hate. They often debated issues, but Sylva said Pascrell was a devoted Christian who fought battles daily on Capitol Hill. </span></p>
+<p><span data-preserver-spaces="true">His work in Congress led to Murphy designating Route 19 as the William J. Pascrell Highway. Sylva quipped to the governor, sitting in the front pew, that he didn’t know about the honor because there’s no sign noting it.</span></p>
+<p><span data-preserver-spaces="true">“May you speedily arrive home to heaven, where there’ll be no need for you to be fiery and fierce,” Sylva said. “We’re going to get that sign up on Route 19.”</span></p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Political consultant admits filing false nominating petitions, attorney general says</title>
+		<link>https://newjerseymonitor.com/briefs/political-consultant-admits-filing-false-nominating-petitions-attorney-general-says/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Wed, 28 Aug 2024 19:57:54 +0000</pubDate>
+				<category><![CDATA[Politics]]></category>
+		<category><![CDATA[Drew Skinner]]></category>
+		<category><![CDATA[James Devine]]></category>
+		<category><![CDATA[Lisa McCormick]]></category>
+		<category><![CDATA[Matt Platkin]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14573</guid>
+
+					<description><![CDATA[Prosecutors recommend James Devine face two years of probation following a guilty plea to election fraud charges.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="694" src="https://newjerseymonitor.com/wp-content/uploads/2023/02/1O1A0667_1-1024x694.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/02/1O1A0667_1-1024x694.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/02/1O1A0667_1-300x203.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/02/1O1A0667_1-768x521.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2023/02/1O1A0667_1-1536x1042.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2023/02/1O1A0667_1-2048x1389.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Attorney General Matt Platkin said it’s critical for law enforcement to ensure that efforts to tamper with our elections are investigated and prosecuted. (Dana DiFilippo | New Jersey Monitor)</p><p style="font-weight: 400;">A political consultant admitted to filing nominating petitions with more than 1,900 fraudulent signatures in his quest to get a candidate on the gubernatorial ballot in 2021, Attorney General Matt Platkin announced Wednesday.</p>
+<p style="font-weight: 400;">James Devine pleaded guilty to charges that he submitted fraudulent nominating petitions on behalf of Lisa McCormick, a Democrat and perennial candidate who has previously launched campaigns for U.S. Senate, the House of Representatives, and New Jersey’s governorship.</p>
+<p style="font-weight: 400;">“For the public to have faith in our elections, it’s critical for law enforcement to ensure that efforts to tamper with them are investigated and prosecuted,” Platkin said. “This defendant’s plea is a testament to my office’s commitment to fair elections and to holding bad actors accountable when they attempt to taint our democratic system.”</p>
+<p style="font-weight: 400;">A judge must still approve Devine’s plea deal. The charge he pleaded guilty to carries penalties of up to five years imprisonment and a maximum fine of $15,000, though prosecutors recommended Devine, 62, be sentenced to two years of probation.</p>
+<p style="font-weight: 400;">Authorities accused Devine of filing roughly 1,948 fraudulent signatures to get McCormick onto the ballot as a contender for the 2021 Democratic gubernatorial nomination.</p>
+<p style="font-weight: 400;">The Democratic State Committee challenged McCormick’s nominating petitions, noting voters purported to have signed them said they never did. The signatures included some belonging to dead voters. Others had misspelled names or addresses, and in one instance form fields appeared in place of a voter&#8217;s name.</p>
+<p style="font-weight: 400;">An administrative law judge ordered McCormick to be removed from the ballot in mid-April 2021.</p>
+<p style="font-weight: 400;">Authorities said their investigation revealed Devine uploaded false voter information to the petition forms before submitting them to state election officials.</p>
+<p style="font-weight: 400;">“The defendant in this case has now admitted to fraudulently trying to get a candidate on the primary ballot for governor,” said Drew Skinner, executive director of Platkin’s public integrity and accountability office. “Anyone who might try to cheat our democratic system should know: We will hold you accountable.”</p>
+<p style="font-weight: 400;">McCormick mounted a write-in campaign for the nomination but failed to gain measurable support.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Bridgegate&#8217;s Bridget Kelly blasts nominee for New York City&#8217;s top attorney as &#8216;sexist&#8217;</title>
+		<link>https://newjerseymonitor.com/2024/08/28/bridgegates-bridget-kelly-blasts-nominee-for-new-york-citys-top-attorney-as-sexist/</link>
+		
+		<dc:creator><![CDATA[Dana DiFilippo]]></dc:creator>
+		<pubDate>Wed, 28 Aug 2024 15:27:25 +0000</pubDate>
+				<category><![CDATA[Politics]]></category>
+		<category><![CDATA[Bridget Kelly]]></category>
+		<category><![CDATA[Randy Mastro]]></category>
+		<category><![CDATA[Rudy Giuliani]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14543</guid>
+
+					<description><![CDATA[Bridgegate's Bridget Kelly told New York City Council Tuesday that they shouldn't support Randy Mastro as the city's top attorney.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2021/09/DPR-Bridget-Anne-Kelly-021-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2021/09/DPR-Bridget-Anne-Kelly-021-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2021/09/DPR-Bridget-Anne-Kelly-021-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2021/09/DPR-Bridget-Anne-Kelly-021-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2021/09/DPR-Bridget-Anne-Kelly-021-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2021/09/DPR-Bridget-Anne-Kelly-021-2048x1365.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Bridget Anne Kelly told New York City Council members Tuesday that Mayor Eric Adams’ choice for top city attorney is a “conniving and ruthless politician and political operative.” (Danielle Richards for New Jersey Monitor)</p><p style="font-weight: 400;">A New York City Council meeting might seem an odd place for one of New Jersey’s most notorious political scandals to arise.</p>
+<p style="font-weight: 400;">But Bridgegate defendant <a href="https://newjerseymonitor.com/2021/10/04/with-bridgegate-at-center-stage-race-for-humdrum-bergen-county-post-heats-up/">Bridget Anne Kelly</a> took the microphone there Tuesday night to deliver a scathing takedown of Randy Mastro, who New York City Mayor Eric Adams picked to become the city’s top attorney.</p>
+<p style="font-weight: 400;">She did not mince words.</p>
+<p style="font-weight: 400;">“Randy Mastro is a conniving and ruthless politician and political operative who happens to be an attorney,” she tearfully told council members. “When would somebody hire Randy Mastro? Perhaps you hire him when you need to threaten or scare someone, or when you need to take someone down for your own political security, or when you need a scapegoat to get you out of trouble.”</p>
+<p style="font-weight: 400;">Former Gov. Chris Christie hired Mastro to investigate Bridgegate, the 2013 incident in which workers closed two of the three toll lanes in Fort Lee approaching the George Washington Bridge — the world’s busiest bridge — for several days. Mastro <a href="https://www.wsj.com/public/resources/documents/nybridge0327.PDF" target="_blank">accused</a> Kelly, who was then one of Christie’s top aides, of playing &#8220;a central role&#8221; in the scheme after her romantic relationship with another Christie staffer soured.</p>
+<p style="font-weight: 400;">Kelly was federally indicted in 2015 for fraud and conspiracy but appealed her conviction all the way to the U.S. Supreme Court, which unanimously reversed it in 2020. The state <a href="https://newjerseymonitor.com/2023/05/05/lawsuits-cost-new-jersey-taxpayers-177-million-last-year/">paid</a> $7.2 million in 2022 to cover her legal expenses.</p>
+<p style="font-weight: 400;">Tuesday, Kelly told New York City Council members that Mastro’s report was a “little Harlequin novel,” called him sexist, and urged them to oppose his nomination. She noted that his report came out in 2014, years before the MeToo movement sparked a national reckoning about workplace sexual harassment.</p>
+<p style="font-weight: 400;">“Confirming Randy Mastro to serve as corporation counsel to the city of New York will send a very strong and direct message to every woman who has ever been scapegoated or slut-shamed to protect a man in power,” Kelly said. “And unfortunately, there are far too many of us to whom that resonates.”</p>
+<p>Kelly told the New Jersey Monitor Wednesday that she&#8217;s not sure her testimony changed any minds.</p>
+<p>&#8220;I don&#8217;t know New York politics, nor do I care. I was a political pawn, unfortunately,&#8221; she said. &#8220;To me, it&#8217;s more about the workplace environment, and, quite frankly, as the mother of two daughters, I think that it was important for me to remind them and other young women — because it was 10 years ago, everybody forgets — that it can happen to anybody.&#8221;</p>
+<figure id="attachment_14544" class="wp-caption alignleft" style="max-width:100%;width:300px;"><a href="https://newjerseymonitor.com/2024/08/28/bridgegates-bridget-kelly-blasts-nominee-for-new-york-citys-top-attorney-as-sexist/bridget-kelly-2/" rel="attachment wp-att-14544"><img decoding="async" loading="lazy" class="size-medium wp-image-14544" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/Bridget-Kelly-2-300x214.png" alt="" width="300" height="214" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/Bridget-Kelly-2-300x214.png 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Bridget-Kelly-2-1024x729.png 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Bridget-Kelly-2-768x547.png 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Bridget-Kelly-2.png 1132w" sizes="(max-width: 300px) 100vw, 300px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Bridget Kelly testified before the New York City Council to oppose Mayor Eric Adams&#8217; nomination of attorney Randy Mastro as city corporation counsel. (Screenshot courtesy of New York City Council)</em></p></figure>
+<p>Kelly, who brought her 27-year-old daughter to the hearing for support, told council members she still can’t get a job in government, feels like she continues to be shunned in New Jersey politics even by her fellow Republicans, and remains in therapy for post-traumatic stress disorder.</p>
+<p>“I am in PTSD therapy. I should be billing him for it,” she said.</p>
+<p>During her testimony, Kelly threw a shout-out to former state Sen. Loretta Weinberg, who “told Randy Mastro where to go with that report.”</p>
+<p>Mastro, a former federal prosecutor and chief of staff to Rudy Giuliani, did not respond to the New Jersey Monitor’s request for comment. The 51-member city council is expected to vote on his nomination next month.</p>
+<p>City Council Speaker Adrienne Adams told Kelly that she and her colleagues, some of whom have <a href="https://www.amny.com/opinion/randy-mastro-would-serve-the-powerful-not-the-public/" target="_blank">publicly rejected</a> Mastro’s nomination, “certainly feel your pain.”</p>
+<p>“We watched your ordeal, as I&#8217;m sure a lot of the nation watched your ordeal through Bridgegate, and your courage is admirable,” Adams said.</p>
+<p>Kelly’s 12 minutes of testimony came nine hours into a contentious 11-hour hearing on the nomination, which has sparked widespread opposition in the city. As she sat down to testify, Mastro walked out of the chambers. She addressed him anyway.</p>
+<p>“Your investigation led to the destruction of not only my career, but my reputation,” she said.</p>
+<p>She reminded council members that Mastro, who testified earlier Tuesday, expressed no regrets about his Bridgegate report.</p>
+<p>“He could have said something today — not that it would have made it better, but to show maybe some of you that he has a soul,&#8221; she said. &#8220;But I&#8217;m not sure he does.&#8221;</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>As more terminally ill people use the N.J. aid-in-dying law, calls grow for expanded access</title>
+		<link>https://newjerseymonitor.com/2024/08/28/as-more-terminally-ill-people-use-the-n-j-aid-in-dying-law-calls-grow-for-expanded-access/</link>
+		
+		<dc:creator><![CDATA[Dana DiFilippo]]></dc:creator>
+		<pubDate>Wed, 28 Aug 2024 11:08:22 +0000</pubDate>
+				<category><![CDATA[Gov + Legislature]]></category>
+		<category><![CDATA[Health]]></category>
+		<category><![CDATA[Compassion & Choices]]></category>
+		<category><![CDATA[Corinne Carey]]></category>
+		<category><![CDATA[Deborah Pasik]]></category>
+		<category><![CDATA[Herb Conaway Jr.]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14483</guid>
+
+					<description><![CDATA[In the past five years, doctors in New Jersey have evaluated and approved almost 300 people to end their lives by self-administering prescribed medication.]]></description>
+																						<content:encoded><![CDATA[<img width="800" height="534" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/gettyimages-1397344056-1024x6831708386034-1.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/gettyimages-1397344056-1024x6831708386034-1.jpg 800w, https://newjerseymonitor.com/wp-content/uploads/2024/08/gettyimages-1397344056-1024x6831708386034-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/gettyimages-1397344056-1024x6831708386034-1-768x513.jpg 768w" sizes="(max-width: 800px) 100vw, 800px" /><p style="font-size:12px;">In the past five years, doctors in New Jersey have evaluated and approved almost 300 people to end their lives by self-administering prescribed medication. (Getty Images)</p><p><span data-preserver-spaces="true">Since New Jersey lawmakers passed an aid-in-dying law five years ago, the number of terminally ill patients who have sought to end their lives by self-administered medication has jumped almost tenfold.</span></p>
+<p><span data-preserver-spaces="true">Now, advocates are working on two fronts to push state policymakers to “course-correct” the law and make it more accessible to people nearing death with unbearable pain and suffering.</span></p>
+<p><span data-preserver-spaces="true">They want to abolish a provision in the law that restricts it to New Jersey residents. Two terminally ill patients from Delaware and Pennsylvania and two New Jersey doctors sued the state last summer, calling the residency restriction discriminatory and unconstitutional.</span></p>
+<p><span data-preserver-spaces="true">They also want state legislators to move on a </span><a class="editor-rtfLink" href="https://www.njleg.state.nj.us/bill-search/2024/A1880/bill-text?f=A2000&amp;n=1880_I1" target="_blank" rel="noopener"><span data-preserver-spaces="true">stalled bill</span></a><span data-preserver-spaces="true"> that would allow doctors to waive the mandatory 15-day waiting period after patients&#8217; initial requests for life-ending medication. The wait was meant as a safeguard but instead has become a barrier, supporters say.</span></p>
+<p><span data-preserver-spaces="true">“Between 25 and 30% of patients that initiate the process don&#8217;t make it the 15 days to their second visit, either because they die or they lose their eligibility because mentally they&#8217;re no longer with us or they&#8217;re too weak to self-medicate,” said Dr. Deborah Pasik, a rheumatologist for more than 35 years in Morristown. “It&#8217;s really, really tragic when that happens.”</span></p>
+<p><span data-preserver-spaces="true">The advocacy comes as bodily autonomy in health care decisions has become a flashpoint nationally, with conservative states increasingly restricting abortion rights and access to gender-affirming care.</span></p>
+<p><span data-preserver-spaces="true">“I definitely worry,” Pasik said. “This is a sanctuary state for abortion care and for gender-affirming care. Why can&#8217;t it be sanctuary state for medical aid-in-dying too?”</span></p>
+<p><span data-preserver-spaces="true">    <h4 class="editorialSubhed">An upward trend</h4>
+
+	</span></p>
+<p><span data-preserver-spaces="true">New Jersey’s Medical Aid in Dying for the Terminally Ill Act was deeply controversial, with critics, </span><a class="editor-rtfLink" href="https://www.nj.com/politics/2015/01/christie_has_grave_concerns_about_physician-assist.html" target="_blank" rel="noopener"><span data-preserver-spaces="true">including former Gov. Chris </span><span data-preserver-spaces="true">Christie,</span></a><span data-preserver-spaces="true"> raising ethical and religious objections and supporters insisting people deserve dignity and autonomy in death. Even Gov. Phil Murphy, who signed the law into passage seven years after it was first introduced, acknowledged mixed feelings, </span><a class="editor-rtfLink" href="https://d31hzlhk6di2h5.cloudfront.net/20190412/4b/cd/8b/1f/02854e1f1393a35250679633/A1504.pdf" target="_blank" rel="noopener"><span data-preserver-spaces="true">writing</span></a><span data-preserver-spaces="true"> that he was &#8220;torn&#8221; between the principles of his long-held Catholic faith and compassion for those who face intolerable suffering as their lives end.</span></p>
+<p><span data-preserver-spaces="true">But by April 2019, it had mustered enough votes to pass, and the law went into effect in August 2019, 22 years after Oregon became the first state to pass such a law.</span></p>
+<p><span data-preserver-spaces="true">Now, 10 states and the District of Columbia have similar laws, and another 18 states — including New York, Pennsylvania, and Delaware — have pending legislation, according to Compassion &amp; Choices, a Colorado-based nonprofit that advocates for end-of-life autonomy.</span></p>
+<p><span data-preserver-spaces="true">Medical aid-in-dying is something that few people will need, want, or qualify for, but such laws are important for terminally ill people who want to direct their own care and avoid unnecessary suffering, said Corinne Carey, Compassion &amp; Choices’ senior campaign director for New Jersey and New York.</span></p>
+<p><span data-preserver-spaces="true">“These laws give everyone the peace of mind of knowing that they have this freedom to make their own decisions at the end of life and chart their own death experience,” Carey said.</span></p>
+<p><span data-preserver-spaces="true">Data shows there’s a growing demand for it.</span></p>
+<p><span data-preserver-spaces="true">In the past five years, doctors in New Jersey have evaluated and approved almost 300 people to end their lives by self-administering prescribed medication, with the number steadily climbing from 12 in 2019 to 101 last year, according to the Office of the Chief State Medical Examiner.</span></p>
+<figure id="attachment_14484" class="wp-caption aligncenter" style="max-width:100%;width:1262px;"><a href="https://newjerseymonitor.com/2024/08/28/as-more-terminally-ill-people-use-the-n-j-aid-in-dying-law-calls-grow-for-expanded-access/screenshot-2024-08-26-at-3-18-06-pm/" rel="attachment wp-att-14484"><img decoding="async" loading="lazy" class="wp-image-14484 size-full" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/Screenshot-2024-08-26-at-3.18.06 PM.png" alt="" width="1262" height="530" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/Screenshot-2024-08-26-at-3.18.06 PM.png 1262w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Screenshot-2024-08-26-at-3.18.06 PM-300x126.png 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Screenshot-2024-08-26-at-3.18.06 PM-1024x430.png 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Screenshot-2024-08-26-at-3.18.06 PM-768x323.png 768w" sizes="(max-width: 1262px) 100vw, 1262px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>(Chart courtesy of N.J. Office of the Chief State Medical Examiner)</em></p></figure>
+<p style="font-weight: 400;">Those who applied last year ranged in age from 37 to 100, but most — 81% — were 65 or older, <a href="https://ocsme.nj.gov/Public_Reports/MAidAnnualReports/2023.pdf" target="_blank">data</a> shows. Most (83%) chose to die at home, while the rest died at hospice facilities, nursing homes, someone else&#8217;s home, and a hotel. Terminal cancer was the most common diagnosis for people who used the law last year, representing 61% of cases. Applicants also tended to be female (57%), college-educated (71%), single, divorced, or widowed (62%), and white (95%).</p>
+<p style="font-weight: 400;">Carey attributed the racial disparity to cultural objections and health literacy, and she consequently has done outreach in communities of color.</p>
+<p style="font-weight: 400;">“If you lack health literacy, you&#8217;re certainly not going to know about this option,” Carey said. “There&#8217;s a whole range of options, and the important thing is that you&#8217;re in the driver&#8217;s seat, no matter what your decisions are.”</p>
+<p style="font-weight: 400;">    <h4 class="editorialSubhed">Waiting period</h4>
+
+	
+<p style="font-weight: 400;">In New Jersey, people given a diagnosis of six months or less to live can seek a prescription for life-ending medication under the law, as long as two doctors confirm the diagnosis. The law requires the patient to make two verbal requests 15 days apart, as well as one in writing.</p>
+<p style="font-weight: 400;">Under a bill Assemblyman Herb Conaway Jr. (D-Burlington) has introduced twice since 2022, that 15-day waiting period would be eliminated for patients not expected to survive for 15 days.</p>
+<p style="font-weight: 400;">“Most laws need to be adjusted at one point or another, driven by the data that we accumulate in the wake of the initial passage,” Conaway said.</p>
+<p style="font-weight: 400;">Most states that have legalized aid-in-dying used Oregon’s law as their blueprint, but the waiting period is a “remnant” of that pioneering law that many have since eliminated, Carey said.</p>
+<p style="font-weight: 400;">New Jersey’s bill has no co-sponsors or Senate companion, but Carey said she has been lobbying lawmakers to sign on to it — an especially urgent task if Conaway wins his <a href="https://newjerseymonitor.com/briefs/assemblyman-herb-conaway-rajesh-mohan-will-face-off-in-3rd-district-house-race/">bid for Congress</a> in November and leaves state politics.</p>
+<p style="font-weight: 400;">Conaway, a doctor who chairs the Assembly&#8217;s health committee, said he remains committed to the bill and said it could see traction this fall.</p>
+<p style="font-weight: 400;">“We in health care are taught to trust our patients and their judgment and offer to them the best advice that we can under the circumstances before us,” he said. “The decision should always rest with the patient.”</p>
+<figure id="attachment_11048" class="wp-caption aligncenter" style="max-width:100%;width:2560px;"><a href="https://newjerseymonitor.com/2024/01/11/supporters-vow-to-revive-some-of-the-10k-bills-now-dead-in-trenton/conaway/" rel="attachment wp-att-11048"><img decoding="async" loading="lazy" class="wp-image-11048 size-full" src="https://newjerseymonitor.com/wp-content/uploads/2023/12/Conaway-scaled.jpg" alt="" width="2560" height="1707" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/12/Conaway-scaled.jpg 2560w, https://newjerseymonitor.com/wp-content/uploads/2023/12/Conaway-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/12/Conaway-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/12/Conaway-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2023/12/Conaway-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2023/12/Conaway-2048x1365.jpg 2048w" sizes="(max-width: 2560px) 100vw, 2560px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Assemblyman Herb Conaway (D-Burlington) (Hal Brown for New Jersey Monitor)</em></p></figure>
+<p style="font-weight: 400;">    <h4 class="editorialSubhed">Residency requirement</h4>
+
+	
+<p>Last August, two terminally ill women from neighboring states filed a <a href="https://newjerseymonitor.com/wp-content/uploads/2024/08/Aid-in-dying-complaint.pdf">federal lawsuit</a> looking to end New Jersey&#8217;s residency requirement for aid-in-dying.</p>
+<p>Plaintiffs Judith Govatos, a Wilmington, Delaware, resident with stage-4 lymphoma, and Andy Sealy, a Philadelphia resident with metastatic breast cancer, wanted to apply for life-ending medication under New Jersey&#8217;s law but couldn&#8217;t because of the residency requirement, according to the complaint.</p>
+<p>Sealy, 44, <a href="https://www.inquirer.com/obituaries/andy-sealy-obituary-breast-cancer-philadelphia-sharon-hill-20240808.html" target="_blank">died</a> earlier this month at her home, seven years after her cancer diagnosis.</p>
+<p>Pasik, founder of New Jersey Death with Dignity, and Dr. Paul Bryman, a geriatrician and medical director of a Camden County hospice, joined as plaintiffs, saying the requirement prevents them from treating out-of-state patients because of potential criminal or civil liability.</p>
+<p>Attorney General Matt Platkin <a href="https://newjerseymonitor.com/wp-content/uploads/2024/08/1-31-24-aid-in-dying-motion-to-dismiss.pdf">asked</a> a judge in January to dismiss the case. There has been no ruling on that motion.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>What are your fair housing rights in New Jersey?</title>
+		<link>https://newjerseymonitor.com/2024/08/28/what-are-your-fair-housing-rights-in-new-jersey/</link>
+		
+		<dc:creator><![CDATA[Joseph Batista]]></dc:creator>
+		<pubDate>Wed, 28 Aug 2024 10:51:16 +0000</pubDate>
+				<category><![CDATA[Commentary]]></category>
+		<category><![CDATA[Housing]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14485</guid>
+
+					<description><![CDATA[New Jersey law provides our state residents with even more protections than federal law, but many New Jerseyans may be unaware of this.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="676" src="https://newjerseymonitor.com/wp-content/uploads/2023/02/IMG_1166_1-1024x676.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/02/IMG_1166_1-1024x676.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/02/IMG_1166_1-300x198.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/02/IMG_1166_1-768x507.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2023/02/IMG_1166_1-1536x1014.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2023/02/IMG_1166_1-2048x1352.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">New Jersey law provides our state residents with even more protections than federal law, but many New Jerseyans may be unaware of this. (Dana DiFilippo | New Jersey Monitor)</p><p><span data-preserver-spaces="true">Housing discrimination is an unfortunate reality in New Jersey.</span></p>
+<p><span data-preserver-spaces="true">Thankfully, federal law protects anyone treated differently by a housing provider, realtors, and landlords because of their race, color, familial status —meaning​ pregnancy or children under the age of 18 — disability, national origin, religion, or sex.</span></p>
+<p><span data-preserver-spaces="true">New Jersey law </span><span data-preserver-spaces="true">provides our state residents with</span><span data-preserver-spaces="true"> even more protections, but many New Jerseyans may be </span><span data-preserver-spaces="true">unaware</span><span data-preserver-spaces="true"> of this.</span> <span data-preserver-spaces="true">People </span><span data-preserver-spaces="true">who have</span><span data-preserver-spaces="true"> criminal records or court involvements, and </span><span data-preserver-spaces="true">people</span><span data-preserver-spaces="true"> who receive government assistance for housing, are often discriminated against but have additional protections under New Jersey law.</span></p>
+<p><span data-preserver-spaces="true">    <h4 class="editorialSubhed">Fair Chance</h4>
+
+	</span></p>
+<p><span data-preserver-spaces="true">New Jersey’s landmark Fair Chance in Housing Act, which was signed into law in 2021, bars housing providers from asking applicants about their criminal history on housing applications in most instances. It is the first state law in the country to do so.</span></p>
+<p><span data-preserver-spaces="true">Housing providers can’t ask about criminal history on applications or during interviews, and they can’t advertise their housing as available only to those without criminal histories. The Fair Chance in Housing Act also prohibits housing providers from requiring drug and alcohol testing as part of the application process.</span></p>
+<p><span data-preserver-spaces="true">There are two exceptions to the criminal history rule. Housing providers can ask if an applicant has ever </span><span data-preserver-spaces="true">been convicted</span><span data-preserver-spaces="true">of drug-related criminal activity for the manufacture or production of methamphetamine on the premises of federally assisted housing. They </span><span data-preserver-spaces="true">can also ask if an applicant has any conviction that requires them to register as a sex offender for life.</span></p>
+<p><span data-preserver-spaces="true">    <h4 class="editorialSubhed">New Jersey’s Law Against Discrimination</h4>
+
+	</span></p>
+<p><span data-preserver-spaces="true">As someone who works for a U.S. Department of Housing and Urban Development-designated fair housing investigation agency, I help provide fair housing counseling for people who have faced housing discrimination. One of the most common incidents involves people applying for housing in New Jersey who are told this: “We can’t take anyone who gets Section 8. They’re usually trouble.”</span></p>
+<p><span data-preserver-spaces="true">Section 8 refers to the federal government&#8217;s voucher program for assisting very low-income families, </span><span data-preserver-spaces="true">the elderly</span><span data-preserver-spaces="true">, and people with disabilities to afford decent, safe, and sanitary housing in the private market. In New Jersey, housing providers are not allowed to reject applicants for this or any other lawful source of income or housing assistance.</span></p>
+<p><span data-preserver-spaces="true">New Jersey’s Law Against Discrimination, for the most part, mirrors federal housing discrimination laws. But it’s also more robust. It protects against discrimination not only for lawful sources of income but also for military status and marital status.</span></p>
+<p><a class="editor-rtfLink" href="https://www.njoag.gov/about/divisions-and-offices/division-on-civil-rights-home/fcha/" target="_blank" rel="noopener"><span data-preserver-spaces="true">Click here to learn more about the Fair Chance in Housing Act</span></a><span data-preserver-spaces="true"> and </span><a class="editor-rtfLink" href="https://www.njoag.gov/about/divisions-and-offices/division-on-civil-rights-home/know-the-law/" target="_blank" rel="noopener"><span data-preserver-spaces="true">click here to learn more about the New Jersey Law Against Discrimination.</span></a></p>
+<p><span data-preserver-spaces="true">To contact New Jersey Citizen Action about fair housing issues and discrimination, call us at 732-246-4772 Ext. 115 or email us at </span><a class="editor-rtfLink" href="mailto:fhintake@njcitizenaction.org" target="_blank" rel="noopener"><span data-preserver-spaces="true">fhintake@njcitizenaction.org</span></a><span data-preserver-spaces="true">.</span></p>
+<p><span data-preserver-spaces="true">To find other HUD-designated fair housing investigation agencies and learn more about fair housing in general, visit </span><a class="editor-rtfLink" href="http://www.hud.gov/fairhousing" target="_blank" rel="noopener"><span data-preserver-spaces="true">www.hud.gov/fairhousing</span></a><span data-preserver-spaces="true">.</span></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Special Counsel Smith files new indictment in Trump’s Jan. 6 case</title>
+		<link>https://newjerseymonitor.com/2024/08/27/special-counsel-smith-files-new-indictment-in-trumps-jan-6-case/</link>
+		
+		<dc:creator><![CDATA[Ashley Murray]]></dc:creator>
+		<pubDate>Wed, 28 Aug 2024 00:49:14 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Donald Trump]]></category>
+		<category><![CDATA[Jack Smith]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14492</guid>
+
+					<description><![CDATA[The new indictment comes after the Supreme Court ruled on July 1 that presidents enjoy criminal immunity for their official “core constitutional” duties while in office.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1586095415-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1586095415-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1586095415-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1586095415-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1586095415-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1586095415-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">WASHINGTON, DC - AUGUST 01:  Special Counsel Jack Smith delivers remarks on a recently unsealed indictment including four felony counts against former U.S. President Donald Trump at the Justice Department on August 1, 2023 in Washington, DC. Trump was indicted on four felony counts for his alleged efforts to overturn the 2020 election. (Photo by Alex Wong/Getty Images)</p><p>WASHINGTON — Adjusting for the U.S. Supreme Court’s sweeping presidential immunity decision last month, U.S. Special Counsel Jack Smith on Tuesday filed a fresh federal indictment alleging former President Donald Trump attempted to overturn the 2020 election in his favor.</p>
+<p>In a <a href="https://www.courtlistener.com/docket/67656595/226/united-states-v-trump/" target="_blank">superseding indictment</a> filed in the late afternoon, Smith emphasized the private nature of Trump and his co-conspirators’ alleged conduct and omitted allegations that Trump pressured Department of Justice officials to overturn election results.</p>
+<p>The new indictment, which will replace the original August 2023 document, comes after the Supreme Court <a href="https://www.newsfromthestates.com/article/presidential-immunity-covers-some-official-acts-supreme-court-rules-trump-case" target="_blank">ruled on July 1</a> that presidents enjoy criminal immunity for their official “core constitutional” duties while in office, but are not immune for unofficial acts.</p>
+<p>The justices returned the case to the federal trial court level following the ruling.</p>
+<p>Earlier this month, U.S. District Judge Tanya Chutkan <a href="https://www.newsfromthestates.com/article/added-delays-store-trump-2020-election-interference-case%C2%A0" target="_blank">granted</a> Smith’s request for more time to assess how the immunity ruling could impact the election subversion case against Trump. The parties are set to meet in court for a pre-trial hearing on Sept. 5.</p>
+<p>In his superseding document, Smith left out a substantial section from the <a href="https://www.courtlistener.com/docket/67656595/1/united-states-v-trump/" target="_blank">original indictment</a> that detailed Trump’s conversations with former Department of Justice officials about his alleged scheme to overturn the 2020 presidential election results. Trump’s pressure campaign on the department allegedly included urging officials to send letters to state election officials falsely claiming investigations into election results, according to the original indictment.</p>
+<p>Smith also focuses attention in the superseding indictment to Trump’s lack of a formal role in the states’ certification of election results.</p>
+<p>“The defendant had no official responsibilities related to any state’s certification of the election results,” Smith wrote in the revised indictment.</p>
+<p>He later added, “The defendant had no official responsibilities related to the convening of legitimate electors or their signing and mailing of their certificates of vote.”</p>
+<p>Core to the charges against Trump are his alleged conspiracies with private attorneys and state election officials to produce and deliver false slates of electors to Vice President Mike Pence and Congress for final certification on Jan. 6, 2021. Those states included Arizona, Georgia, Michigan, Nevada, New Mexico, Pennsylvania and Wisconsin.</p>
+<p>Both the former and superseding indictments allege Trump repeated false claims about election results on his Twitter account leading up to and on Jan. 6, 2021.</p>
+<p>However, the fresh indictment states that while Trump “sometimes used his Twitter account to communicate with the public, as President, about official actions and policies, he also regularly used it for personal purposes — including to spread knowingly false claims of election fraud, exhort his supporters to travel to Washington, D.C., on January 6 [and] pressure the Vice President to misuse his ceremonial role in the certification proceeding [.]”</p>
+<p>Smith also wrote in the superseding indictment that Trump’s remarks to supporters on Jan. 6, 2021, at the Ellipse — the park between the White House and Washington Monument — amounted to a “campaign speech at a privately-funded, privately-organized political rally held on the Ellipse.”</p>
+<p>The felony criminal charges against Trump remain unchanged in the new indictment.</p>
+<p>Trump is accused of conspiracy to defraud the United States; conspiracy to obstruct an official proceeding; obstruction of, and attempt to obstruct, an official proceeding; and conspiracy against rights.</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>DOJ looks to revive classified documents case against Trump, argues judge’s dismissal was ‘flawed’</title>
+		<link>https://newjerseymonitor.com/2024/08/27/doj-looks-to-revive-classified-documents-case-against-trump-argues-judges-dismissal-was-flawed/</link>
+		
+		<dc:creator><![CDATA[Ashley Murray]]></dc:creator>
+		<pubDate>Tue, 27 Aug 2024 22:49:26 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Donald Trump]]></category>
+		<category><![CDATA[Jack Smith]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14490</guid>
+
+					<description><![CDATA[The appeals process could take months, likely closing the door on any movement in the classified documents case against Trump before November’s election.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1570156607-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1570156607-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1570156607-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1570156607-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1570156607-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1570156607-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">WASHINGTON, DC - AUGUST 01: Special Counsel Jack Smith arrives to remarks on a recently unsealed indictment including four felony counts against former U.S. President Donald Trump on August 1, 2023 in Washington, DC. Trump was indicted on four felony counts for his alleged efforts to overturn the 2020 election. (Photo by Drew Angerer/Getty Images)</p><p>WASHINGTON — U.S. Special Counsel Jack Smith has asked a federal appeals court to reverse the dismissal of a case alleging former President Donald Trump mishandled classified documents at his Florida home after he left the Oval Office.</p>
+<p>The appeals process could take months, likely closing the door on any movement in the classified documents case against Trump, the 2024 Republican presidential nominee, before November’s election.</p>
+<p>Smith argued late Monday that U.S. District Judge Aileen Cannon’s decision to toss the case was based on a “flawed” argument that Smith was illegally appointed to the office of special counsel.</p>
+<p>Over an 81-page <a href="https://www.courtlistener.com/docket/68955302/18/united-states-v-donald-trump/" target="_blank">brief</a> filed in the U.S. Court of Appeals for the Eleventh Circuit, Smith cited statutes and a Watergate-era Supreme Court decision to argue the time-tested legality of U.S. attorneys general to appoint and fund independent, or special, counsels.</p>
+<p>“In ruling otherwise, the district court deviated from binding Supreme Court precedent, misconstrued the statutes that authorized the Special Counsel’s appointment, and took inadequate account of the longstanding history of Attorney General appointments of special counsels,” Smith wrote.</p>
+<p>Further, he warned, “[t]he district court’s rationale could jeopardize the longstanding operation of the Justice Department and call into question hundreds of appointments throughout the Executive Branch.”</p>
+<p>Cannon, a federal judge for the Southern District of Florida, <a href="https://www.newsfromthestates.com/article/federal-judge-dismisses-trump-classified-documents-criminal-case" target="_blank">dismissed the classified documents case</a> against Trump on July 15 — two days after Trump <a href="https://penncapital-star.com/campaigns-elections/trump-campaigns-in-western-pennsylvania-with-rally-in-butler-county/" target="_blank">was injured</a> in an attempted assassination in Pennsylvania and just as the Republican National Convention <a href="https://www.newsfromthestates.com/article/gop-convention-go-planned-milwaukee-trump-attendance" target="_blank">kicked off</a> in Wisconsin.</p>
+<p>Cannon is a Trump appointee who was nominated in 2020 and <a href="https://www.senate.gov/legislative/LIS/roll_call_votes/vote1162/vote_116_2_00228.htm" target="_blank">confirmed</a> by the U.S. Senate later that year.</p>
+<p>Trump had argued for the case’s dismissal in February.</p>
+<p>Days before he was set to officially accept the party’s nomination for president, Trump hailed Cannon’s dismissal as a way to unite the nation following the attempt on his life in Butler, Pennsylvania.</p>
+<p>Cannon argued Smith’s appointment violated two clauses of the U.S. Constitution that govern how presidential administrations and Congress appoint and approve “Officers of the United States,” and how taxpayer money can be used to pay their salaries and other expenses.</p>
+<p>Smith appealed her decision just days later.</p>
+    <h4 class="editorialSubhed">Historic classified documents case</h4>
+
+	
+<p>Smith’s historic case against Trump marked the first time a former U.S. president faced federal criminal charges.</p>
+<p>A grand jury handed up a 37-count indictment in June 2023 charging the former president, along with his aide Walt Nauta, with felonies related to mishandling classified documents after Trump’s term in office, including storing them at his Florida Mar-a-Lago estate. A <a href="https://www.justice.gov/storage/US-v-Trump-Nauta-De-Oliveira-23-80101.pdf" target="_blank">superseding indictment</a> that added charges and another co-defendant was handed up a little over a month later.</p>
+<p>The classified documents case is just one of several legal entanglements for Trump, who became a <a href="https://www.newsfromthestates.com/article/trump-found-guilty-34-felony-counts-ny-hush-money-trial-10" target="_blank">convicted felon</a> in New York state court in May.</p>
+<p>The former president also continues to face federal criminal charges for <a href="https://www.newsfromthestates.com/article/fueled-lies-trump-charged-seeking-overturn-2020-election-6" target="_blank">allegedly conspiring</a> to overturn the 2020 presidential election results. That case has also been in a holding pattern for several months as Trump appealed all the way to the U.S. Supreme Court, arguing that the charges should be dropped based on presidential criminal immunity.</p>
+<p>The Supreme Court ruled in early July that the former presidents enjoy immunity for official “core Constitutional” acts and returned the case to the federal trial court in Washington, D.C.</p>
+<p>Smith has until the end of August to assess how the immunity decision affects the election subversion case against Trump. A pre-trial hearing is scheduled for Sept. 5.</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Funeral Mass for late Rep. Bill Pascrell set for Wednesday</title>
+		<link>https://newjerseymonitor.com/briefs/funeral-mass-for-late-rep-bill-pascrell-set-for-wednesday/</link>
+		
+		<dc:creator><![CDATA[Sophie Nieto-Munoz]]></dc:creator>
+		<pubDate>Tue, 27 Aug 2024 21:06:19 +0000</pubDate>
+				<category><![CDATA[Politics]]></category>
+		<category><![CDATA[bill pascrell]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14487</guid>
+
+					<description><![CDATA[Pascrell, who lived in Paterson his entire life, died Aug. 21 after a prolonged hospitalization for a respiratory infection.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2022/01/DPR-Gun-Violence-012722-029-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2022/01/DPR-Gun-Violence-012722-029-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2022/01/DPR-Gun-Violence-012722-029-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2022/01/DPR-Gun-Violence-012722-029-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2022/01/DPR-Gun-Violence-012722-029.jpg 1200w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">The late Rep. Bill Pascrell Jr. died Aug. 21 after a prolonged stay in a Paterson hospital. (Danielle Richards for New Jersey Monitor)</p><p><span data-preserver-spaces="true">The funeral for Rep. Bill Pascrell Jr., </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/08/21/rep-bill-pascrell-dies-after-prolonged-hospital-stays/" target="_blank" rel="noopener"><span data-preserver-spaces="true">the fiery Passaic County Democrat</span></a><span data-preserver-spaces="true"> who served in Congress for more than two decades, will be held Wednesday at the Cathedral of St. John the Baptist in Paterson.</span></p>
+<p><span data-preserver-spaces="true">Pascrell, who lived in Paterson his entire life, died Aug. 21 after a prolonged hospitalization for a respiratory infection. He was 87. </span></p>
+<p><span data-preserver-spaces="true">The funeral Mass will begin at 11 a.m. at the Cathedral, and will be followed by interment at the Holy Sepulchre Cemetery in Totowa. </span></p>
+<p><span data-preserver-spaces="true">Pascrell, who was one of the oldest members of Congress, was a public school teacher first elected to the state Legislature in 1987. He was elected as mayor of Paterson in 1990 — his family called it his &#8220;dream job&#8221; — and moved on to Congress seven years later. </span></p>
+<p><span data-preserver-spaces="true">Pascrell may have dined with presidents and befriended prime ministers, but he was happiest in North Jersey, where he lived for his entire life, his family said in an obituary. </span></p>
+<p><span data-preserver-spaces="true">Shortly after his family announced Pascrell’s death </span><a class="editor-rtfLink" href="https://x.com/BillPascrell/status/1826284560499261692" target="_blank" rel="noopener"><span data-preserver-spaces="true">on social media</span></a><span data-preserver-spaces="true">, he was fondly remembered by leaders and politicians from both sides of the aisle. Gov. Phil Murphy said Pascrell was a “lifelong champion for our most vulnerable neighbors.” </span></p>
+<p><span data-preserver-spaces="true">He is survived by his wife, Elsie, three children, and five grandchildren.</span></p>
+<p><span data-preserver-spaces="true">In lieu of flowers, the family asks donations be made to the </span><a class="editor-rtfLink" href="https://www.bianj.org/" target="_blank" rel="noopener"><span data-preserver-spaces="true">Brain Injury Alliance of New  Jersey</span></a><span data-preserver-spaces="true">, </span><a class="editor-rtfLink" href="https://www.evasvillage.org/" target="_blank" rel="noopener"><span data-preserver-spaces="true">Eva’s Village in Paterson</span></a><span data-preserver-spaces="true">, or the </span><a class="editor-rtfLink" href="https://kesslerfoundation.org/about-us?gad_source=1&amp;gclid=CjwKCAjw8rW2BhAgEiwAoRO5rHXi9PrdHKzFDOXVBh5h6-SVPQuR35B0wyPosin0HL4wE4lu5ZsEjRoCmiUQAvD_BwE" target="_blank" rel="noopener"><span data-preserver-spaces="true">Kessler Foundation</span></a><span data-preserver-spaces="true">. </span></p>
+<p><span data-preserver-spaces="true">Pascrell&#8217;s death leaves a vacancy on the ballot in the 9th Congressional District, where he was seeking reelection in November. Democrats from the district are scheduled to gather on Thursday to </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/briefs/state-sen-pou-gets-key-backing-to-replace-late-rep-pascrell-on-november-ballot/" target="_blank" rel="noopener"><span data-preserver-spaces="true">choose who will replace him on the ballot</span></a><span data-preserver-spaces="true">.</span></p>
+<p><span data-preserver-spaces="true">    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	</span></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Federal judge pauses programs that grants protections for undocumented spouses</title>
+		<link>https://newjerseymonitor.com/2024/08/27/federal-judge-pauses-programs-that-grants-protections-for-undocumented-spouses/</link>
+		
+		<dc:creator><![CDATA[Ariana Figueroa]]></dc:creator>
+		<pubDate>Tue, 27 Aug 2024 14:32:43 +0000</pubDate>
+				<category><![CDATA[Civil Rights + Immigration]]></category>
+		<category><![CDATA[DC Bureau]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14479</guid>
+
+					<description><![CDATA[The ruling is an administrative stay, meaning no applications to the program can be processed while the case is ongoing.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/immigration-families-2048x1365-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/immigration-families-2048x1365-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/immigration-families-2048x1365-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/immigration-families-2048x1365-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/immigration-families-2048x1365-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/immigration-families-2048x1365-1.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">A federal judge has temporarily blocked a Biden administration plan to give deportation protection to undocumented people married to U.S. citizens for at least 10 years. (File photo of a 2018 protest against the Trump administration’s immigration policies. By David McNew/Getty Images)</p><p>WASHINGTON — A Texas federal judge late Monday sided with 16-Republican led states to temporarily block a Biden administration program that grants deportation protections for undocumented spouses of U.S. citizens and a potential pathway to citizenship.</p>
+<p>The ruling by Judge J. Campbell Barker of the U.S. District Court for the Eastern District of Texas, is <a href="https://storage.courtlistener.com/recap/gov.uscourts.txed.232527/gov.uscourts.txed.232527.27.0_1.pdf" target="_blank">an administrative stay</a>, meaning no applications can be processed while the case is ongoing. The Department of Homeland Security began accepting applications last week.</p>
+<p>“The claims are substantial and warrant closer consideration than the court has been able to afford to date,” Barker, who former president Donald Trump appointed, wrote in his order.</p>
+<p>A DHS spokesperson said the agency will defend the program, known as Keeping Families Together, in court.</p>
+<p>“Keeping Families Together enables U.S. citizens and their family members to live without fear of separation, consistent with fundamental American values,” a DHS spokesperson said. “The Department of Homeland Security will comply with the court’s decision, including continuing to accept applications, while we defend Keeping Families Together in court.”</p>
+<p>DHS is still allowed to collect applications for the program, but not allowed to approve them, according to the order from Barker. <a href="https://www.uscis.gov/i-131f" target="_blank">Applications that have already been processed</a> and a parole in place granted, are not impacted by the current stay.</p>
+<p>The states, <a href="https://www.newsfromthestates.com/article/gop-states-aim-halt-biden-program-protecting-undocumented-spouses-deportation" target="_blank">which filed the suit last week</a>, are Alabama, Arkansas, Florida, Georgia, Idaho, Iowa, Kansas, Louisiana, Missouri, North Dakota, Ohio, South Carolina, South Dakota, Tennessee, Texas and Wyoming.</p>
+<p>They are being represented by America First Legal, an organization established by former Trump adviser Stephen Miller — the architect of Trump’s hard-line immigration policies.</p>
+<p>Those states argue that the Biden administration overreached its authority in creating the program and they argue the program would financially harm them if that group of undocumented people — roughly 500,000 — are allowed to remain in the country.</p>
+<p>In his order, Barker set a court timeline that could deliver a decision by mid-October, right before the presidential election. Both sides have until Oct. 10 to submit their briefs.</p>
+<p>“The court does not, however, express any ultimate conclusions about the success or likely success of those claims,” Barker wrote. “As with most administrative stays, the court has simply undertaken a screening, ‘first-blush’ review of the claims and what is at stake in the dispute.”</p>
+<p>President Joe Biden <a href="https://newjerseymonitor.com/2024/06/18/biden-to-unveil-protections-for-some-undocumented-spouses-easier-daca-work-visas/">in June unveiled the program</a>, which is a one-time action that applies to long-term undocumented people married to U.S. citizens for 10 years as of June 17 this year. It also applies to their children. It’s expected to roughly include 50,000 children who are undocumented but have an immigrant parent married to a U.S. citizen.</p>
+<p>The program allows for those undocumented spouses and their children to apply for a green card under certain requirements, which DHS will review on a case-by-case basis.</p>
+<p>Under current U.S. immigration law, if a noncitizen enters the country without authorization, they are ineligible for permanent legal status and would need to leave the U.S. and then reenter through a green card application by their U.S. spouse. It’s a lengthy process that can take years.</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Rate hikes loom for public health plan premiums</title>
+		<link>https://newjerseymonitor.com/2024/08/27/rate-hikes-loom-for-public-health-plan-premiums/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Tue, 27 Aug 2024 10:58:44 +0000</pubDate>
+				<category><![CDATA[Gov + Legislature]]></category>
+		<category><![CDATA[Health]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14472</guid>
+
+					<description><![CDATA[Local officials say the proposed rate hikes could push towns and counties off state-run health plans, risking yet higher increases.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="675" src="https://newjerseymonitor.com/wp-content/uploads/2023/06/Trenton-Statehouse-1024x675.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/06/Trenton-Statehouse-1024x675.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/06/Trenton-Statehouse-300x198.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/06/Trenton-Statehouse-768x506.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2023/06/Trenton-Statehouse-1536x1013.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2023/06/Trenton-Statehouse-2048x1351.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Local officials say the proposed rate hikes could push towns and counties off state-run health plans, risking yet higher increases. (Dana DiFilippo | New Jersey Monitor)</p><p><span data-preserver-spaces="true">A set of looming double-digit rate hikes proposed for New Jersey’s state-run health plans risks redoubling municipal flight toward other options and pushing rates up yet further. </span></p>
+<p><span data-preserver-spaces="true">State actuaries in July recommended increasing health premiums by an average of 17% for local government workers and retirees and by 11% for their counterparts at the state level. Premiums under the School Employee Health Benefits Program should increase by 14% on average, they said.</span></p>
+<p><span data-preserver-spaces="true">The hikes, compounded with rate hikes of more than 20% in 2022 and more moderate ones last year, have worried local officials who fear the increased costs will further strain already tight municipal budgets.</span></p>
+<p><span data-preserver-spaces="true">“The state health benefit plans are seeing double-digit increases while health insurance funds which some of our towns are in &#8230; are only seeing like 8%, 9% increases, so what&#8217;s the difference? What&#8217;s the driving factor?” said Lori Buckelew, assistant executive director at the New Jersey League of Municipalities.</span></p>
+<p><span data-preserver-spaces="true">Local government enrollments for active employees in the State Health Benefits Program declined by roughly 18% in the two years after the <a href="https://newjerseymonitor.com/2022/09/14/double-digit-hike-in-insurance-premiums-approved-for-government-workers/" target="_blank" rel="noopener">double-digit rate increases in 2022</a>, with similar drops for plan retirees, according to actuarial reports.</span></p>
+<p><span data-preserver-spaces="true"><a href="https://newjerseymonitor.com/2022/10/10/counties-towns-weigh-withdrawal-from-state-health-plan/" target="_blank" rel="noopener">More towns may leave</a> if faced with another round of rate shock.</span></p>
+<p><span data-preserver-spaces="true">“We have members that are absolutely looking to see what other plans are out there and to see how they can control the cost,” Buckelew said.</span></p>
+<p><span data-preserver-spaces="true">Maggie Garbarino, a spokesperson for Gov. Phil Murphy, said his administration is “always concerned about increased costs and what they mean for families across New Jersey.”</span></p>
+<p><span data-preserver-spaces="true">“The Governor remains committed to working with partners in government and labor to make meaningful progress in delivering affordable health care to the State’s public workforce,” Garbarino said.</span></p>
+<p><span data-preserver-spaces="true">Towns and counties regularly move off and onto state health plans, but a large-scale exodus could lock the state plans in a vicious cycle where high rates lead to a smaller subscriber pool, which leads to yet higher rates.</span></p>
+<p><span data-preserver-spaces="true">Some small municipalities with too few workers to self-insure and no access to cooperative health insurance procurement could have no choice but to remain on state plans even as costs rise, Buckelew said.</span></p>
+<p><span data-preserver-spaces="true">Enrollment among other sectors of public workers has proven more resilient. Policy changes that in 2021 began basing school employees’ insurance obligations off their compensation instead of a portion of premiums have insulated those workers from the direst effects of the steep swings, but those increases still drive up costs for school districts.</span></p>
+<p><span data-preserver-spaces="true">Active employee enrollment in the School Employee Health Benefits Program fell by just under 3% over the two-year period. State units cannot move to other health benefit providers, and enrollment under state plans has remained largely static despite the cost increases.</span></p>
+<p><span data-preserver-spaces="true">Commissions charged with setting rates for the public health plans were due to approve the premium increases in late July but scrubbed those meetings to allow a separate committee</span><strong><span data-preserver-spaces="true"> </span></strong><span data-preserver-spaces="true">to approve a pilot program that would allow public workers to seek certain procedures at select well-performing hospitals without copayments.</span><strong><span data-preserver-spaces="true"> </span></strong></p>
+<p><span data-preserver-spaces="true">The effect the pilot program and other plan design changes, including reduced specialist copays, will have on premiums remains unclear.</span></p>
+<p><span data-preserver-spaces="true">“We&#8217;re optimistic that it&#8217;ll be a reduction of the increase, but will it be a significant reduction of the increase? That&#8217;s the unknown,” said Buckelew.</span></p>
+<p><span data-preserver-spaces="true">Also unclear is whether the commissions intend to approve the rate hikes at their regular September meetings or whether they’ll convene for the vote outside of their normal schedule.</span></p>
+<p><span data-preserver-spaces="true">The state intends to begin open enrollment for the public health plans on Oct. 1, and a spokesperson for the Treasury warned that delaying rate-setting would leave officials less time to coordinate with vendors and other tasks to ensure a smooth transition to a new plan year.</span></p>
+<p><span data-preserver-spaces="true">“In the past, when rates have been approved later </span><span data-preserver-spaces="true">and</span><span data-preserver-spaces="true"> there has been less time to prepare for the October 1 open enrollment, there were numerous issues during the open enrollment process that negatively impacted members,” said Danielle Currie, a Treasury spokesperson.</span></p>
+<p><span data-preserver-spaces="true">Delaying the open enrollment period would also create problems, she said, because officials must complete their work before the new plan year begins on Jan. 1.</span></p>
+<p><span data-preserver-spaces="true"> </span>    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Family of man who overdosed in N.J. prison alleges &#8216;pervasive&#8217; drug smuggling behind bars</title>
+		<link>https://newjerseymonitor.com/2024/08/26/family-of-man-who-overdosed-in-n-j-prison-alleges-pervasive-drug-smuggling-behind-bars/</link>
+		
+		<dc:creator><![CDATA[Dana DiFilippo]]></dc:creator>
+		<pubDate>Mon, 26 Aug 2024 19:53:15 +0000</pubDate>
+				<category><![CDATA[Civil Rights + Immigration]]></category>
+		<category><![CDATA[Criminal Justice]]></category>
+		<category><![CDATA[Health]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14467</guid>
+
+					<description><![CDATA[A new lawsuit claims state officials don't do enough to keep drugs out of prisons, leading to drug use and overdose deaths behind bars.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="668" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_3609-1024x668.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_3609-1024x668.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_3609-300x196.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_3609-768x501.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_3609-1536x1003.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_3609-2048x1337.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Relatives of a Howell man who overdosed on drugs in state prison say officials should have monitored him because his struggle with addiction was well-known. They're now suing. (Photo by New Jersey Monitor)</p><p style="font-weight: 400;">The family of a man who fatally overdosed in East Jersey State Prison has sued the state for wrongful death, saying officials “routinely turn a blind eye” to drug smuggling behind bars and thereby create dangerous living conditions for people who struggle with addiction.</p>
+<p style="font-weight: 400;">Michael Cassella, 40, of Howell, died of acute fentanyl toxicity on Aug. 18, 2022, at the state prison in Rahway, according to <a href="https://newjerseymonitor.com/wp-content/uploads/2024/08/Michael-Cassella-DOC-lawsuit.pdf" target="_blank" rel="noopener">a lawsuit</a> filed last week in state Superior Court in Union County.</p>
+<p style="font-weight: 400;">Cassella had a history of drug addiction and should have been monitored accordingly, attorney Brooke M. Barnett wrote in the complaint.</p>
+<p style="font-weight: 400;">Despite the state Department of Corrections’ zero-tolerance policy for the possession, sale, or use of drugs and alcohol, East Jersey State Prison tolerates “a pervasive and systemic pattern and practice” of substance smuggling by correctional officers and incarcerated people, as well as grossly inadequate medical treatment provided by deliberately indifferent staff, Barnett wrote.</p>
+<p style="font-weight: 400;">Cassella was dead for “awhile” by the time an officer found him unresponsive in his cell, she added. His aunt called the prison several times about him when he failed to contact her, but prison officials didn’t notify her of his death until days afterward, the lawsuit says.</p>
+
+<div class=" newsroomBlockQuoteContainer  ">
+	<div class="newsroomBlockQuoteSVGContainer">
+		<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12.81 9">
+			<g>
+				<path d="M2.7,0A3,3,0,0,0,.7.8,2.64,2.64,0,0,0,0,2.7,2.14,2.14,0,0,0,.8,4.4a2.84,2.84,0,0,0,1.7.7,1.45,1.45,0,0,0,.7-.2,1.45,1.45,0,0,1,.7-.2q.3,0,.3.6A3.47,3.47,0,0,1,3,7.6a4.21,4.21,0,0,1-2.6,1V9a5.51,5.51,0,0,0,4-1.6A5.06,5.06,0,0,0,6,3.7a3.92,3.92,0,0,0-.9-2.6A3.19,3.19,0,0,0,2.7,0Z"/>
+				<path d="M11.8,1.1A2.84,2.84,0,0,0,9.5,0a2.79,2.79,0,0,0-2,.8,2.64,2.64,0,0,0-.7,1.9,2.06,2.06,0,0,0,.7,1.7,2.41,2.41,0,0,0,1.8.7,1.85,1.85,0,0,0,.7-.2,1.45,1.45,0,0,1,.7-.2q.3,0,.3.6A2.94,2.94,0,0,1,9.8,7.6a4.21,4.21,0,0,1-2.6,1V9a5.51,5.51,0,0,0,4-1.6,4.6,4.6,0,0,0,1.6-3.8A3.47,3.47,0,0,0,11.8,1.1Z"/>
+			</g>
+		</svg>
+	</div>
+	<div class="newsroomBlockQuoteQuoteContainer">
+		<p class="newsroomBlockQuote ">Heroin and fentanyl are clearly infiltrating the prisons.</p>
+	</div>
+		<div class="newsroomBlockQuoteAuthorContainer">
+		<p style="font-size:13px"><b>– Attorney Brooke M. Barnett</b></p>
+	</div>
+	</div>
+
+	
+<p style="font-weight: 400;">“The serious medical needs of inmates, including Mr. Cassella, are given cursory attention, when not entirely ignored, and when acknowledged at all, treated with slipshod, hasty, inefficacious, rubber-stamp patch-jobs, designed to quiet inmate complaints, rather than treat the medical needs of human beings,” Barnett wrote.</p>
+<p style="font-weight: 400;">The complaint, filed by Cassella’s aunt, Donna McNichol of Freehold, names Department of Corrections Commissioner Victoria Kuhn as a defendant, along with the department, the prison, and unnamed correctional officers and prison medical staff.</p>
+<p style="font-weight: 400;">It accuses them of failure to protect, state-created danger, negligence, and wrongful death.</p>
+<p style="font-weight: 400;">&#8220;Heroin and fentanyl are clearly infiltrating the prisons,&#8221; Barnett told the New Jersey Monitor. &#8220;They have a duty to protect these people. I&#8217;m not saying that it&#8217;s got to be the Hilton Hotel, but you expect these correctional officers and the medical departments in there to do what they&#8217;re supposed to do. If we don&#8217;t file these lawsuits, everything stays behind the four walls and nothing will be exposed. I look forward to getting some answers.&#8221;</p>
+<p>Daniel Sperrazza, a Department of Corrections spokesman, said he could not comment on pending litigation.</p>
+<p>But he said correctional agencies nationally, including in New Jersey, have seen &#8220;a substantial increase in the prevalence and illicit use of synthetic drugs entering facilities disguised in regular mail.&#8221;</p>
+<p>&#8220;This has contributed to the rising number of assaults on staff and threatening the safety of all persons within the correctional setting,&#8221; Sperrazza said.</p>
+<p>Officials will implement mail scanning and screening technology by the end of the year with state funding provided in the 2025 budget lawmakers approved in June, Sperrazza said. The heightened postal scrutiny comes after officials <a href="https://newjerseymonitor.com/2023/04/14/new-jersey-revamps-prison-mail-delivery-to-fight-drugs/">launched</a> a pilot program last year intended to strengthen safeguards against drug smuggling by mail.</p>
+<p>&#8220;This mail scanning technology processes original documents off-site, scans them, and then distributes copies of the mail to the population to stem the flow of contraband,&#8221; Sperrazza said.</p>
+<p style="font-weight: 400;">East Jersey State Prison, which incarcerates about 1,200 men, has a history of both drug-related deaths — a Newark man incarcerated there <a href="https://www.njoag.gov/state-grand-jury-declines-to-criminally-charge-correctional-police-officers-involved-in-death-at-east-jersey-state-prison-on-february-29-2020/" target="_blank">died in 2020</a> after reacting badly to synthetic drugs in his cell — and drug smuggling by <a href="https://www.nj.com/news/2011/02/ex-teachers_assistant_is_sente.html" target="_blank">staff</a> and others, including <a href="https://www.njoag.gov/member-of-ruling-panel-of-lucchese-crime-family-sentenced-to-five-years-in-state-prison-as-a-result-of-operation-heat-probe-by-new-jersey-attorney-generals-office-targeted-multi/" target="_blank">gang members and mob bosses.</a></p>
+<p style="font-weight: 400;">Cassella was serving a 20-year prison sentence for an October 2011 car crash that killed a Mount Arlington police officer. In that incident, Cassella was under the influence of several drugs when he crossed a median on Route 80 in Roxbury Township and hit officer Joseph Wargo’s cruiser head-on. Wargo died soon after at the hospital. Cassella told a trooper at the scene he was in recovery for heroin addiction, <a href="https://law.justia.com/cases/new-jersey/appellate-division-unpublished/2014/a3908-12.html" target="_blank">court records</a> show. He <a href="https://www.nj.com/morris/2016/01/man_who_admitted_guilt_in_drug-related_fatal_crash.html" target="_blank">pleaded guilty</a> to aggravated manslaughter in 2013.</p>
+<p style="font-weight: 400;">    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+<p style="font-weight: 400;">
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>State Sen. Pou gets key backing to replace late Rep. Pascrell on November ballot</title>
+		<link>https://newjerseymonitor.com/briefs/state-sen-pou-gets-key-backing-to-replace-late-rep-pascrell-on-november-ballot/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Mon, 26 Aug 2024 17:46:15 +0000</pubDate>
+				<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Politics]]></category>
+		<category><![CDATA[Andre Sayegh]]></category>
+		<category><![CDATA[Benjie Wimberly]]></category>
+		<category><![CDATA[bill pascrell]]></category>
+		<category><![CDATA[Craig Guy]]></category>
+		<category><![CDATA[John Currie]]></category>
+		<category><![CDATA[Nellie Pou]]></category>
+		<category><![CDATA[Paul Juliano]]></category>
+		<category><![CDATA[Phil Murphy]]></category>
+		<category><![CDATA[Shavonda Sumter]]></category>
+		<category><![CDATA[Trend – Election 2024]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14469</guid>
+
+					<description><![CDATA[Sen. Nellie Pou has become the front-runner to replace the late Rep. Bill Pascrell Jr. on November's ballot in the 9th Congressional District.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/01/Pou-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/01/Pou-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/01/Pou-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/01/Pou-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/01/Pou-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/01/Pou-2048x1365.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Sen. Nellie Pou has become the front-runner to replace the late Rep. Bill Pascrell Jr. on November's ballot in the 9th Congressional District. (Hal Brown for New Jersey Monitor)</p><p><span data-preserver-spaces="true">Democratic Party leaders in each of the 9th Congressional District’s three counties endorsed state Sen. Nellie Pou (D-Passaic) to succeed <a href="https://newjerseymonitor.com/2024/08/21/rep-bill-pascrell-dies-after-prolonged-hospital-stays/" target="_blank" rel="noopener">the late Rep. Bill Pascrell Jr.</a> on </span><span data-preserver-spaces="true">the general election ballot Monday</span><span data-preserver-spaces="true">.</span></p>
+<p><span data-preserver-spaces="true">The endorsements from Passaic County Chairman John Currie, Hudson County Chairman Craig Guy, and Bergen County Chairman Paul Juliano come just days before the district’s county committee people will gather this week to select a replacement for Pascrell, who died last week after prolonged hospital stays.</span></p>
+<p><span data-preserver-spaces="true">“Senator Nellie Pou has a long and distinguished record of public service, and we believe she is the right choice to represent our diverse and vibrant district in Congress,” Currie said. “We are excited about the historic opportunity to elect the first Latina congresswoman in our state’s history.”</span></p>
+<p><span data-preserver-spaces="true">The chairs’ endorsements could make Pou, who chairs the state Senate Commerce Committee, a favorite to snag Pascrell’s place on November’s ballot.</span></p>
+<p><span data-preserver-spaces="true">Assemblywoman Shavonda Sumter (D-Passaic) and Assemblyman Benjie Wimberly (D-Passaic) — who represent Pou’s legislative district in the Assembly — are also seeking the nomination.</span></p>
+<p><span data-preserver-spaces="true">“While we have great respect for all the candidates who have shown interest in running, Senator Pou is uniquely qualified to serve the residents of the 9th District. Her experience and leadership will ensure that our community continues to thrive,” Guy said.</span></p>
+<p><span data-preserver-spaces="true">The </span><a class="editor-rtfLink" href="https://newjerseyglobe.com/campaigns/juliano-currie-and-guy-endorse-nellie-pou-for-congress/" target="_blank" rel="noopener"><span data-preserver-spaces="true">New Jersey Globe</span></a><span data-preserver-spaces="true"> first reported the chairs’ endorsements.</span></p>
+<p>Whatever Democrat ends up replacing Pascrell on the ballot will <span data-preserver-spaces="true">face Republican Billy Prempeh in this largely Democratic district.</span></p>
+<p><span data-preserver-spaces="true">New Jersey statute affords the power to fill ballot vacancies to county committee members of the party whose candidate is no longer on the ballot. In this case, county committee members from the portions of Hudson, Bergen, and Passaic counties within the 9th District will vote for Pascrell’s replacement.</span></p>
+<p><span data-preserver-spaces="true">The timing of the congressman’s death left little time for party officials to select a replacement ahead of an Aug. 29 deadline to fill vacancies on the general election ballot</span><span data-preserver-spaces="true">, and because</span><span data-preserver-spaces="true"> his death came within six months of the general election, </span><span data-preserver-spaces="true">statute</span><span data-preserver-spaces="true"> does not require Gov. Phil Murphy to call a special election to fill his seat.</span></p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>A week of free trips on NJ Transit begins Monday</title>
+		<link>https://newjerseymonitor.com/briefs/a-week-of-free-trips-on-nj-transit-begins-monday/</link>
+		
+		<dc:creator><![CDATA[Dana DiFilippo]]></dc:creator>
+		<pubDate>Mon, 26 Aug 2024 10:43:31 +0000</pubDate>
+				<category><![CDATA[Gov + Legislature]]></category>
+		<category><![CDATA[Transportation]]></category>
+		<category><![CDATA[Nancy Munoz]]></category>
+		<category><![CDATA[NJ Transit]]></category>
+		<category><![CDATA[Phil Murphy]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14454</guid>
+
+					<description><![CDATA[Commuters who use NJ Transit buses, trains, and light rail will get a week of free rides, as an apology for a summer of interrupted service.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="728" src="https://newjerseymonitor.com/wp-content/uploads/2024/06/Snapseed-41-1024x728.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/06/Snapseed-41-1024x728.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/06/Snapseed-41-300x213.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/06/Snapseed-41-768x546.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/06/Snapseed-41-1536x1092.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/06/Snapseed-41-2048x1456.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">NJ Transit and Amtrak commuters walk through Newark Penn Station. (Dana DiFilippo | New Jersey Monitor)</p><p style="font-weight: 400;">A week of free rides on New Jersey Transit’s trains and buses started Monday, a <a href="https://newjerseymonitor.com/2024/08/15/nj-transit-will-be-free-for-a-week-as-apology-for-ugly-summer-governor-says/">“fare holiday”</a> meant to appease customers enraged after a summer of service suspensions and interruptions.</p>
+<p style="font-weight: 400;">Passengers will pay nothing until Sept. 2 on trains, light rail, and buses, while monthly customers will get a 25% discount on their September passes.</p>
+<p style="font-weight: 400;">Critics have panned the fare holiday — which is expected to cost the state $19 million, roughly 2% of this year’s expected fare revenue — as a gimmick that does nothing to fix the system’s entrenched problems.</p>
+<p style="font-weight: 400;">Assemblywoman Nancy Muñoz (R-Union) said the public “should be really distressed” that the fare holiday comes on the heels of <a href="https://newjerseymonitor.com/2024/07/25/nj-transit-approves-3b-budget-amid-outcry-over-fare-hikes/">fare hikes</a> and a <a href="https://newjerseymonitor.com/2024/06/27/lawmakers-advance-new-business-surtax-aimed-at-funding-nj-transit/">new corporate tax</a> that are meant to help the underfunded transit agency dodge a projected fiscal cliff.</p>
+<p style="font-weight: 400;">“I&#8217;m aggravated by the fact that they&#8217;re going to offer a free week of free rides — which is very nice and people will appreciate it, but it&#8217;s not going to improve the service, number one. Number two, it&#8217;s the last week of August, leading into Labor Day, so many people will be on vacation, so it&#8217;s probably the fewest number of riders,” Muñoz said. “And it doesn&#8217;t fix the problem.&#8221;</p>
+<p style="font-weight: 400;">In announcing the fare holiday earlier this month, Gov. Phil Murphy said officials wanted to “end the summer on a grace note” after extreme heat and the system’s ancient infrastructure stranded thousands of rail riders periodically since June.</p>
+<p style="font-weight: 400;">The causes of the delays led to finger-pointing between NJ Transit and Amtrak, which owns the tracks and tunnels traversed by NJ Transit trains.</p>
+
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>What’s IUI? What’s IVF? A look at the fertility treatments the Walz family is talking about</title>
+		<link>https://newjerseymonitor.com/2024/08/26/whats-iui-whats-ivf-a-look-at-the-fertility-treatments-the-walz-family-is-talking-about/</link>
+		
+		<dc:creator><![CDATA[Elisha Brown]]></dc:creator>
+		<pubDate>Mon, 26 Aug 2024 10:39:22 +0000</pubDate>
+				<category><![CDATA[Health]]></category>
+		<category><![CDATA[Tim Walz]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14462</guid>
+
+					<description><![CDATA[The broader scope of fertility treatments entered the spotlight last week after Minnesota Gov. Tim Walz and his wife Gwen shared that they had children through a less commonly known procedure. Since Vice President Kamala Harris selected Gov. Walz as her running mate, he has discussed his family’s fertility journey during speeches in Pennsylvania, Nebraska [&#8230;]]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167854626-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167854626-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167854626-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167854626-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167854626-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167854626-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Vice presidential candidate Minnesota Gov. Tim Walz celebrates with his daughter Hope, son Gus and wife Gwen at Democratic National Convention on Wednesday, Aug. 21, in Chicago. The Walzes clarified last week that they didn’t use IVF but another kind of fertility treatment to grow their family. (Justin Sullivan/Getty Images)</p><p>The broader scope of fertility treatments entered the spotlight last week after Minnesota Gov. Tim Walz and his wife Gwen shared that they had children through a less commonly known procedure.</p>
+<p>Since Vice President Kamala Harris selected Gov. Walz as her running mate, he has discussed his family’s fertility journey during speeches in <a href="https://www.youtube.com/live/wP5qOjgY88M?feature=shared&amp;t=4386" target="_blank">Pennsylvania</a>, <a href="https://www.c-span.org/video/?537741-1/democratic-vice-presidential-nominee-tim-walz-campaigns-omaha-nebraska" target="_blank">Nebraska</a> and mostly recently at the Democratic National Convention in Chicago, <a href="https://www.newsfromthestates.com/article/former-high-school-football-coach-rises-running-mate-walz-accepts-vp-nomination" target="_blank">Illinois</a>.</p>
+<p>“It took Gwen and I years,” Walz <a href="https://youtu.be/Mf0u5MJEjhw?feature=shared&amp;t=468" target="_blank">said</a> on Wednesday night. “But we had access to fertility treatments. And when our daughter was born, we named her Hope.”</p>
+<p>Last week, the Walzes clarified that they conceived via intrauterine insemination, not in vitro fertilization.</p>
+<p>IUI involves injecting sperm into the uterus <a href="https://www.hopkinsmedicine.org/gynecology-obstetrics/specialty-areas/fertility-center/infertility-services/intrauterine-insemination" target="_blank">during</a> or <a href="https://www.bcm.edu/healthcare/specialties/obstetrics-and-gynecology/reproductive-endocrinology-and-infertility/intrauterine-insemination-iui" target="_blank">just before</a> ovulation to increase the chances of fertilization and pregnancy.</p>
+<p>“Our fertility journey was an incredibly personal and difficult experience. Like so many who have experienced these challenges, we kept it largely to ourselves at the time — not even sharing the details with our wonderful and close family,” Gwen Walz said in a statement provided to States Newsroom. “The only person who knew in detail what we were going through was our next door neighbor. She was a nurse and helped me with the shots I needed as part of the IUI process.”</p>
+<p>During IVF, eggs and sperm are combined in a lab and an embryo is inserted into the uterus. IVF has been drawn into national reproductive rights debates for much of this year, and Walz has been talking about it on the campaign trail while discussing his family’s fertility journey.</p>
+<p>U.S. Ohio Sen. J.D. Vance, the Republican vice presidential candidate, accused his opponent of lying about how he and his wife had children. In an Aug. 20 social media post, Vance <a href="https://x.com/JDVance/status/1825905977008533700" target="_blank">said</a>, “Today it came out that Tim Walz had lied about having a family via IVF. Who lies about something like that?” He also shared a clip of Walz talking about fertility care and families on <a href="https://x.com/KamalaHQ/status/1821904074649883007" target="_blank">Aug. 9</a>.</p>
+<p>In a statement, Harris-Walz campaign spokesperson Mia Ehrenberg said, “Governor Walz talks how normal people talk. He was using commonly understood shorthand for fertility treatments.”</p>
+<p>Experts said that patients commonly get IUI and IVF confused or refer to them interchangeably, given that in vitro fertilization is more popular.</p>
+<p>“There’s such a huge sort of alphabet soup that comes along with assisted reproduction,” said Kimberly Mutcherson, a professor at Rutgers University-Camden who specializes in reproductive justice, bioethics, and family and health law.</p>
+<p>Dr. Kelly Acharya, a fertility physician and assistant professor of obstetrics and gynecology at Duke University, said patients’ partners are more likely to mix up the two treatments or rope related procedures into IVF.</p>
+<p>“A lot of times in my line of work, I see people that are referring to other things, like egg freezing, they call that IVF, even though technically it’s not,” she said.</p>
+<p>Both Acharya and Mutcherson said the main differences between IUI and IVF are where fertilization occurs, the price and effectiveness.</p>
+<p>“Intrauterine insemination or IUI is basically less invasive. It’s typically less expensive, and it is often what is recommended as the first thing that somebody tries,” Acharya said. “When somebody has mild forms of infertility, like if there are mild differences in the semen analysis, or if somebody is young and they’re not quite sure why they’re not getting pregnant, then often a provider will recommend that they do IUI as a first step to help things along.”</p>
+<p>IUI is performed during or near ovulation, and it typically takes 10 minutes and is a minor procedure, according to Acharya. The price of IUI varies, depending on insurance coverage, from a <a href="https://www.plannedparenthood.org/learn/pregnancy/fertility-treatments/what-iui" target="_blank">few hundred dollars</a> to <a href="https://www.fertilityiq.com/fertilityiq/iui-or-artificial-insemination/the-cost-of-iui" target="_blank">several thousand dollars</a>.</p>
+<p>Mutcherson noted that some people also confuse IUI with intracervical insemination, or ICI. During this method, the sperm is inserted into the cervix — the passageway to the uterus, according to the <a href="https://carolinasfertilityinstitute.com/the-difference-between-ici-and-iui/#:~:text=Intracervical%20insemination%20is%20when%20sperm,increase%20the%20chances%20of%20conception." target="_blank">Carolina Fertility Institute</a>.</p>
+<p>Doctors often recommend ICI or IUI as a precursor to IVF, which Mutcherson said can cost $12,000 to $15,000 per cycle — or more with grading and genetic testing. During IVF, “fertilization happens outside of the body,” Acharya said.</p>
+<p>IUI, the treatment the Walz family used to have children, is not under the same scrutiny as IVF, which has faced opposition from anti-abortion hardliners. “It sometimes is listed as being less controversial than IVF, because it’s just helping along the natural process of getting the sperm inside the uterus and then expecting fertilization to happen inside the body,” Acharya said.</p>
+<p>But Mutcherson said that could also be attributed to the fact that it’s a less well-known procedure.</p>
+<p>“I think the really big issue when it comes to something like artificial insemination is that it allows people to create families that a lot of these folks — unfortunately, in the Republican Party and folks who are evangelicals — don’t approve of: families with two moms, families with two dads, single women who are having children,” she said.</p>
+<p>Price is a significant barrier to fertility care. Only 21 states require insurers to cover fertility procedures, <a href="https://stateline.org/2023/07/28/fertility-health-coverage-is-still-hard-to-come-by-in-many-states/" target="_blank">Stateline</a> reported. A successful birth via IVF can cost more than $60,000, according to a 2022 <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9351254/" target="_blank">study</a> published in Reproductive Biology and Endocrinology.</p>
+<p>“It requires a lot more physically, emotionally and economically to be able to do IVF,” Mutcherson, who conceived via IUI, said.</p>
+<p>IVF became a national reproductive rights issue in February after the Alabama Supreme Court likened frozen embryos to “unborn children” in a ruling. The plaintiffs were couples who sued for damages under an 1872 wrongful death of children law after their embryos were accidentally destroyed in a clinic four years ago, <a href="https://www.newsfromthestates.com/article/alabama-supreme-court-ruling-could-end-ivf-treatments-state" target="_blank">Alabama Reflector</a> reported. Alabama’s fertility clinics temporarily closed after the ruling until Republican Gov. Kay Ivey signed legislation in March shielding providers from criminal and civil liabilities, the <a href="https://www.newsfromthestates.com/article/alabama-passed-new-ivf-law-questions-remain" target="_blank">Reflector</a> reported.</p>
+<p>But there’s still <a href="https://www.newsfromthestates.com/article/women-undergoing-ivf-alabama-face-uncertainty-amid-legal-battle" target="_blank">uncertainty</a> over whether embryos and fetuses in the state have legal “personhood” rights. Despite the new law, two fertility clinics in Alabama announced <a href="https://www.newsfromthestates.com/article/alabama-clinic-end-ivf-services-light-litigation-concerns" target="_blank">plans to close</a> by the end of the year, though <a href="https://www.newsfromthestates.com/article/huntsville-ivf-clinic-close-january-denies-link-alabama-supreme-court-ruling" target="_blank">one denied the decision was related</a> to the  ruling.</p>
+<p>Since the Alabama ruling, polls have shown most Americans back IVF. A survey conducted by <a href="https://www.pewresearch.org/short-reads/2024/05/13/americans-overwhelmingly-say-access-to-ivf-is-a-good-thing/#:~:text=An%20April%20Pew%20Research%20Center,%2C%20while%2022%25%20are%20unsure." target="_blank">Pew</a> in April found that 70% said IVF is a good thing, while 22% said they’re not sure, and 8% said it’s a bad thing. Awareness is growing, too: <a href="https://www.pewresearch.org/short-reads/2023/09/14/a-growing-share-of-americans-say-theyve-had-fertility-treatments-or-know-someone-who-has/" target="_blank">42% of Americans said they or someone they know have had fertility treatments</a>, according to a 2023 Pew poll.</p>
+<p>Nationally, <a href="https://www.newsfromthestates.com/article/trump-comes-out-against-alabama-ivf-ruling-national-republicans-scramble-distance" target="_blank">Republicans</a> and <a href="https://www.newsfromthestates.com/article/us-senate-republicans-reject-democrats-bill-ivf-protections" target="_blank">Democrats</a> condemned the Alabama Supreme Court’s ruling and filed bills seeking to protect IVF this spring, though all of them stalled in Congress. The Republican Party’s <a href="https://www.presidency.ucsb.edu/documents/2024-republican-party-platform?emci=e10b129f-7f4f-ef11-86c3-6045bdd9e096&amp;emdi=1abd2530-f54f-ef11-86c3-6045bdee6681&amp;ceid=526826#:~:text=We%20proudly%20stand%20for%20families,pass%20Laws%20protecting%20those%20Rights." target="_blank">platform</a> featured support for both IVF and the equal protections clause of the 14th Amendment, which <a href="https://www.heritage.org/life/report/can-the-fourteenth-amendment-be-used-protect-human-life-birth?emci=e10b129f-7f4f-ef11-86c3-6045bdd9e096&amp;emdi=1abd2530-f54f-ef11-86c3-6045bdee6681&amp;ceid=526826" target="_blank">conservative legal scholars</a> argue can be used to solidify “<a href="https://www.newsfromthestates.com/article/potential-threats-ivf-push-political-novices-election-year-advocacy" target="_blank">fetal personhood</a>” along with effectively banning abortion. And in June, the <a href="https://www.newsfromthestates.com/article/republican-ivf-bill-fails-us-senate" target="_blank">Southern Baptist Convention</a> — the largest Protestant denomination in the U.S. — voted to condemn IVF, particularly the destruction or donation of embryos that are not implanted in the uterus.</p>
+<p>“People who believe that life begins at conception, people who believe that an embryo is no different than a 5-year-old sitting in a kindergarten classroom, those are people who have really deep and abiding principles related to procedures like in vitro fertilization,” Mutcherson said.</p>
+<p>The number of babies born in the U.S. using assisted reproductive technology has increased in recent years: 2.5% of newborns were conceived using fertility treatments in 2022, according to the <a href="https://www.asrm.org/news-and-events/asrm-news/press-releasesbulletins/ivf-assisted-pregnancies-constitute/#:~:text=In%202022%2C%20the%20number%20of,result%20of%20successful%20ART%20cycles" target="_blank">American Society of Reproductive Medicine</a>. That’s up from <a href="https://www.hhs.gov/about/news/2024/03/13/fact-sheet-in-vitro-fertilization-ivf-use-across-united-states.html" target="_blank">2.3% in 2021</a>, per federal data.</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Facing natural disasters, more lawmakers look to make oil companies pay for the damage</title>
+		<link>https://newjerseymonitor.com/2024/08/26/facing-natural-disasters-more-lawmakers-look-to-make-oil-companies-pay-for-the-damage/</link>
+		
+		<dc:creator><![CDATA[Alex Brown]]></dc:creator>
+		<pubDate>Mon, 26 Aug 2024 10:36:37 +0000</pubDate>
+				<category><![CDATA[Environment]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14460</guid>
+
+					<description><![CDATA[The so-called climate Superfund measures are based on the “polluter pays” concept of the 1980 federal Superfund law, which covers the cleanup of toxic waste sites.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2021/09/GettyImages-1337892663.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2021/09/GettyImages-1337892663.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2021/09/GettyImages-1337892663-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2021/09/GettyImages-1337892663-768x512.jpg 768w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Flooding in Lincoln Park in Morris County on Sept. 2, 2021, the day after the remnants of Hurricane Ida led to widespread flooding in the region. (Photo by Michael M. Santiago/Getty Images)</p><p>Vermont is the first state trying a new approach to climate policy: charging fossil fuel companies money to cover the damages caused by natural disasters worsened by climate change.</p>
+<p>Other states could be close behind. New York lawmakers passed their own measure in June, though it’s unclear if Democratic Gov. Kathy Hochul will sign the bill. And legislators in California, Maryland, Massachusetts and New Jersey have introduced similar bills, which environmental advocates in those states have identified as a top priority for upcoming sessions.</p>
+<p>“We’re certainly hoping that Vermont will be in good company soon,” said Ben Edgerly Walsh, climate and energy program director with the Vermont Public Interest Research Group, an environmental nonprofit.</p>
+<p>The so-called climate Superfund measures are based on the “polluter pays” concept of the 1980 federal Superfund law, which covers the cleanup of toxic waste sites. Under the proposals, states would determine how much to charge fossil fuel companies based on their historical role in producing the emissions responsible for climate change.</p>
+<p>The proposals could bring in billions of dollars to deal with disasters such as the flooding that has ravaged Vermont in the past year. Other states could use the cash to address the damages caused by sea level rise, wildfires or droughts.</p>
+<p>But such measures are likely to face stiff legal challenges from the oil and gas industry, making some state leaders wary of an expensive courtroom battle. And some lawmakers fear the bills will be linked to threats of higher gas prices, although advocates argue they won’t raise costs for consumers.</p>
+
+<div class=" newsroomBlockQuoteContainer  ">
+	<div class="newsroomBlockQuoteSVGContainer">
+		<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12.81 9">
+			<g>
+				<path d="M2.7,0A3,3,0,0,0,.7.8,2.64,2.64,0,0,0,0,2.7,2.14,2.14,0,0,0,.8,4.4a2.84,2.84,0,0,0,1.7.7,1.45,1.45,0,0,0,.7-.2,1.45,1.45,0,0,1,.7-.2q.3,0,.3.6A3.47,3.47,0,0,1,3,7.6a4.21,4.21,0,0,1-2.6,1V9a5.51,5.51,0,0,0,4-1.6A5.06,5.06,0,0,0,6,3.7a3.92,3.92,0,0,0-.9-2.6A3.19,3.19,0,0,0,2.7,0Z"/>
+				<path d="M11.8,1.1A2.84,2.84,0,0,0,9.5,0a2.79,2.79,0,0,0-2,.8,2.64,2.64,0,0,0-.7,1.9,2.06,2.06,0,0,0,.7,1.7,2.41,2.41,0,0,0,1.8.7,1.85,1.85,0,0,0,.7-.2,1.45,1.45,0,0,1,.7-.2q.3,0,.3.6A2.94,2.94,0,0,1,9.8,7.6a4.21,4.21,0,0,1-2.6,1V9a5.51,5.51,0,0,0,4-1.6,4.6,4.6,0,0,0,1.6-3.8A3.47,3.47,0,0,0,11.8,1.1Z"/>
+			</g>
+		</svg>
+	</div>
+	<div class="newsroomBlockQuoteQuoteContainer">
+		<p class="newsroomBlockQuote ">Don’t you think the people who are responsible for a significant share of what’s happening ought to be on the hook for some amount of the costs we are facing?</p>
+	</div>
+		<div class="newsroomBlockQuoteAuthorContainer">
+		<p style="font-size:13px"><b>– New York Democratic state Sen. Liz Krueger</b></p>
+	</div>
+	</div>
+
+	
+<p>Legislators and advocates say the efforts in Vermont and New York are emboldening leaders in other states. But a veto from Hochul, they warn, could raise doubts elsewhere and slow that momentum.</p>
+<h4>    <h4 class="editorialSubhed">Vermont goes first</h4>
+
+	</h4>
+<p>The <a href="https://legislature.vermont.gov/bill/status/2024/S.259" target="_blank">new law</a> in Vermont, which took effect July 1, tasks the state treasurer with calculating the damages from climate change-caused disasters, as well as the expenses the state is incurring to adapt to changing conditions such as increasing precipitation.</p>
+<p>The state will then collect money to cover those costs from any company responsible for more than 1 billion metric tons of greenhouse gas emissions over the past 30 years, proportional to its share of global emissions.</p>
+<p>The law and similar measures are underpinned by an emerging field known as attribution science, which uses computer modeling to determine whether climate change caused or intensified a natural disaster.</p>
+<p>“There’s a wealth of information out there dating back before 1995 indicating that the [oil] industry knew of the risks associated with its products,” said Elena Mihaly, vice president of Conservation Law Foundation Vermont. “It is wholly fair and reasonable to apply retroactive liability to those parties, given what they knew and when.”</p>
+<p>The <a href="https://legislature.vermont.gov/bill/status/2024/S.259" target="_blank">bill</a> passed 93-39 in the Vermont House and 26-3 in the Senate, and Republican Gov. Phil Scott allowed it to become law without his signature. Scott said the state has been hit hard by climate change but expressed concern about the legal costs of taking on oil companies.</p>
+<p>Oil industry groups have disputed the credibility of attribution science and claim states have no grounds to punish them for extracting, refining and selling a legal product. The American Petroleum Institute did not grant a Stateline interview request, nor did Energy In Depth, a research, education and public outreach campaign of the Independent Petroleum Association of America. Both instead issued statements decrying climate Superfund policies.</p>
+<p>Mandi Risko, a spokesperson for Energy In Depth, wrote that the bills are “based on shoddy attribution science which arbitrarily picks winners and losers according to an ideological agenda.” Risko also claimed the bills would raise energy costs.</p>
+<p>While no lawsuits have been filed against Vermont yet, advocates are preparing for a battle. They’re hoping they won’t have to fight alone.</p>
+<figure id="attachment_11497" class="wp-caption aligncenter" style="max-width:100%;width:799px;"><a href="https://newjerseymonitor.com/briefs/gov-murphy-among-democrats-asking-biden-congress-for-migrant-aid/52055318325_0494d5a23d_c/" rel="attachment wp-att-11497"><img decoding="async" loading="lazy" class="wp-image-11497 size-full" src="https://newjerseymonitor.com/wp-content/uploads/2024/01/52055318325_0494d5a23d_c.jpg" alt="" width="799" height="533" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/01/52055318325_0494d5a23d_c.jpg 799w, https://newjerseymonitor.com/wp-content/uploads/2024/01/52055318325_0494d5a23d_c-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/01/52055318325_0494d5a23d_c-768x512.jpg 768w" sizes="(max-width: 799px) 100vw, 799px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em><span data-preserver-spaces="true">Climate experts do not expect New York Gov. Kathy Hochul to act until after November’s election on a bill to charge fossil fuel companies money to cover damages caused by natural disasters related to climate change. (Don Pollard/Office of Governor Kathy Hochul)</span></em></p></figure>
+<h4>    <h4 class="editorialSubhed">Hochul’s hesitation</h4>
+
+	</h4>
+<p>Soon after Vermont’s bill became law in May, New York legislators voted to pass their own measure. The New York <a href="https://nyassembly.gov/leg/?default_fld=&amp;leg_video=&amp;bn=S02129&amp;term=2023&amp;Summary=Y&amp;Actions=Y&amp;Committee%26nbspVotes=Y&amp;Floor%26nbspVotes=Y&amp;Memo=Y&amp;Text=Y&amp;LFIN=Y&amp;Chamber%26nbspVideo%2FTranscript=Y" target="_blank">bill</a> would apply to roughly three dozen fossil fuel companies, collecting $3 billion per year over 25 years to help cover the costs of climate change. Advocates say climate change-caused damages are likely to far exceed that figure.</p>
+<p>“Don’t you think the people who are responsible for a significant share of what’s happening ought to be on the hook for some amount of the costs we are facing?” said Democratic state Sen. Liz Krueger, who sponsored the bill. “This bill is an attempt to get polluters to at least pay part of it.”</p>
+<p>Krueger said the biggest challenge that backers encountered was lawmakers’ fear of facing the oil industry in court. Hochul may be considering that factor as well, though her office would only say that she is “reviewing the legislation.”</p>
+<p>The governor has until the end of the year to decide the bill’s fate, and climate advocates don’t expect her to act until after the November election. Krueger said a veto from Hochul would be “disturbing,” given New York’s potential to be a climate leader.</p>
+<p>“Other states are waiting patiently in line, wanting to do the same thing, hoping we deal with the litigation before they jump in,” she said.</p>
+<p>In a statement to New York lawmakers, the oil industry challenged the accuracy of greenhouse gas accounting.</p>
+<p>“At best the state can only estimate emissions; and these estimates are imprecise and not accurate enough to base a prorated share of a $75 billion dollar penalty,” the American Petroleum Institute wrote in a 2023 statement to lawmakers as they debated climate Superfund legislation, according to media outlet <a href="https://citylimits.org/2023/03/27/new-york-considers-first-in-the-nation-bill-to-charge-fossil-fuel-companies-for-climate-change-destruction/" target="_blank">City Limits</a>.</p>
+<p>Backers note that the program only charges companies that emitted 1 billion tons of greenhouse gases over a 19-year period. Many gas companies in New York won’t be affected, and some will pay a smaller amount based on their share of emissions.</p>
+<p>Advocates say that the biggest polluters, such as Saudi Aramco, the company most liable for emissions under the bill, will still have to compete with companies that are not being penalized.</p>
+<p>“If you’re Aramco and you’re on the hook for 20 cents a gallon and you raise your price 20 cents, nobody’s gonna fill up there,” said Blair Horner, executive director of the New York Public Interest Research Group, a nonprofit research and advocacy organization.</p>
+<h4>    <h4 class="editorialSubhed">Waiting in the wings</h4>
+
+	</h4>
+<p>New Yorkers aren’t the only ones hanging on Hochul’s decision.</p>
+<p>“In the Massachusetts context, it’s really important that she move forward on this,” said Dan Zackin, legislative coordinator with 350 Mass, an environmental nonprofit that is pushing for a similar approach. “Our leaders in Massachusetts have been fairly risk-averse and hesitant to do things that would take on the fossil fuel industry, so we really need that precedent to be set so we know what’s going to come when we pass this.”</p>
+<p>State Sen. Jamie Eldridge, a Democrat who sponsored the Massachusetts <a href="https://malegislature.gov/Bills/193/S481" target="_blank">bill</a>, said Hochul’s potential veto is a “real concern.”</p>
+<p>“Sometimes in Massachusetts we look to see if something passes in a couple other states before we pass it ourselves,” he said.</p>
+<p>But he said environmental advocates are increasingly supporting the proposal as the concept gains traction and backers are building momentum for the next legislative session, regardless of the outcome in New York.</p>
+<p>Lawmakers in <a href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202320240SB1497" target="_blank">California</a>, <a href="https://mgaleg.maryland.gov/mgawebsite/Legislation/Details/HB1438" target="_blank">Maryland</a> and <a href="https://www.njleg.state.nj.us/bill-search/2024/S3545" target="_blank">New Jersey</a> have drafted similar bills, and activists expect more states to follow suit — especially if Hochul signs the New York measure. California’s bill progressed through three committees this year, but did not receive a full Senate vote before the end of the legislation session.</p>
+<p>“This is going to be our top-priority bill for the next session starting in September,” said Maggie Coulter, senior attorney with the Center for Biological Diversity, an environmental nonprofit. “We were blown away by the support. States like Vermont charging ahead and being willing to engage with a litigious industry group is inspiring and puts a little bit of pressure on states like California to step up to the plate.”</p>
+<p><em><a href="https://stateline.org" target="_blank">Stateline</a> is part of States Newsroom, a nonprofit news network supported by grants and a coalition of donors as a 501c(3) public charity. Stateline maintains editorial independence. Contact Editor Scott S. Greenberger for questions: <a href="mailto:info@stateline.org">info@stateline.org</a>. Follow Stateline on <a href="https://facebook.com/statelinenewsroom" target="_blank">Facebook</a> and <a href="https://x.com/stateline_news" target="_blank">X</a>.</em></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>In Las Vegas, Trump touts Kennedy endorsement, declares support for keeping subminimum wage</title>
+		<link>https://newjerseymonitor.com/2024/08/23/in-las-vegas-trump-touts-kennedy-endorsement-declares-support-for-keeping-subminimum-wage/</link>
+		
+		<dc:creator><![CDATA[Jeniffer Solis]]></dc:creator>
+		<pubDate>Sat, 24 Aug 2024 00:35:12 +0000</pubDate>
+				<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Donald Trump]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14476</guid>
+
+					<description><![CDATA[Monday was former president Donald Trump’s first campaign event in Nevada since his Democratic rival, Joe Biden, dropped out.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/DSC05070-2048x1365-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/DSC05070-2048x1365-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/DSC05070-2048x1365-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/DSC05070-2048x1365-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/DSC05070-2048x1365-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/DSC05070-2048x1365-1.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">rump Friday criticized Harris’ support for legislation in 2021 to raise the federal minimum wage to $15, noting that legislation also would have eliminated the federal “tip credit” provision. That provision allows employers to pay tipped workers less than the federal minimum wage. (Photo: Jeniffer Solis/Nevada Current)</p><p>Former president Donald Trump’s first campaign event in Nevada since his Democratic rival Joe Biden dropped out was billed as an event to tout Trump’s “no tax on tips” policy.</p>
+<p>But that message was overshadowed by Arizona independent candidate Robert F Kennedy’s announcement that he was dropping out of the race and endorsing Trump.</p>
+<p>“We just had a very nice endorsement from RFK,” Trump said at the Las Vegas campaign event Friday.</p>
+<p>Trump said it was “a great honor” to receive Kennedy’s endorsement, adding he would be meeting with him soon to discuss his support. Despite Kennedy’s declining polling numbers and past controversies, Trump praised him and his endorsement.</p>
+<p>“Not everyone agrees with everything he says. That’s true of everybody, but he’s a very respected person. He’s a very beloved person in many ways,” Trump said.</p>
+<p>Kennedy <a href="https://www.axios.com/2024/08/23/trump-robert-f-kennedy-jr-endorsement" target="_blank">joined Trump </a>during a campaign event in Arizona on Friday following Trump’s Las Vegas event.</p>
+<p>With Kennedy no longer campaigning in critical battleground states, his voters are up for grabs in tight swing states. Following the endorsement, Trump’s campaign team said they believe a majority of Kennedy’s Nevada voters will break for Trump based on their own internal modeling, making his exit a net positive for Trump in major swing states.</p>
+<p>The latest The New York Times and Siena College<a href="https://www.nytimes.com/2024/08/17/us/elections/kamala-harris-trump-az-nc-ga-nv.html" target="_blank"> poll shows</a> Trump and Vice President Kamala Harris, his new rival for the presidency, neck-and-neck in Nevada — a state Biden won four years ago — with Trump leading Harris 48% to 47%.</p>
+<p>“We’re going to win. The state is looking very good,” Trump said Friday.</p>
+<p>It’s far from clear what if any impact Kennedy’s departure from the race will have in Nevada. Trump’s lead over Harris was actually larger when the NYT-Siena poll <a href="https://www.nytimes.com/interactive/2024/08/17/us/elections/times-siena-poll-nevada-registered-voters.html" target="_blank">included Kennedy in the mix</a>, putting Trump at 45%, Harris at 42%, and Kennedy garnering 6%.</p>
+<p>Friday’s campaign event was Trump’s first Nevada appearance since rival Joe Biden dropped out of the race and endorsed Vice President Kamala Harris earlier last month.</p>
+<p>The low-profile affair held in a Las Vegas restaurant also came within 24 hours of the last night of a raucous Democratic National Convention that officially nominated Harris.</p>
+<h4>    <h4 class="editorialSubhed">Trump declares support for subminimum wage</h4>
+
+	</h4>
+<p>Trump delivered remarks pushing his “no tax on tips” policy proposal at the Toro E La Capra restaurant, located near Sunset Road and Decatur Boulevard. The proposal would abolish federal income taxes on tips.</p>
+<p>Trump first unveiled the policy during a campaign rally in Las Vegas in June. The policy was quickly endorsed by the politically connected Culinary Workers Union in Las Vegas.</p>
+<p>At Friday’s event, Trump suggested his declaration to end the federal taxation of tipped income would earn him voters from Culinary workers.</p>
+<p>“We want to get the Culinary Union,” Trump said. “A lot of them are voting for us, I can tell you that.”</p>
+<p>The Culinary, however, has endorsed Harris, and prior to Trump’s remarks Friday, Culinary officials held an event and issued a statement slamming Trump.</p>
+<p>“Kamala Harris has promised to raise the minimum wage for all workers – including tipped workers – and eliminate tax on tips,” said Culinary Vice President Leain Vashon.</p>
+<p>Vashon said Trump didn’t help tipped workers while he was president, so “Why would we trust him? Kamala has a plan, Trump has a slogan.”</p>
+<p>While details on Trump’s tax policy are scant, the policy proposal quickly gained steam, leading Nevada Democratic Sens. Catherine Cortez Masto and Jacky Rosen to back a “no tax on tips,” bill introduced by Texas Republican Sen. Ted Cruz.</p>
+<p>Harris later proposed her own “no tax on tips” policy.</p>
+<p>“Kamala Harris is now pretending to endorse my policy,” Trump said. “She’s a copycat. She’s a flip flopper.”</p>
+<p>Harris’ position — similar to legislation Nevada Democratic Rep. Steven Horsford <a href="https://nevadacurrent.com/2024/08/13/horsford-announces-bill-to-make-sure-high-end-earners-cant-exploit-an-end-to-tax-on-tips/" target="_blank">said he will sponsor</a> — eliminates federal taxation on tips, but would also eliminate the federal subminimum wage on tipped incomes, which can be as low as $2.13 an hour.</p>
+<p>Trump Friday criticized Harris’ support for legislation in 2021 to raise the federal minimum wage to $15, noting that legislation also would have eliminated the federal “tip credit” provision.</p>
+<p>That is the provision in federal law that <a href="https://www.epi.org/publication/waiting-for-change-tipped-minimum-wage/" target="_blank">allows employers to pay tipped workers less</a> than the federal minimum wage.</p>
+<p>“Kamala supports a bill to eliminate the federal tip credit, which would force restaurants to impose large service charges on diners, meaning customers will not leave tips at all, and you’ll be stuck with a minimum wage,” Trump said. “I will never let that happen under the Trump administration.”</p>
+<p>Horsford has said his legislation would also include guardrails designed to prevent employers or high-end earners from exploiting the elimination of federal taxation of tips.</p>
+<p>The policy may have some appeal in the Silver State. Nevada has one of the largest shares of tipped workers in the nation. Nevada is also one of only seven states that have abolished the subminimum wage for tipped workers altogether.</p>
+<p>Nationally, as many as 4.3 million people work in predominantly tipped occupations in the United States, according to the <a href="https://www.nelp.org/insights-research/minimum-wage-basics-overview-tipped-minimum-wage/" target="_blank">National Employment Law Project</a>. Women also make up more than two-thirds of the tipped workforce, according to the <a href="https://nwlc.org/wp-content/uploads/2024/06/Tipped-Workers-FS-2024.6.12v1.pdf?utm_medium=email&amp;utm_source=ncl_amplify&amp;utm_campaign=240812-kamala_copies_president_trump_but_voters_arent_stupid&amp;utm_content=ncl-9Rdap5qfav&amp;_nlid=HHj3Ua7gxR&amp;_nhids=G9xniLOGbM" target="_blank">National Woman’s Center</a>. Tipped workers are also more than twice as likely to live in poverty compared to the overall workforce.</p>
+<p>Neither the Culinary nor congressional backers can provide an estimate of how much of a financial impact would actually be realized if tips weren’t taxed.</p>
+<p>An analysis by the left-leaning Center for American Progress projects that “exempting tips from income taxes does nothing for tipped workers whose earnings are so low that they are already exempt from income taxes.”</p>
+<p>The group points to an <a href="https://budgetlab.yale.edu/news/240624/no-tax-tips-act-background-tipped-workers" target="_blank">estimate from the Yale Budget Lab</a> indicating at least a third of tipped workers don’t make enough to pay any income taxes, and for moderate wage tipped workers who do pay income taxes, any tax relief from not taxing the tipped portion of their income would be small.</p>
+<p>Harris and Trump are set to debate Sept. 10.</p>
+<p><em><a href="https://nevadacurrent.com" target="_blank">Nevada Current</a> is part of States Newsroom, a nonprofit news network supported by grants and a coalition of donors as a 501c(3) public charity. Nevada Current maintains editorial independence. Contact Editor Hugh Jackson for questions: <a href="mailto:info@nevadacurrent.com">info@nevadacurrent.com</a>. Follow Nevada Current on <a href="https://facebook.com/newnevadacurrent" target="_blank">Facebook</a> and <a href="https://x.com/NevadaCurrent" target="_blank">X</a>.</em></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Robert F. Kennedy Jr. suspends his presidential bid, backs Trump </title>
+		<link>https://newjerseymonitor.com/2024/08/23/robert-f-kennedy-jr-suspends-his-presidential-bid-backs-trump/</link>
+		
+		<dc:creator><![CDATA[Shauneen Miranda]]></dc:creator>
+		<pubDate>Fri, 23 Aug 2024 21:11:45 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Donald Trump]]></category>
+		<category><![CDATA[Robert F. Kenedy Jr.]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14457</guid>
+
+					<description><![CDATA[Robert F. Kennedy Jr. said his now-suspended presidential campaign "changed the national political conversation forever."]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/RFKJR-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/RFKJR-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/RFKJR-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/RFKJR-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/RFKJR-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/RFKJR-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">PHOENIX, ARIZONA - AUGUST 23: Former Presidential candidate Robert F. Kennedy Jr. gives remarks at the Renaissance Phoenix Downtown Hotel on August 23, 2024 in Phoenix, Arizona.Kennedy announced that he was suspending his presidential campaign and supporting Republican presidential candidate, former U.S. President Donald Trump.(Photo by Rebecca Noble/Getty Images)</p><p>Independent presidential candidate Robert F. Kennedy Jr. said Friday he is suspending his campaign and threw his support behind former President Donald Trump — the GOP presidential nominee.</p>
+<p>The announcement from the environmental lawyer and anti-vaccine activist, who has held on to a long-shot presidential bid, comes just a day after Vice President Kamala Harris formally <a href="https://www.newsfromthestates.com/article/lets-fight-it-harris-vows-chart-new-way-forward-defeat-trump-11" target="_blank">accepted her party’s nomination</a> at the Democratic National Convention.</p>
+<p>“It’s with a sense of victory and not defeat that I’m suspending my campaign activities,” Kennedy said in Phoenix, Arizona, during a lengthy news conference.</p>
+<p>“Not only did we do the impossible by collecting a million signatures, but we changed the national political conversation forever,” he said, adding that “I can say to all who have worked so hard the last year-and-a-half — thank you for a job well done.”</p>
+<p>Kennedy acknowledged that he “cannot, in good conscience, ask my staff and volunteers to keep working their long hours, or ask my donors to keep giving when I cannot honestly tell them that I have a real path to the White House.”</p>
+<p>He clarified that he is not terminating his campaign and that his name will “remain on the ballot in most states.”</p>
+<p>The third-party candidate said he would remove his name from the ballot in about 10 battleground states “where my presence would be a spoiler.” He did not specify the states.</p>
+<p>He said voters who live in a blue state can vote for him “without harming or helping (former) President Trump or Vice President Harris.”</p>
+<p>In response, Trump thanked Kennedy during a campaign event in Las Vegas, Nevada.</p>
+<p>“That was very nice,” the former president said, adding that Kennedy is a “great guy” and “respected by everybody.”</p>
+<p>Kennedy drew speculation about withdrawing his candidacy and backing Trump in the days leading up to the Friday announcement. On Thursday, he filed the paperwork to withdraw his name from Arizona’s ballot, per Arizona Secretary of State Adrian Fontes in a <a href="https://x.com/AZSecretary/status/1826824488249688233" target="_blank">post on X</a>.</p>
+<p>Kennedy has faced dwindling polling numbers and <a href="https://www.politico.com/news/2024/08/19/robert-kennedy-jr-july-fundraising-00174760" target="_blank">financial trouble</a> for his campaign while undertaking a monumental task in getting on states’ ballots as an independent candidate. He initially ran as a Democrat but switched to an independent ticket in October 2023.</p>
+<p>Kennedy — son of Robert F. Kennedy and the nephew of John F. Kennedy — is part of one of the most storied families in Democratic politics. Throughout his campaign, he amplified anti-vaccine conspiracy theories and was seen as a possible spoiler candidate.</p>
+<p>Harris-Walz campaign chair Jen O’Malley Dillon said “for any American out there who is tired of Donald Trump and looking for a new way forward, ours is a campaign for you,” per a Friday statement in response to Kennedy suspending his campaign.</p>
+<p>“In order to deliver for working people and those who feel left behind, we need a leader who will fight for you, not just for themselves, and bring us together, not tear us apart. Vice President Harris wants to earn your support.”</p>
+<p>Meanwhile, Trump is set to speak in Glendale, Arizona, later Friday. His campaign said Thursday that a “special guest” would join him at the rally.</p>
+    <a href="https://newjerseymonitor.com/donate" style="text-decoration:none;">
+    <div class="donateContainer">
+        <div class="donateTextContainer">
+            <p>SUPPORT NEWS YOU TRUST.</p>
+        </div>
+        <div class="donateButtonContainer">
+            <button>DONATE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Jersey City to face daily fines for not reinstating cops fired for using cannabis</title>
+		<link>https://newjerseymonitor.com/2024/08/23/jersey-city-to-face-daily-fines-for-not-reinstating-cops-fired-for-using-cannabis/</link>
+		
+		<dc:creator><![CDATA[Sophie Nieto-Munoz]]></dc:creator>
+		<pubDate>Fri, 23 Aug 2024 21:08:38 +0000</pubDate>
+				<category><![CDATA[Cannabis]]></category>
+		<category><![CDATA[Politics]]></category>
+		<category><![CDATA[cannabis]]></category>
+		<category><![CDATA[Matt Platkin]]></category>
+		<category><![CDATA[Steve Fulop]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14455</guid>
+
+					<description><![CDATA[The city will face daily fines of $100 for each of two officers it has been ordered to rehire, with fines up to $20,000 total.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2021/10/JCcityhall05-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2021/10/JCcityhall05-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2021/10/JCcityhall05-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2021/10/JCcityhall05-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2021/10/JCcityhall05-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2021/10/JCcityhall05-2048x1365.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">The city will face daily fines of $100 for each of two officers it has been ordered to rehire, with fines up to $20,000 total. (Fran Baltzer for the New Jersey Monitor)</p><p style="font-weight: 400;">Jersey City could begin facing daily fines starting Saturday for refusing to reinstate two police officers whose terminations over their cannabis usage were overturned by the state Civil Service Commission.</p>
+<p style="font-weight: 400;">The state will fine the city $100 daily for each officer — Norhan Mansour and Omar Polanco — with a total maximum of $20,000. Saturday will mark 31 days since the Civil Service Commission gave the city one month to rehire the officers.</p>
+<p style="font-weight: 400;">Michael Rubas, attorney for the cops plus three others who were disciplined for their cannabis consumption, said he has inquired with the city police department four times since Aug. 2 about their jobs. Rubas said that Mansour and Polanco remained unemployed as of Friday.</p>
+<p style="font-weight: 400;">
+<figure id="attachment_9341" class="wp-caption alignleft" style="max-width:100%;width:300px;"><a href="https://newjerseymonitor.com/img_0971/"><img decoding="async" loading="lazy" class="size-medium wp-image-9341" src="https://newjerseymonitor.com/wp-content/uploads/2023/08/IMG_0971-300x200.jpg" alt="" width="300" height="200" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/08/IMG_0971-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/08/IMG_0971-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/08/IMG_0971-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2023/08/IMG_0971-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2023/08/IMG_0971-2048x1365.jpg 2048w" sizes="(max-width: 300px) 100vw, 300px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Jersey City Mayor Steve Fulop. (Nikita Biryukov | New Jersey Monitor)</em></p></figure>
+<p style="font-weight: 400;">A Jersey City spokeswoman didn’t respond when asked if the city would pay the fines or reinstate the officers. City spokeswoman Kimberly Wallace-Scalcione said the department plans to appeal.</p>
+<p style="font-weight: 400;">“As the liable entity, we will appeal as the Civil Service Commission continues to avoid the principal cause at the center of this legal dispute,” she said in a statement.</p>
+<p style="font-weight: 400;">This comes on the heels of Rubas filing <a href="https://newjerseymonitor.com/briefs/jersey-city-loses-third-bid-to-fire-police-officer-for-using-cannabis/" target="_blank" rel="noopener">a wrongful termination lawsuit</a> on behalf of Mackenzie Reilly, one of the other officers fired for using marijuana. Rubas says in the lawsuit that Jersey City Mayor Steve Fulop is terminating cops to bring attention to his 2025 gubernatorial campaign.</p>
+<p style="font-weight: 400;">“He has lost at every turn including in Federal Court. His actions have cost the taxpayers of Jersey City hundreds of thousands of dollars in needless attorney&#8217;s fees with much more to come,” Rubas said in a statement Friday. “Now, those same taxpayers will be liable for thousands of dollars in fines because he refuses to comply with the lawful reinstatement orders.”</p>
+<p style="font-weight: 400;">The city has already lost several battles in its crusade against <a href="https://newjerseymonitor.com/2022/04/29/all-eyes-on-new-jersey-as-it-grapples-with-letting-cops-use-cannabis/" target="_blank" rel="noopener">cops using cannabis</a>. The legal fight began when Fulop said he would defy a 2022 memo from Attorney General Matt Platkin that said the state’s marijuana legalization law allows police officers to consume legal cannabis off duty. Jersey City Public Safety Director James Shea <a href="https://newjerseymonitor.com/2023/10/17/jersey-city-sues-new-jersey-in-bid-to-halt-cops-from-using-cannabis/" target="_blank" rel="noopener">sued the state over this</a>, arguing federal law bans people who use cannabis from owning firearms and ammunition, <a href="https://newjerseymonitor.com/2024/02/01/jersey-city-says-it-must-fire-cops-who-use-cannabis-police-union-says-thats-pure-hogwash/" target="_blank" rel="noopener">including police officers.</a></p>
+<p style="font-weight: 400;">But the Civil Service Commission and administrative law judges have ruled that the federal guns statute does not preempt the state’s cannabis law. They’ve come to the same decision in three cases regarding Jersey City cops — Mansour, Polanco, and Reilly, whose case was decided last week.</p>
+<p style="font-weight: 400;">The commission reversed Mansour’s “unlawful removal” on Aug. 2, 2023, and she was awarded back pay, seniority, benefits, and counsel fees. Polanco’s case was decided on Sept. 20, 2023, with the same outcome.</p>
+<p style="font-weight: 400;">The commission denied the city’s request for reconsideration and granted Mansour and Polanco’s requests that it fine Jersey City for not rehiring them. Rubas said no enforcement action has been filed for Reilly because the city can still ask the commission to reconsider that ruling.</p>
+<p style="font-weight: 400;">Fulop continues to play political games, Rubas said.</p>
+<p style="font-weight: 400;">“Mayor Fulop is the epitome of the saying ‘absolute power corrupts absolutely,’” Rubas said.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>New law hikes pay for county prosecutors, some judges</title>
+		<link>https://newjerseymonitor.com/2024/08/23/new-law-hikes-pay-for-county-prosecutors-some-judges/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Fri, 23 Aug 2024 10:50:51 +0000</pubDate>
+				<category><![CDATA[Courts]]></category>
+		<category><![CDATA[Gov + Legislature]]></category>
+		<category><![CDATA[Brian Stack]]></category>
+		<category><![CDATA[Esther Suarez]]></category>
+		<category><![CDATA[Mark Musella]]></category>
+		<category><![CDATA[Nicholas Scutari]]></category>
+		<category><![CDATA[Paul Sarlo]]></category>
+		<category><![CDATA[Phil Murphy]]></category>
+		<category><![CDATA[Tahesha Way]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14443</guid>
+
+					<description><![CDATA[The measure boosts pay and pension access for county prosecutors, allowing them to collect judicial pensions while serving.]]></description>
+																						<content:encoded><![CDATA[<img width="799" height="533" src="https://newjerseymonitor.com/wp-content/uploads/2023/09/53148009551_27fc342d9e_c.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/09/53148009551_27fc342d9e_c.jpg 799w, https://newjerseymonitor.com/wp-content/uploads/2023/09/53148009551_27fc342d9e_c-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/09/53148009551_27fc342d9e_c-768x512.jpg 768w" sizes="(max-width: 799px) 100vw, 799px" /><p style="font-size:12px;">Senate President Nicholas Scutari signed the new law as acting governor. (Rich Hundley III/Governor’s Office)</p><p><span data-preserver-spaces="true">Senate President Nicholas Scutari, acting as the state’s chief executive while the governor and lieutenant governor are away, signed legislation Thursday that will raise pay for county prosecutors and some judges and allow prosecutors to collect judicial pensions while receiving their full salary.</span></p>
+<p><a class="editor-rtfLink" href="https://pub.njleg.state.nj.us/Bills/2024/S2500/2470_R1.PDF" target="_blank" rel="noopener"><span data-preserver-spaces="true">The bill</span></a><span data-preserver-spaces="true">, which passed both chambers in June in votes that fell almost entirely along party lines, will raise salaries for county prosecutors to $204,167 retroactive to the beginning of 2024.</span></p>
+<p><span data-preserver-spaces="true">“Our judges and county prosecutors work extremely hard every day to ensure justice is served at the highest level and quality here in New Jersey,” Scutari (D-Union) said in a statement. “The enactment of this bill allows us to maintain competitive salaries and retirement compensation for these officials.”</span></p>
+<p><span data-preserver-spaces="true">The bill will also index those salaries to increases in the Consumer Price Index for at least three years. </span></p>
+<p><span data-preserver-spaces="true">That provision prolongs cost-of-living adjustments present in existing law through the start of 2025, but not after. The previous increases were enacted under legislation Gov. Phil Murphy signed in 2018.</span></p>
+<p><span data-preserver-spaces="true">The salary increases are expected to cost the state $135,900 in the current and following July-to-June fiscal years, $275,193 in the two fiscal years thereafter, and $367,697 in future years, according to a fiscal note prepared by the Office of Legislative Services.</span></p>
+<p><span data-preserver-spaces="true">“This will help attract and retain qualified professionals to serve as prosecutors and judges,” bill sponsor Sen. Paul Sarlo (D-Bergen) said in a statement.</span></p>
+<p><span data-preserver-spaces="true">Prosecutors receiving pension benefits through the judicial retirement system cannot simultaneously accrue benefits through a separate state retirement system.</span></p>
+<p><span data-preserver-spaces="true">The bill also raises the salaries of presiding New Jersey appellate judges to $218,546, up from $215,546.</span></p>
+<p><span data-preserver-spaces="true">The legislation allows prosecutors who earned pension credits as judges to draw on their pensions while serving as county prosecutors, something barred under current law.</span></p>
+<p><span data-preserver-spaces="true">Other provisions allow prosecutors to purchase pension credits based on past work as law clerks for a New Jersey judge or justice. This “will help New Jersey’s legal system attract and retain top talent who have valuable experience working in a state court,” said bill sponsor Sen. Brian Stack (D-Hudson).</span></p>
+<p><span data-preserver-spaces="true">It’s not clear how many of New Jersey’s 21 county prosecutors will benefit from the change to pension rules.</span></p>
+<p><span data-preserver-spaces="true">Hudson County Prosecutor Esther Suarez served five years as a Superior Court judge in Passaic County before being confirmed prosecutor in 2015, and Bergen County Prosecutor Mark Musella clerked for former Superior Court Judge Ralph Polito.</span></p>
+<p><span data-preserver-spaces="true">Scutari is acting governor while Gov. Phil Murphy and Lt. Gov. Tahesha Way are in Chicago for the <a href="https://newjerseymonitor.com/2024/08/23/lets-fight-for-it-harris-vows-to-chart-a-new-way-forward-defeat-trump/" target="_blank" rel="noopener">Democratic National Convention</a>. Scutari attended the convention earlier this week but returned to take helm of the administration Thursday. Murphy and Way are expected to return Friday morning.</span></p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>‘Let’s fight for it’: Harris vows to chart a new way forward, defeat Trump</title>
+		<link>https://newjerseymonitor.com/2024/08/23/lets-fight-for-it-harris-vows-to-chart-a-new-way-forward-defeat-trump/</link>
+		
+		<dc:creator><![CDATA[Ariana Figueroa]]></dc:creator>
+		<pubDate>Fri, 23 Aug 2024 10:38:38 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Donald Trump]]></category>
+		<category><![CDATA[Kamala Harris]]></category>
+		<category><![CDATA[Tim Walz]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14450</guid>
+
+					<description><![CDATA[The vice president told her life story to the millions of Americans watching, saying it informed her agenda meant to boost the country’s’ middle class.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167986119-1.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167986119-1.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167986119-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167986119-1-768x512.jpg 768w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">CHICAGO, ILLINOIS - AUGUST 22: (L-R) Second gentleman Doug Emhoff, Democratic presidential nominee, U.S. Vice President Kamala Harris, Democratic vice presidential nominee Minnesota Gov. Tim Walz and Minnesota first lady Gwen Walz celebrate after Harris accepted the Democratic presidential nomination during the final day of the Democratic National Convention at the United Center on August 22, 2024 in Chicago, Illinois. Delegates, politicians, and Democratic Party supporters are gathering in Chicago, as current Vice President Kamala Harris is named her party's presidential nominee. The DNC takes place from August 19-22. (Photo by Chip Somodevilla/Getty Images)</p><p>CHICAGO — Vice President Kamala Harris accepted her party’s nomination for president Thursday evening, pitching her candidacy as an opportunity for the nation to move forward, rather than accept a dark future she said would follow a second election of her Republican opponent.</p>
+<p>Harris on the last night of the Democratic National Convention took advantage of the largest television audience she’s likely to have at least until her first debate with Republican nominee Donald Trump next month.</p>
+<p>The vice president told her life story to the millions of Americans watching, saying it informed her agenda meant to boost the country’s’ middle class.</p>
+<p>She characterized herself as a lifelong public servant and unifier, in contrast to what she described as Trump’s divisive self-centeredness.</p>
+<p>“My entire career, I have only had one client: the people,” she said. “And so, on behalf of the people, on behalf of every American, regardless of party, race, gender, or the language your grandmother speaks, on behalf of my mother and everyone who has ever set out  on their own unlikely journey … on behalf of everyone whose story could only be written in the greatest nation on Earth, I accept your nomination for president of the United States of America.”</p>
+<p>She professed her patriotism several times in her roughly 40-minute address. Near the close, she urged the Democrats in the arena and viewers at home to work for her election on behalf of the country.</p>
+<p>“Let’s get out there and let’s fight for it,” she said “Let us write the next great chapter in the most extraordinary story ever told.”</p>
+<p>Americans across the nation made their assessments. Yvette Young, a lifelong Philadelphia resident and project manager at SEPTA who attended a watch party at a Harris campaign office, said she thought it was an excellent speech and comprehensive.</p>
+<p>“She touched on, I think, every issue,” Young said. “She wasn’t afraid to call Donald Trump out on his nonsense and put into perspective how he has harmed our country.”</p>
+    <h4 class="editorialSubhed">A middle-class childhood</h4>
+
+	
+<p>Harris has downplayed the historic nature of her candidacy — she is the first Black and South Asian woman to lead a major party ticket and would be the first woman president of any race — but expanded Thursday on the values her immigrant mother instilled in her.</p>
+<p>Her mother, a scientist from India, “was tough, courageous, a trailblazer in the fight for women’s health,” she said.</p>
+<p>Harris described her upbringing as middle class, saying she was raised mainly by her mom after her parents divorced. Harris’ father was a Jamaican student who met her mother at a civil rights meeting, Harris said Thursday.</p>
+<p>The vice president promised to be a middle-class champion, creating what she called “an opportunity economy” that would unite labor, small businesses and workers. Additionally, she pledged to “end America’s housing shortage,” to lower the cost of everyday needs.</p>
+<p>Ahead of the convention, Harris<a href="https://www.newsfromthestates.com/article/harris-unveils-plan-curb-price-gouging-boost-child-tax-credit-tackle-rent-hikes" target="_blank"> unveiled policy details</a> to stop price gouging, boost the child tax credit, curb rent hikes and help first-time homebuyers.</p>
+<p>“We know a strong middle class has always been critical to America’s success,” she said. “And building that middle class will be a defining goal of my presidency. This is personal to me. The middle class is where I come from.”</p>
+<p>Her remarks were applauded by another person at the watch party, Lindsay Davis, a Germantown resident and UX designer.</p>
+<p>Davis believes that there’s a particular issue that Harris can talk about that can sway undecided voters.</p>
+<p>“A lot of the stuff she’s already said about making it easier for first-time homebuyers to buy a house that was, like, huge,” she said. “I think that’s really big for, like, younger people that aren’t boomers, I guess Gen Z, Gen X, Gen whatever, all the Gens.”</p>
+<figure id="attachment_14452" class="wp-caption aligncenter" style="max-width:100%;width:1024px;"><a href="https://newjerseymonitor.com/harrisdncnight/"><img decoding="async" loading="lazy" class="wp-image-14452 size-large" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/harrisDNCnight-1024x681.jpg" alt="" width="1024" height="681" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/harrisDNCnight-1024x681.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/harrisDNCnight-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/harrisDNCnight-768x511.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/harrisDNCnight-1536x1022.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/harrisDNCnight-2048x1363.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Vice President Kamala Harris speaking in Chicago on the last night of the Democratic National Convention on Aug. 23, 2024. (Photos by Shaun Griswold / Source NM)</em></p></figure>
+    <h4 class="editorialSubhed">A sense of justice</h4>
+
+	
+<p>Harris’s mother also taught her daughters “never to complain about injustice, but to do something about it,” she said, repeating a line former first lady Michelle Obama used throughout a Tuesday speech.</p>
+<p>She said the same sense of justice motivated her to become a prosecutor, which she did as the district attorney of San Francisco and attorney general of California before her election to the U.S. Senate in 2016.</p>
+<p>As the top lawyer in California, Harris won a $20 billion settlement for homeowners in the state as part of a nationwide lawsuit against banks over predatory lending during the 2008 financial crisis.</p>
+<p>North Carolina Gov. Roy Cooper, who was also his state’s attorney general at the time, said Thursday in remarks just before Harris spoke that he saw her demand much more than what the banks initially offered.</p>
+<p>“America, we’ve got a lot of big fights ahead of us,” he said. “And we’ve got one hell of a fighter ready to take them on.”</p>
+    <h4 class="editorialSubhed">Trump’s ‘dark agenda’</h4>
+
+	
+<p>Harris described much of her policy objectives in contrast to her opponent, the former president seeking another term, Trump.</p>
+<p>While her administration would work to expand reproductive rights, Trump would further restrict them, she said.</p>
+<p>Trump would pursue a nationwide abortion ban “with or without Congress,” limit access to birth control and require women to report miscarriages, she said.</p>
+<p>“Why is it that they don’t trust women?” she asked the packed United Center crowd. “Well, we trust women.”</p>
+<p>She said if she is elected, and Congress passes a bill restoring the Roe v. Wade abortion decision, she will sign it into law. For that to happen, Democrats would likely need to not only control both chambers, but also have 60 votes in the Senate.</p>
+<p>On foreign policy, Harris said Trump wouldn’t stand up to dictators, “because he wants to be an autocrat himself.”</p>
+<p>She described November’s election as a “fight for America’s future.”</p>
+<p>The crowd broke out in a chant: “We’re not going back.”</p>
+<p>She also asked the audience to imagine how dangerous Trump would be in office after a July 1 U.S. Supreme Court ruling that said Trump could not be prosecuted for most actions he took in office.</p>
+    <h4 class="editorialSubhed">Second woman candidate</h4>
+
+	
+<p>Harris addressed a packed crowd in which many women wore white, a nod to the women’s suffrage movement.</p>
+<p>Former Secretary of State Hillary Clinton, who gave a speech Monday, was the first woman to accept the presidential nomination of a major party at the 2016 Democratic National Convention, when she gave her acceptance speech in a white pantsuit.</p>
+<p>But Harris dressed head to toe in black.</p>
+<p>She took the stage to Beyoncé’s “Freedom,” a song the campaign has <a href="https://www.newsfromthestates.com/article/black-women-quickly-mobilize-boost-kamala-harris-presidential-bid" target="_blank">made its anthem.</a> Beyoncé, however, did not appear in person, despite widespread rumors she would show up.</p>
+<p>After Harris’ speech, what Democratic officials said were 100,000 red, white and blue balloons were released, a convention tradition. Harris and her husband, Doug Emhoff, and her running mate, Minnesota Gov. Tim Walz and his wife, Gwen Walz, held hands onstage and acknowledged the cheers of the delegates.</p>
+    <h4 class="editorialSubhed">‘Unexpected’ path to nomination</h4>
+
+	
+<p>Harris acknowledged her abbreviated path to the nomination, which began just 32 days ago, was highly unusual.</p>
+<p>After President Joe Biden dropped his reelection bid and endorsed Harris on July 21, the party quickly coalesced around the vice president.</p>
+<p>She racked up the necessary delegates and after a short vetting period tapped Walz. They soon hit the campaign trail in the seven key battleground states – Arizona, Georgia, Michigan, Nevada, North Carolina, Pennsylvania, Wisconsin.</p>
+<p>Throughout the whirlwind, she has praised Biden for his leadership and accomplishments.</p>
+<p>She did again in the opening lines of her speech Thursday.</p>
+<p>“Your record is extraordinary, as history will show,” she said. “And your character is inspiring.”</p>
+<p>Republicans have criticized the process that led to Harris’ nomination, calling it a “coup” against Biden.</p>
+<p>In a written statement ahead of Harris’ address Thursday, Republican National Committee Chairman Michael Whatley repeated that claim and slammed Harris’ policy proposals as “the most radical agenda ever put forward at a major party convention.”</p>
+<p>“After staging a coup to take the nomination from Joe Biden just weeks ago, Kamala Harris will take the stage at the DNC to share her dangerously liberal agenda with the Democrats gathered to coronate her in Chicago,” he said.</p>
+    <h4 class="editorialSubhed">Convention capstone</h4>
+
+	
+<p>Harris’ acceptance marked the end of a four-day convention focused on the theme of passing the torch to the next generation that was woven through the speeches of long-established Democrats in the party, such as former President Bill Clinton, who said he <a href="https://www.newsfromthestates.com/article/bill-clinton-urges-democrats-work-harris-president-joy" target="_blank">loved “seeing all these young leaders.”</a></p>
+<p>On the first night, Biden, who dropped out of the race last month, <a href="https://www.newsfromthestates.com/article/biden-delivers-late-night-farewell-democrats-he-passes-torch-harris" target="_blank">delivered a farewell address to Democrats</a>, endorsing Harris. The Obamas Tuesday made the <a href="https://www.newsfromthestates.com/article/hope-making-comeback-obamas-make-case-kamala-harris" target="_blank">case for Harris,</a> saying in her candidacy, “hope is making a comeback.”</p>
+<p>As Harris gave her speech aimed at defining her candidacy and vision for the country as one of freedom and joy, <a href="https://www.newsfromthestates.com/article/frustrated-uncommitted-delegates-push-palestinian-american-speaker-dnc-nears-end" target="_blank">a sit-in protest occurred outside the United Center.</a> Dozens of Uncommitted delegates who advocated for a Palestinian American to have a speaking slot at the DNC said they had their request denied by the Harris campaign.</p>
+<p>Inside the arena, Harris said negotiating an end to the war, with a return of Israeli hostages and a lasting cease-fire, was a top administration priority.</p>
+<p>“President Biden and I are working to end this war, such that Israel is secure, the hostages are released, the suffering in Gaza ends and the Palestinian people can realize their right to dignity,” she said.</p>
+<p>At the watch party in Philadelphia, Alina Taylor, a special education teacher who lives in Upper Dublin, said as a Democratic committee person for her area, she plans to volunteer and canvass for the Harris campaign.</p>
+<p>“I came down here because I’m fired up and I’m ready to go,” she said.</p>
+<p>She said prior to Harris’ speech that she wants to hear her talk about the economy and what she plans on doing about reproductive rights.</p>
+<p>“That’s so huge, because I want my daughters to have more rights than me, and I don’t want them to have less,” she said.</p>
+<p><em>Pennsylvania Capital-Star reporter John Cole contributed to this report.</em></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Mayor&#8217;s opposition to cops using weed is &#8216;ruse&#8217; to boost campaign for governor, lawsuit says</title>
+		<link>https://newjerseymonitor.com/2024/08/22/mayor-opposes-cops-using-weed-as-ruse-to-boost-campaign-for-governor-lawsuit-says/</link>
+		
+		<dc:creator><![CDATA[Sophie Nieto-Munoz]]></dc:creator>
+		<pubDate>Thu, 22 Aug 2024 22:26:18 +0000</pubDate>
+				<category><![CDATA[Election 2025]]></category>
+		<category><![CDATA[Politics]]></category>
+		<category><![CDATA[Jersey City]]></category>
+		<category><![CDATA[Matt Platkin]]></category>
+		<category><![CDATA[Steve Fulop]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14447</guid>
+
+					<description><![CDATA[Jersey City Mayor Steve Fulop is fighting orders that he should reinstate cops his city fired for using cannabis.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2023/08/GettyImages-679470344.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/08/GettyImages-679470344.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/08/GettyImages-679470344-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/08/GettyImages-679470344-768x512.jpg 768w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Jersey City Mayor Steve Fulop is fighting orders that he should reinstate cops his city fired for using cannabis. (Photo by Dave Kotinsky/Getty Images for Liberty Science Center)</p><p>A lawyer is accusing Jersey City Mayor Steve Fulop of terminating cops for their off-duty cannabis consumption so he can get attention for his campaign for governor.</p>
+<p><a class="editor-rtfLink" href="https://newjerseymonitor.com/wp-content/uploads/2024/08/Reilly-v.-Jersey-City.pdf" target="_blank" rel="noopener"><span data-preserver-spaces="true">In a new legal filing</span></a><span data-preserver-spaces="true">, attorney Michael Rubas said Fulop’s move to fire cops for using legal cannabis in defiance of state law is a “ruse done solely to bring attention to him and to assist his gubernatorial campaign to the detriment of Jersey City employees as well as taxpayers who are now footing the bill of hundreds of thousands of dollars in back pay awards and attorney fees.”</span></p>
+<p><span data-preserver-spaces="true">Fulop is seeking the Democratic nomination for governor in 2025.</span></p>
+<p><span data-preserver-spaces="true">Rubas’ allegation comes in a wrongful termination lawsuit filed in Superior Court in Hudson County on behalf of one of the cops, Mackenzie Reilly, whom Jersey City fired in August 2023 when he tested positive for cannabis after a random drug screening. Last week, the state Civil Service Commission </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/briefs/jersey-city-loses-third-bid-to-fire-police-officer-for-using-cannabis/" target="_blank" rel="noopener"><span data-preserver-spaces="true">ordered the city to reinstate Reilly</span></a><span data-preserver-spaces="true">.</span></p>
+<p><span data-preserver-spaces="true">Jersey City officials have </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2023/10/17/jersey-city-sues-new-jersey-in-bid-to-halt-cops-from-using-cannabis/" target="_blank" rel="noopener"><span data-preserver-spaces="true">fired or suspended multiple cops</span></a><span data-preserver-spaces="true"> for using regulated cannabis off duty, arguing that officers who use cannabis are violating federal law and cannot carry a firearm or ammunition.</span></p>
+<p><span data-preserver-spaces="true">The city has lost this battle involving three different cops, but the city has refused to relent. The Civil Service Commission has also ordered the city to rehire officers Norhan Mansour and Omar Polanco, who were also terminated for using regulated cannabis while off duty, but the city has not done so.</span></p>
+<p><span data-preserver-spaces="true">Under the state’s recreational marijuana legalization law, signed by Gov. Phil Murphy in 2021, police officers are allowed to use cannabis if they’re not on duty, per a 2022 memo from Attorney General Matt Platkin.</span></p>
+<p><span data-preserver-spaces="true">But Jersey City’s public safety director, James Shea, sued the state over this issue, arguing </span><span data-preserver-spaces="true">that it flies in the face of a federal law that bars people who use cannabis from owning guns or ammunition. </span></p>
+<p><span data-preserver-spaces="true">According to the latest complaint, before the city implemented its “unlawful policy,” city officials had a conference call with the state Attorney General’s Office where they were told that cops can’t be disciplined for using legal cannabis. During that call, Jersey City officials “openly conspired to violate the law,” the complaint states. </span></p>
+<p><span data-preserver-spaces="true">Six days after Fulop announced Jersey City’s policy that cops cannot use cannabis, Fulop received an email from a political operative who sent him a Politico New Jersey article about the issue — “South Jersey Democrats request ‘clarification’ from Platkin on cannabis and cops memo” —  and five minutes later, Fulop sent an email to Shea saying, “Little revolt we started.” </span></p>
+<p><span data-preserver-spaces="true">Rubas’ legal filing calls that comment “flippant.”</span></p>
+<p><span data-preserver-spaces="true">City spokeswoman Kimberly Wallace-Scalcione said it is “silly” to accuse Fulop of playing political games, adding the city is following federal policy.</span></p>
+<p><span data-preserver-spaces="true">“Most people would agree with the administration that police officers should not be coming to work stoned,” she said in a statement. </span></p>
+<p><span data-preserver-spaces="true">Reilly was first suspended without pay in March 2023 and fired Aug. 25, 2023, the complaint says, in an “arrogant and condescending” disciplinary order from Shea, who failed to acknowledge the state constitution, the state’s marijuana legalization law, or the attorney general’s memo. </span></p>
+<p><span data-preserver-spaces="true">At one point, Jersey City officials announced to the entire department that Reilly was guilty of serious misconduct that warranted termination, which the complaint says gave Reilly’s coworkers the false impression he was “derelict in his employment.” </span></p>
+<p><span data-preserver-spaces="true">By not rehiring Reilly, the city is acting in a “willful and malicious manner with immoral purpose to injure and cause harm,” the complaint says.</span></p>
+<p><span data-preserver-spaces="true">“This constitutional right to possess and consume regulated cannabis is granted to all New Jersey citizens, including Jersey City Police Officers,” it says. </span></p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Prosecutors prod judge for hearing in bribery case of ex-senator&#8217;s wife</title>
+		<link>https://newjerseymonitor.com/briefs/prosecutors-prod-judge-for-hearing-in-bribery-case-of-ex-senators-wife/</link>
+		
+		<dc:creator><![CDATA[Dana DiFilippo]]></dc:creator>
+		<pubDate>Thu, 22 Aug 2024 20:02:38 +0000</pubDate>
+				<category><![CDATA[Criminal Justice]]></category>
+		<category><![CDATA[Menendez on trial]]></category>
+		<category><![CDATA[Bob Menendez]]></category>
+		<category><![CDATA[Damian Williams]]></category>
+		<category><![CDATA[Nadine Menendez]]></category>
+		<category><![CDATA[Sidney H. Stein]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14445</guid>
+
+					<description><![CDATA[Federal prosecutors have asked for a Dec. 9 hearing in the bribery case against former Sen. Bob Menendez's wife Nadine.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="576" src="https://newjerseymonitor.com/wp-content/uploads/2023/10/IMG_5991-1024x576.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/10/IMG_5991-1024x576.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/10/IMG_5991-300x169.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/10/IMG_5991-768x432.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2023/10/IMG_5991-1536x864.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2023/10/IMG_5991-2048x1152.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Nadine Menendez leaves the Southern District of New York courthouse Oct. 2 after attorneys held a trial conference. (Sophie Nieto-Muñoz for New Jersey Monitor)</p><p><span data-preserver-spaces="true">Federal prosecutors have asked a judge to schedule a hearing in Nadine Menendez’s bribery case, hinting they’d welcome a plea deal.</span></p>
+<p><span data-preserver-spaces="true">In </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/wp-content/uploads/2024/08/8-22-24-N.-Menendez-speedy-trial-letter.pdf" target="_blank" rel="noopener"><span data-preserver-spaces="true">a letter</span></a><span data-preserver-spaces="true"> to Judge Sidney H. Stein made public on Thursday, U.S. Attorney Damian Williams said a trial for Nadine Menendez would be similarly long, “or only modestly shorter,” as the 10-week trial her husband and co-defendant, former Sen. Bob Menendez, endured earlier this year. Her trial had been indefinitely postponed to accommodate her medical treatment for breast cancer.</span></p>
+<p><span data-preserver-spaces="true">In the heavily redacted letter, Williams asked Stein to set a scheduling hearing on Dec. 9 and exclude the delay under a federal law that guarantees criminal defendants the right to a speedy trial. </span><span data-preserver-spaces="true">That date would give defense attorneys a chance “to review the voluminous discovery in this complex case and to engage in discussions with the Government concerning a possible disposition of this matter,” Williams wrote.</span></p>
+<p>Stein agreed to the request, and directed both sides to clear their trial calendars for January and February to accommodate a trial. He also directed defense attorneys to file an update from Nadine Menendez&#8217;s doctors by Nov. 22.</p>
+<p><span data-preserver-spaces="true">If the case does go to trial, prosecutors could introduce evidence of “her consciousness of guilt,” Williams warned. He did not specify what that evidence is, but noted it wasn’t introduced in Bob Menendez&#8217;s trial.</span></p>
+<p><span data-preserver-spaces="true">Nadine Menendez is charged with 15 federal crimes in a six-year corruption scheme that earned her husband and three business associates </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/07/16/sen-menendez-convicted-of-bribery-other-charges-in-corruption-trial/" target="_blank" rel="noopener"><span data-preserver-spaces="true">felony convictions last month.</span></a></p>
+<p><span data-preserver-spaces="true">Prosecutors </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/05/28/prosecutors-say-messages-between-sen-menendez-wife-reveal-details-of-egypt-focused-scheme/" target="_blank" rel="noopener"><span data-preserver-spaces="true">have said</span></a><span data-preserver-spaces="true"> she began injecting herself into her husband’s political doings just weeks after they began dating in 2018, becoming the </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/05/29/men-accused-of-bribing-sen-menendez-had-to-keep-nadine-happy-trial-testimony-shows/" target="_blank" rel="noopener"><span data-preserver-spaces="true">go-between</span></a><span data-preserver-spaces="true"> linking Bob Menendez to the men who gave them cash, gold bars, a luxury car, and other valuables for political favors. Bob Menendez&#8217;s defense team </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/05/15/did-he-take-bribes-or-was-he-duped-by-his-wife-arguments-under-way-in-menendez-trial/" target="_blank" rel="noopener"><span data-preserver-spaces="true">blamed his wife</span></a><span data-preserver-spaces="true"> for his troubles, saying she took money and made deals without his knowledge.</span></p>
+<p><span data-preserver-spaces="true">On Tuesday, the day before he resigned from the Senate, Menendez and his co-defendants Wael Hana and Fred Daibes </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/08/20/menendez-lawyers-ask-judge-to-reverse-his-unjust-conviction-in-international-bribery-scheme/" target="_blank" rel="noopener"><span data-preserver-spaces="true">asked Stein</span></a><span data-preserver-spaces="true"> to reverse their convictions.</span></p>
+    <a href="https://newjerseymonitor.com/donate" style="text-decoration:none;">
+    <div class="donateContainer">
+        <div class="donateTextContainer">
+            <p>SUPPORT NEWS YOU TRUST.</p>
+        </div>
+        <div class="donateButtonContainer">
+            <button>DONATE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>State to require mental health experts to accompany cops in barricade situations</title>
+		<link>https://newjerseymonitor.com/2024/08/22/state-to-require-mental-health-experts-to-accompany-cops-in-barricade-situations/</link>
+		
+		<dc:creator><![CDATA[Dana DiFilippo]]></dc:creator>
+		<pubDate>Thu, 22 Aug 2024 18:24:52 +0000</pubDate>
+				<category><![CDATA[Criminal Justice]]></category>
+		<category><![CDATA[Social Justice]]></category>
+		<category><![CDATA[Amber Reed]]></category>
+		<category><![CDATA[Matt Platkin]]></category>
+		<category><![CDATA[Victoria Lee]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14439</guid>
+
+					<description><![CDATA[Police in New Jersey will soon have to bring supervisors and mental health experts on barricade calls, the A.G. announced.]]></description>
+																						<content:encoded><![CDATA[<img width="799" height="533" src="https://newjerseymonitor.com/wp-content/uploads/2023/11/53332821839_7c0e9ba7df_c.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/11/53332821839_7c0e9ba7df_c.jpg 799w, https://newjerseymonitor.com/wp-content/uploads/2023/11/53332821839_7c0e9ba7df_c-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/11/53332821839_7c0e9ba7df_c-768x512.jpg 768w" sizes="(max-width: 799px) 100vw, 799px" /><p style="font-size:12px;">Attorney General Matt Platkin on Aug. 22, 2024, expanded the state's use of force policy for police encounters with people in barricade situations. (Courtesy of the Attorney General's Office)</p><p style="font-weight: 400;">New Jersey Attorney General Matt Platkin issued <a href="https://www.nj.gov/oag/dcj/agguide/directives/ag-Directive-2024-04_Adopting-Barricaded-Individual-Policy.pdf" target="_blank">a new directive Thursday</a> intended to “slow and stabilize” encounters between New Jersey police and barricaded people.</p>
+<p style="font-weight: 400;">Under the new directive, police will be required to bring a mental health professional when they respond to barricaded people, wait instead of forcing their way inside, bring less lethal weapons like Tasers to such calls, and immediately involve a supervisor.</p>
+<p>The changes come three weeks after police busted into an apartment in Fort Lee, where a woman in mental crisis was barricaded inside, and shot her to death in an encounter that has <a href="https://newjerseymonitor.com/2024/08/15/renewed-calls-for-action-on-mental-health-after-police-shoot-and-kill-fort-lee-woman/">sparked protests.</a> The family of Victoria Lee, 25, had called 911 for help and repeatedly asked that no police come or enter their home, but officers entered anyway and one shot Lee when she threw a water jug at them (police say she had a knife). Lee joins a dismal list of several people who police in New Jersey have killed in recent years in barricade situations, resulting in <a href="https://newjerseymonitor.com/2024/08/21/jersey-city-sued-over-police-killing-of-man-suffering-mental-health-crisis/">lawsuits</a> and <a href="https://newjerseymonitor.com/2023/03/27/n-j-attorney-general-announces-state-takeover-of-paterson-police-department/">protests.</a></p>
+<p style="font-weight: 400;">Platkin said he first directed his staff draft changes to make police encounters with barricaded people safer in March 2023, three weeks after Paterson police <a href="https://newjerseymonitor.com/2023/03/16/video-911-calls-released-in-fatal-police-shooting-of-patersons-najee-seabrooks/">gunned down</a> advocate Najee Seabrooks after he barricaded himself in a bathroom during a mental crisis. The directive announced Thursday, with changes made in consultation with mental health professionals, community members, and faith leaders, expands the state’s existing use-of-force policy.</p>
+<p style="font-weight: 400;">“Encounters involving barricaded individuals are often difficult and high risk, regularly involving individuals in the midst of crisis who are armed,” Platkin said in a statement. “Our goal is to provide first responders with the tools to slow and stabilize these standoffs, empowering officers to navigate the dangerous first minutes of these encounters, so proper resources can be deployed to intervene and resolve the situations safely without force, significant injuries, or death.”</p>
+<p style="font-weight: 400;">Under the new directive, police responding to a barricade call must bring mental health professionals, in addition to crisis negotiators. The mental health professionals will train with law enforcement at least quarterly and be available around the clock to monitor communications with the barricaded person and offer advice and assistance to resolve the situation peacefully. It’s unclear when this change will be implemented, because Platkin noted it will take time to ensure “adequate staffing and resource availability.”</p>
+<p><span data-preserver-spaces="true">Other changes, set to take effect in October, include:</span></p>
+<ul>
+<li><span data-preserver-spaces="true">Responding officers must wait for mental health professionals to respond, establish a perimeter, and begin communicating with the barricaded person — but not try to force a resolution “unless that would be immediately necessary to prevent injury or death.”</span></li>
+<li><span data-preserver-spaces="true">In situations where police involvement poses “unreasonable risk,” officers should leave, delay contact, or return at a different time and under different circumstances. Agencies must consider using community-based crisis response teams groups to help de-escalate encounters.</span></li>
+<li><span data-preserver-spaces="true">An on-duty supervisor must immediately respond to barricade situations, take command, and summon a tier 1 or tier 2 SWAT tactical team, which have more personnel and experience in hostages and barricade situations.</span></li>
+<li><span data-preserver-spaces="true">Tactical teams must be equipped with less lethal weapons, such as stun guns and “impact munitions,” like bean </span><span data-preserver-spaces="true">bag</span><span data-preserver-spaces="true"> or rubber projectiles.</span></li>
+</ul>
+<figure id="attachment_14335" class="wp-caption aligncenter" style="max-width:100%;width:2560px;"><a href="https://newjerseymonitor.com/victoria-lee-3/"><img decoding="async" loading="lazy" class="wp-image-14335 size-full" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/Victoria-Lee-3-scaled.jpg" alt="" width="2560" height="1920" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/Victoria-Lee-3-scaled.jpg 2560w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Victoria-Lee-3-300x225.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Victoria-Lee-3-1024x768.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Victoria-Lee-3-768x576.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Victoria-Lee-3-1536x1152.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Victoria-Lee-3-2048x1536.jpg 2048w" sizes="(max-width: 2560px) 100vw, 2560px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Amber Reed, co-executive of AAPI New Jersey, called on officials to swiftly investigate the police shooting of Victoria Lee. (Sophie Nieto-Munoz | New Jersey Monitor)</em></p></figure>
+<p style="font-weight: 400;">The changes drew lukewarm praise from some still mourning Lee’s death.</p>
+<p style="font-weight: 400;">The true test of their value will come in implementation, said Amber Reed, co-executive director of AAPI New Jersey.</p>
+<p style="font-weight: 400;">“It&#8217;s very clear this policy is saying the best practice is not to break down the door within a minute and go in shooting. It says things like time is your ally, and talks about how to bring in mental health professionals to help the de-escalate the interaction,” Reed said. “But there was already good guidance in the use of force directive that the officers’ actions did not reflect. So how do you operationalize this? Can you do more regular audits to make sure that these policies, which are fundamentally good policies, are being complied with in the field?”</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>New Jerseyans, know your fair housing disability rights</title>
+		<link>https://newjerseymonitor.com/2024/08/22/new-jerseyans-know-your-fair-housing-disability-rights/</link>
+		
+		<dc:creator><![CDATA[Joseph Batista]]></dc:creator>
+		<pubDate>Thu, 22 Aug 2024 10:51:03 +0000</pubDate>
+				<category><![CDATA[Commentary]]></category>
+		<category><![CDATA[Housing]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14434</guid>
+
+					<description><![CDATA[Many people with disabilities — and housing providers — are not aware of what accommodations are protected under the federal Fair Housing Act.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/Cornerstone_at_Seaside_Heights-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/Cornerstone_at_Seaside_Heights-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Cornerstone_at_Seaside_Heights-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Cornerstone_at_Seaside_Heights-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Cornerstone_at_Seaside_Heights-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Cornerstone_at_Seaside_Heights.jpg 1680w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Many people with disabilities — and housing providers — are not aware of what accommodations are protected under the federal Fair Housing Act. (Courtesy of the New Jersey Department of Community Affairs)</p><p><span data-preserver-spaces="true">Everyone should be treated fairly by housing providers, whether you’re seeking to rent, lease, or purchase a property. But the sad fact remains that housing discrimination does occur. Anyone who has been discriminated against because of their race, color, familial status, disability, national origin, religion, sex, or other protected class under federal and state fair housing laws is entitled to help.</span></p>
+<p><span data-preserver-spaces="true">As someone who works for a US Department of Housing and Urban Development-designated fair housing investigation agency, I help provide fair housing counseling for people who have faced housing discrimination, guidance for filing housing discrimination complaints, recommendations for navigating the legal process, and when needed, referrals to government agencies and attorneys.</span></p>
+<p><span data-preserver-spaces="true">Some of the incidents referred to us are incidents the general public may be aware of. People of color and families with children, for example, are sometimes told by housing providers there are no apartments available for rent when the opposite is true.</span></p>
+<p><span data-preserver-spaces="true">But an increasing number of fair housing incidents involve people with disabilities. This is driven in part by many people with disabilities — and housing providers — not being aware of what accommodations are protected under the federal Fair Housing Act.</span></p>
+<p><span data-preserver-spaces="true">    <h4 class="editorialSubhed">Fair Housing accommodations</h4>
+
+	</span></p>
+<p><span data-preserver-spaces="true">When searching for rental properties, people with disabilities have the right to ask housing providers for available dwellings on the first floor of a building. Housing providers can only lawfully refuse this if all dwellings on the first floor are already rented out to other tenants.</span></p>
+<p><span data-preserver-spaces="true">People with disabilities are also allowed to have a live-in emotional support animal with them, even in rental properties that don’t allow pets. Note that these are not “special” pets; they are professionally trained, certified emotional support animals who work with people with disabilities.</span></p>
+<p><span data-preserver-spaces="true">Once situated in a rental property, people with disabilities can ask their landlord to make reasonable physical modifications to help accommodate their needs. This can include changes to door sizes and bathroom fixtures and the addition of ramps. What’s considered “reasonable” depends on many factors, including when the property was built and the cost and time involved with modifications. This is decided on a case-by-case basis.</span></p>
+<p><span data-preserver-spaces="true">People with auto-immune disabilities, who can be particularly vulnerable to infection, can request that maintenance and repair personnel wear protective gear such as masks when working in their living space.</span></p>
+<p><span data-preserver-spaces="true">    <h4 class="editorialSubhed">Tips for renters with disabilities</h4>
+
+	</span></p>
+<p><span data-preserver-spaces="true">Many people with disabilities are understandably reluctant to share specifics about their conditions with housing providers. We recommend that people who need accommodations take the following steps to help navigate the housing and rental market:</span></p>
+<ul>
+<li><span data-preserver-spaces="true">Develop a relationship with a medical professional who can provide written certification about your disability or disabilities. That document won’t disclose your condition, just certify that you are protected under law and can be helped with specific reasonable accommodations (a support animal, a physical modification to a dwelling, etc.). The medical professional can be a doctor, nurse, therapist — anyone with the appropriate training who can certify your condition.</span></li>
+<li><span data-preserver-spaces="true">Research any prospective rental property. The Fair Housing Act requires that new multifamily housing (both for rent and for sale) with four or more dwelling units built for initial occupancy after March 13, 1991, be designed and built to contain at least a minimum level of accessibility features for persons with disabilities. Physical modifications you request at these properties may not be classified as reasonable due to the work and expense involved.</span></li>
+</ul>
+<p><span data-preserver-spaces="true">If you have any questions about this process or feel you have been discriminated against, HUD-designated fair housing investigation agencies such as <a href="https://www.njcitizenaction.org" target="_blank" rel="noopener">New Jersey Citizen Action</a> are here to help.</span></p>
+<p>To contact New Jersey Citizen Action about fair housing issues and discrimination call us at 732-246-4772 ext. 115 or email us at <b><u><a id="m_3657256021550559367OWA2b186733-3e28-07c7-ab90-f3f33d33084a" href="mailto:fhintake@njcitizenaction.org" target="_blank" rel="noopener">fhintake@njcitizenaction.org.</a></u></b> To find other HUD-designated fair housing investigation agencies and learn more about fair housing visit <a href="http://www.hud.gov/fairhousing" target="_blank" rel="noopener" data-saferedirecturl="https://www.google.com/url?q=http://www.hud.gov/fairhousing&amp;source=gmail&amp;ust=1724414445082000&amp;usg=AOvVaw18UNbkQsn9-kQcaya8EizY">www.hud.gov/fairhousing</a>.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>A former high school football coach rises to running mate as Walz accepts VP nomination</title>
+		<link>https://newjerseymonitor.com/2024/08/22/a-former-high-school-football-coach-rises-to-running-mate-as-walz-accepts-vp-nomination/</link>
+		
+		<dc:creator><![CDATA[Jacob Fischler]]></dc:creator>
+		<pubDate>Thu, 22 Aug 2024 10:38:46 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Kamala Harris]]></category>
+		<category><![CDATA[Tim Walz]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14429</guid>
+
+					<description><![CDATA[A native of a small town in Nebraska, Minnesota Gov. Tim Walz is a former high school teacher, coach and Army National Guardsman.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/WalzDNC-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/WalzDNC-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/WalzDNC-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/WalzDNC-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/WalzDNC-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/WalzDNC-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">CHICAGO, ILLINOIS - AUGUST 21:  Democratic vice presidential nominee Minnesota Gov. Tim Walz reacts after accepting the vice presidential nomination during the third day of the Democratic National Convention at the United Center on August 21, 2024 in Chicago, Illinois. Delegates, politicians, and Democratic Party supporters are in Chicago for the convention, concluding with current Vice President Kamala Harris accepting her party's presidential nomination. The DNC takes place from August 19-22.   (Photo by Joe Raedle/Getty Images)</p><p>CHICAGO — Minnesota Gov. Tim Walz accepted the Democratic nomination for vice president Wednesday, showcasing his appeal on the third night of the Democratic National Convention as a candidate who can fuse a middle-class image to a fairly progressive record and effectively attack the Republican alternative.</p>
+<p>A native of a small town in Nebraska, Walz is a former high school teacher, coach and Army National Guardsman whom presidential nominee Vice President Kamala Harris chose just a little more than two weeks ago as her running mate.</p>
+<p>In his speech to delegates packed into the United Center, an introduction to millions of Americans, Walz made the case that Democrats’ policies were the ones more consistent with heartland values than those of Republicans, led by the presidential ticket of former President Donald Trump and Ohio Sen. J.D. Vance.</p>
+<p>“This is a big part about what this election is about: freedom,” he said.</p>
+<p>Republicans invoke freedom to pass restrictions on reproductive rights, allow corporations to pollute and permit banks to take advantage of customers, he said.</p>
+<p>“But when we Democrats talk about freedom, we mean the freedom to make a better life for yourself and the people that you love, to make your own health care decisions, your kids to go to school without worrying about being shot dead,” he said.</p>
+    <h4 class="editorialSubhed">Coach Walz</h4>
+
+	
+<p>A night after former President Barack Obama attested to Walz’s authentic style by lightly mocking his worn flannel shirts, other speakers sought to brandish Walz’s image as a stereotypically sensible Upper Midwesterner.</p>
+<p>Minnesota’s senior Sen. Amy Klobuchar and Benjamin Ingman, a former student and next-door neighbor of Walz’s, introduced the vice-presidential candidate.</p>
+<p>“Tim Walz is the kind of the guy you can count on to push you out of a snowbank,” Ingman said, referring to the neighborly chore of freeing a vehicle stuck after a heavy snow. “I know this because Tim Walz pushed me out of a snowbank.”</p>
+<p>While Ingman spoke, former members of Walz-coached football teams took the stage, wearing red-and-white Mankato West High School football jerseys.</p>
+<p>Klobuchar praised Walz’s progressive policy wins as governor — signing laws to guarantee paid leave, provide school meals and cut taxes for families.</p>
+<p>She also made note of Walz’s folksy appeal and humble background that is unusual at the highest levels of U.S. politics.</p>
+<p>“A former football coach knows how to level the playing field,” Klobuchar said. “And a former public school teacher knows how to school the likes of J.D. Vance.”</p>
+    <h4 class="editorialSubhed">Freedom theme</h4>
+
+	
+<p>Walz argued that Democrats sought to expand freedom, a central theme of the Harris campaign, while Republicans worked to limit rights.</p>
+<p>He mentioned fertility treatments, which he and his wife, Gwen, used to conceive their two children. After the U.S. Supreme Court repealed the nationwide right to an abortion, some Republicans have also opposed in vitro fertilization, a common fertility treatment. Gwen Walz clarified this week that the Walzes used a different fertility treatment that is not as controversial with anti-abortion advocates.</p>
+<p>Still, Walz said the pain of infertility was “hell,” and in an emotional moment, he acknowledged Gwen and children Hope and Gus in the crowd, telling them they were his “entire world.”</p>
+<p>The crowd cheered as the Walz family’s emotion-filled faces appeared on the screens in the United Center.</p>
+<p>Walz promoted his record as governor, including the free school meals program and an expansion of reproductive rights, and framed them as in line with traditional American values.</p>
+<p>“While other states were banning books from their schools, we were banishing hunger from ours,” he said. “We also protected reproductive freedom because in Minnesota, we respect our neighbors and the choices they make. Even if we wouldn’t make those same choices for ourselves, we’ve got a golden rule: Mind your own damn business.”</p>
+<figure id="attachment_14432" class="wp-caption aligncenter" style="max-width:100%;width:1024px;"><a href="https://newjerseymonitor.com/2024/08/22/a-former-high-school-football-coach-rises-to-running-mate-as-walz-accepts-vp-nomination/2024-democratic-national-convention-day-3-3/" rel="attachment wp-att-14432"><img decoding="async" loading="lazy" class="wp-image-14432 size-full" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167853711.jpg" alt="" width="1024" height="683" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167853711.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167853711-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167853711-768x512.jpg 768w" sizes="(max-width: 1024px) 100vw, 1024px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  CHICAGO, ILLINOIS &#8211; AUGUST 21: Democratic vice presidential candidate Minnesota Gov. Tim Walz embraces his son Gus Walz (C) as his daughter Hope Walz (R) looks on after speaking on stage during the third day of the Democratic National Convention at the United Center on August 21, 2024 in Chicago, Illinois. Delegates, politicians, and Democratic Party supporters are in Chicago for the convention, concluding with current Vice President Kamala Harris accepting her party&#8217;s presidential nomination. The DNC takes place from August 19-22. (Photo by Kevin Dietsch/Getty Images)</p></figure>
+    <h4 class="editorialSubhed">Project 2025</h4>
+
+	
+<p>Walz blasted the Republican agenda, including the 900-plus page proposal published by the conservative think tank the Heritage Foundation.</p>
+<p>Republicans, including the Trump campaign, have sought to distance themselves from the document, which includes several provisions that Democrats have been eager to criticize.</p>
+<p>Walz said it showed Republicans would gut Social Security and Medicare, repeal the popular health care law known as Obamacare and restrict abortion nationwide.</p>
+<p>He characterized Republicans as out of touch, extreme and — and he has for weeks — weird.</p>
+<p>“It’s an agenda that served nobody except the richest and the most extreme amongst us, and it’s an agenda that does nothing for our neighbors in need,” he said. “Is it weird? Absolutely.”</p>
+<p>Walz sought to position Democrats as the party of common sense, including on guns.</p>
+<p>As a veteran and hunter, Walz was familiar with guns and supportive of gun rights. But he suggested there must be limits that many Republicans do not accept.</p>
+<p>“I believe in the Second Amendment,” he said. “But I also believe our first responsibility is to keep our kids safe.”</p>
+    <h4 class="editorialSubhed">Call to action</h4>
+
+	
+<p>As president, he said, Harris would lower middle-class taxes, rein in drug costs and “stand up and fight for your freedom to live the life that you want to lead.”</p>
+<p>Using another mainstay of his campaign speeches, Walz urged the Democratic delegates in the audience to work tirelessly until Election Day.</p>
+<p>Walz’s acceptance pumped up the group of Democratic delegates from Minnesota, who stayed for roughly 30 minutes after the program ended on the United Center floor chanting “U-S-A,” “Harris-Walz,” “Minnesota” and other cheers.</p>
+<p>In another ode to his state, musicians John Legend and Sheila E. performed “Let’s Go Crazy” by Minnesota native Prince before Walz took the stage.</p>
+    <h4 class="editorialSubhed">Oprah endorsement</h4>
+
+	
+<p>Just before the odes to Walz began, TV talk show legend Oprah Winfrey, whose show was broadcast from Chicago for decades, made a surprise appearance on the convention stage.</p>
+<p>Winfrey made the case for Harris as a barrier-breaking candidate and a deeply decent person.</p>
+<p>Winfrey, who has backed every Democratic presidential candidate since Obama in 2008 but said she remains an independent voter, urged undecided voters to base their votes on the candidates’ character.</p>
+<p>“Decency and respect are on the ballot in 2024,” she said. “And just plain common sense. Common sense tells you that Kamala Harris and Tim Walz can give us decency and respect.”</p>
+<p>She criticized Republicans under Trump.</p>
+<p>“Let us choose loyalty to the Constitution instead of loyalty to a single person,” she said</p>
+<p>She appealed for an inclusive vision of politics, rejecting Vance’s dismissive description of some Democratic voters as “childless cat ladies.”</p>
+<p>“Despite what some would have you think, we are not so different from our neighbors,” she said. “When a house is on fire, we don’t ask about the homeowner’s race or religion. We don’t wonder who their partner is or how they voted, no. We just try to do the best we can to save them. And if the place happens to belong to a childless cat lady, well, we try to get that cat out too.”</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Rep. Andy Kim recalls Jan. 6. clean-up effort at Democratic convention in Chicago</title>
+		<link>https://newjerseymonitor.com/briefs/rep-andy-kim-recalls-jan-6-clean-up-effort-at-democratic-convention-in-chicago/</link>
+		
+		<dc:creator><![CDATA[Mark J. Bonamo]]></dc:creator>
+		<pubDate>Thu, 22 Aug 2024 03:57:32 +0000</pubDate>
+				<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Politics]]></category>
+		<category><![CDATA[Andy Kim]]></category>
+		<category><![CDATA[Jan. 6]]></category>
+		<category><![CDATA[Trend – Election 2024]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14427</guid>
+
+					<description><![CDATA[The Democratic National Convention gave Democrat Rep. Andy Kim a chance to introduce himself to a national audience as he seeks a U.S. Senate seat in November.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167841291.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167841291.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167841291-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167841291-768x512.jpg 768w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">CHICAGO, ILLINOIS - AUGUST 21:  U.S. Rep. Andy Kim (D-NJ) speaks on stage during the third day of the Democratic National Convention at the United Center on August 21, 2024 in Chicago, Illinois. Delegates, politicians, and Democratic Party supporters are in Chicago for the convention, concluding with current Vice President Kamala Harris accepting her party's presidential nomination. The DNC takes place from August 19-22.   (Photo by Chip Somodevilla/Getty Images)</p><p style="font-weight: 400;">Twenty years after he graduated from the University of Chicago, Rep. Andy Kim returned to the Windy City Wednesday as part of a group of speakers at the Democratic National Convention who made the Jan. 6, 2021, riot at the U.S. Capitol a focal point of the convention’s third day.</p>
+<p style="font-weight: 400;">In a <a href="https://www.youtube.com/watch?v=EJDgX2C89LM" target="_blank">speech that lasted just under three minutes</a>, Kim (D-03) discussed his efforts to clear the Capitol Rotunda of debris after it was ransacked by supporters of then-President Donald Trump. The convention gave Kim a chance to introduce himself to a national audience as he seeks a U.S. Senate seat in November.</p>
+<p style="font-weight: 400;">Kim said when he was a child, his Korean immigrant parents brought him to the Capitol and taught him the building is “sacred ground, a symbol of democracy.” But on Jan. 6, he said, “we saw something unimaginable — a mob tearing down flags, assaulting police officers.”</p>
+<p>“The floor was covered in broken glass and garbage, strewn with the chaos unleashed by Donald Trump. And I thought to myself, how did it get this bad? So I did the only thing I could think of — I grabbed a trash bag and started cleaning up,” he said.</p>
+<p style="font-weight: 400;">Kim has evoked the Jan. 6 riot frequently on the campaign trail, as well as his clean-up effort that <a href="https://www.nbcnews.com/news/asian-america/year-viral-photo-rep-andy-kim-reflects-caretaker-democracy-rcna11068" target="_blank">garnered him national attention</a>.</p>
+<p style="font-weight: 400;">“What I learned on January 6 is that all of us are caretakers for our great republic. We can heal this country, but only if we try,” Kim said Wednesday. “Always remember, this chaos that we see, it doesn’t have to be this way.”</p>
+<p style="font-weight: 400;"><a href="https://newjerseymonitor.com/2024/06/04/rep-andy-kim-projected-to-win-democratic-nod-for-u-s-senate/" target="_blank" rel="noopener">Kim faces Republican hotelier Curtis Bashaw in November</a> in a race to succeed Sen. Bob Menendez, a Democrat who resigned in disgrace from the Senate Tuesday following his <a href="https://newjerseymonitor.com/2024/07/16/sen-menendez-convicted-of-bribery-other-charges-in-corruption-trial/" target="_blank" rel="noopener">conviction last month on federal corruption charges</a>. Menendez had intended to seek reelection as an independent in November, but suspended that campaign last week.</p>
+<p>Kim ended his speech by calling on the crowd and the country to support the Democratic presidential ticket, Vice President Kamala Harris and Minnesota Gov. Tim Walz.</p>
+<p>“There is a hunger right now in this country for a new generation of leadership to step up. Let’s choose Kamala Harris and Tim Walz. Let’s do this for our kids and our grandkids,” he said.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>With Bob Menendez gone from Senate, ethics panel ends probe of his misconduct</title>
+		<link>https://newjerseymonitor.com/briefs/with-bob-menendez-gone-from-senate-ethics-panel-ends-probe-of-his-misconduct/</link>
+		
+		<dc:creator><![CDATA[Sophie Nieto-Munoz]]></dc:creator>
+		<pubDate>Wed, 21 Aug 2024 21:33:42 +0000</pubDate>
+				<category><![CDATA[Menendez on trial]]></category>
+		<category><![CDATA[Politics]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14422</guid>
+
+					<description><![CDATA[The leaders of the U.S. Senate’s ethics committee said they can only investigate sitting members of Congress. Bob Menendez resigned from the Senate Tuesday.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2023/12/GettyImages-1771185847.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/12/GettyImages-1771185847.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/12/GettyImages-1771185847-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/12/GettyImages-1771185847-768x512.jpg 768w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">The leaders of the U.S. Senate’s ethics committee said they can only investigate sitting members of Congress. Bob Menendez resigned from the Senate Tuesday. (Photo by Anna Moneymaker/Getty Images)</p><p><span data-preserver-spaces="true">The U.S. Senate’s ethics committee has halted its investigation into former Sen. Bob Menendez now that Menendez has resigned from the Senate. </span></p>
+<p><span data-preserver-spaces="true">Menendez’s resignation took effect Tuesday, and the committee can only investigate sitting members of the Senate, Sens. Chris Coons (D-Delaware) and James Lankford (R-Oklahoma) </span><span data-preserver-spaces="true">said in a statement Wednesday</span><span data-preserver-spaces="true">. </span></p>
+<p><span data-preserver-spaces="true">“As such, the Committee has lost jurisdiction for its adjudicatory review and has closed this matter,” said the senators, who oversee the committee. </span></p>
+<p><span data-preserver-spaces="true">Menendez was </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/07/16/sen-menendez-convicted-of-bribery-other-charges-in-corruption-trial/" target="_blank" rel="noopener"><span data-preserver-spaces="true">convicted in federal court in July of 16 counts</span></a><span data-preserver-spaces="true">, including bribery, extortion, wire fraud, acting as a foreign agent, and obstruction of justice. He has maintained his innocence and </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/08/20/menendez-lawyers-ask-judge-to-reverse-his-unjust-conviction-in-international-bribery-scheme/" target="_blank" rel="noopener"><span data-preserver-spaces="true">vows to appeal</span></a><span data-preserver-spaces="true">. </span></p>
+<p><span data-preserver-spaces="true">The six-member committee said in July that it had launched its investigation after Menendez was indicted in September 2023 and accused of accepting bribes in exchange for wielding his political power. After the 10-week trial concluded and Menendez was found guilty on all counts, the committee said it </span><a class="editor-rtfLink" href="https://www.ethics.senate.gov/public/_cache/files/6910db8a-d6a4-44a8-b2d5-473a9215cdf0/select-committee-on-ethics---press-release-july-16-2024.pdf" target="_blank" rel="noopener"><span data-preserver-spaces="true">would complete its investigation</span></a> and &#8220;consider the full range of disciplinary actions.&#8221;</p>
+<p><span data-preserver-spaces="true">The committee admonished Menendez in 2018 after his previous corruption trial — where he was accused of accepting gifts from a Florida eye doctor in exchange for political favors  — ended when the jury deadlocked. </span></p>
+<p><span data-preserver-spaces="true">In the </span><a class="editor-rtfLink" href="https://www.ethics.senate.gov/public/_cache/files/49c12c75-7a26-4fe6-b070-19fcef4d7532/senator-robert-menendez---public-letter-of-admonition.pdf" target="_blank" rel="noopener"><span data-preserver-spaces="true">four-page letter released in April 2018</span></a><span data-preserver-spaces="true">, the committee ordered Menendez to repay the value of all the gifts he received from his codefendant, Dr. Salomon Melgen. Over six years, the committee said, Menendez failed to disclose the value of the gifts on disclosure reports as required by Senate rules and federal law. </span></p>
+
+<p><span data-preserver-spaces="true">On Monday, Menendez and two of his codefendants, who were also found guilty on all counts, asked the judge who oversaw their trial to <a href="https://newjerseymonitor.com/2024/08/20/menendez-lawyers-ask-judge-to-reverse-his-unjust-conviction-in-international-bribery-scheme/" target="_blank" rel="noopener">reverse the guilty verdicts</a> and order a new trial.</span></p>
+<p><span data-preserver-spaces="true">Menendez, who last week announced he would no longer seek reelection in November as an independent candidate, </span><span data-preserver-spaces="true">is scheduled to be sentenced Oct. 29. </span></p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Rep. Bill Pascrell, feisty Democrat from Paterson, dies at 87</title>
+		<link>https://newjerseymonitor.com/2024/08/21/rep-bill-pascrell-dies-after-prolonged-hospital-stays/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Wed, 21 Aug 2024 15:57:44 +0000</pubDate>
+				<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Politics]]></category>
+		<category><![CDATA[bill pascrell]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14420</guid>
+
+					<description><![CDATA[Before joining Congress in 1997, Rep. Bill Pascrell Jr. served seven years as Paterson's mayor and nine years as a member of the General Assembly.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2022/01/DPR-Infrastructure_Rt-3-012522-023-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2022/01/DPR-Infrastructure_Rt-3-012522-023-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2022/01/DPR-Infrastructure_Rt-3-012522-023-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2022/01/DPR-Infrastructure_Rt-3-012522-023-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2022/01/DPR-Infrastructure_Rt-3-012522-023-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2022/01/DPR-Infrastructure_Rt-3-012522-023-2048x1365.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Before joining Congress in 1997, Rep. Bill Pascrell Jr. served seven years as Paterson's mayor and nine years as a member of the General Assembly. (Danielle Richards for New Jersey Monitor)</p><p><span data-preserver-spaces="true">Rep. Bill Pascrell, a Passaic County Democrat who spent more than a quarter century representing New Jersey in Congress, died Wednesday following </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/briefs/pascrell-remains-hospitalized-required-breathing-assistance-after-setback-staff-says/" target="_blank" rel="noopener"><span data-preserver-spaces="true">a prolonged hospitalization</span></a><span data-preserver-spaces="true">. He was 87.</span></p>
+<p><span data-preserver-spaces="true">“It is with a deep sadness that we announce that Bill Pascrell Jr., our beloved husband, father, and grandfather, passed away this morning. As our United States Representative, Bill fought to his last breath to return to the job he cherished and to the people he loved,” the congressman’s family said in a statement.</span></p>
+<p><span data-preserver-spaces="true">The congressman’s death comes a little more than a month after he was hospitalized with a fever in mid-July. The congressman then required breathing assistance but was discharged following a three-week hospital stay before returning to St. Joseph’s hospital in Paterson days later.</span></p>
+<p><span data-preserver-spaces="true">Before joining Congress in 1997, Pascrell served seven years as Paterson’s mayor and nine years as a member of the General Assembly. In D.C. he represented the 9th Congressional District, which covers parts of Passaic, Bergen, and Hudson counties.</span></p>
+<p><span data-preserver-spaces="true">“Bill lived his entire life in Paterson and had an unwavering love for the city that he grew up in and served. He is now at peace after a lifetime devoted to our great nation,” his family said.</span></p>
+<p><span data-preserver-spaces="true">A former school teacher who served in the U.S. Army and U.S. Army Reserves, Pascrell was one of the oldest members of Congress. He is survived by his wife, Elsie, three children, and five grandchildren.</span></p>
+<p><span data-preserver-spaces="true">“I had the honor of serving alongside Bill for 27 years. I will deeply miss my friend and partner. My thoughts and prayers are with his wife, Elsie, their children, and grandchildren, who supported him through a life of public service and generously shared him with all of us. I also want to recognize his dedicated staff, who he considered his extended family, and who guided him through a distinguished career on Capitol Hill,” said Rep. Frank Pallone (D-06).</span></p>
+<figure id="attachment_1923" class="wp-caption aligncenter" style="max-width:100%;width:1024px;"><a href="https://newjerseymonitor.com/house-ways-and-means-committee-holds-markup-for-budget-resolution/"><img decoding="async" loading="lazy" class="wp-image-1923 size-full" src="https://newjerseymonitor.com/wp-content/uploads/2021/12/GettyImages-1340288718.jpg" alt="" width="1024" height="683" srcset="https://newjerseymonitor.com/wp-content/uploads/2021/12/GettyImages-1340288718.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2021/12/GettyImages-1340288718-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2021/12/GettyImages-1340288718-768x512.jpg 768w" sizes="(max-width: 1024px) 100vw, 1024px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Rep. Bill Pascrell (D-NJ), right, speaks during a markup hearing at Longworth House Office Building September 14, 2021 on Capitol Hill in Washington, DC. House Ways And Means Committee continued its markup on a third day for the Democrats&#8217; $3.5 trillion spending package. (Photo by Alex Wong/Getty Images)</em></p></figure>
+<p style="font-weight: 400;">Pascrell was a longtime co-chair of the congressional law enforcement caucus and an ardent opponent of former President Donald Trump. The congressman railed against the former president’s tax policy and repeatedly sought to undo a $10,000 cap on state and local tax deductions that disproportionately affected residents in high-tax states like New Jersey.</p>
+<p style="font-weight: 400;">He repeatedly called for criminal investigations into Trump and Postmaster General Louis DeJoy over policy changes at the United States Postal Service in 2020 and sought to block the swearings-in of congresspeople who joined Trump’s efforts to overturn President Joe Biden’s election.</p>
+<p style="font-weight: 400;">Pascrell was an advocate for first responders and veterans. He championed legislation extending grants to local fire departments to hire additional personnel, purchase equipment, and fund fire prevention programs.</p>
+<p style="font-weight: 400;">&#8220;Today, we mourn the loss of a great friend and colleague, Congressman Bill Pascrell. Bill was a dedicated public servant, a tireless advocate for his constituents, and a passionate supporter of firefighters. We worked closely together on many issues. My deepest condolences go out to his family during this difficult time. Bill will be dearly missed,&#8221; said Rep. Tom Kean (R-07), who cosponsored a recent bill with Pascrell reauthorizing grants for firefighters.</p>
+<p><span data-preserver-spaces="true">Pascrell&#8217;s death will create a vacancy on November’s ballot. Democratic county committee people from the 9th District are tasked with tapping a candidate to replace him in November.</span></p>
+<p><span data-preserver-spaces="true">They don’t have much time to decide. The deadline to fill primary nominee vacancies for the ballot is Aug. 29. Democrats’ pick will face off against Republican Billy Prempeh in November.</span></p>
+<p><span data-preserver-spaces="true">Though the 9th District grew more competitive after its boundary lines were redrawn in late 2021, Democrats are still heavily favored to win there. Because Pascrell’s death came within six months of the general election, Gov. Phil Murphy is not required by law to call a special election.</span></p>
+<p><span data-preserver-spaces="true">Pascrell’s death comes months after the death of Rep. Donald Payne Jr., </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/04/24/rep-donald-payne-jr-hospitalized-after-heart-attack-has-died-at-65/" target="_blank" rel="noopener"><span data-preserver-spaces="true">who died in April after a heart attack</span></a><span data-preserver-spaces="true"> left him hospitalized in a coma.</span></p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Jersey City sued over police killing of man suffering from mental health crisis</title>
+		<link>https://newjerseymonitor.com/2024/08/21/jersey-city-sued-over-police-killing-of-man-suffering-mental-health-crisis/</link>
+		
+		<dc:creator><![CDATA[Mark J. Bonamo]]></dc:creator>
+		<pubDate>Wed, 21 Aug 2024 14:30:40 +0000</pubDate>
+				<category><![CDATA[Courts]]></category>
+		<category><![CDATA[Criminal Justice]]></category>
+		<category><![CDATA[Andrew Washington]]></category>
+		<category><![CDATA[ARRIVE Together]]></category>
+		<category><![CDATA[Jersey City]]></category>
+		<category><![CDATA[Steve Fulop]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14415</guid>
+
+					<description><![CDATA[The man's family says mental health professionals should have responded when they sought help for him. Instead, police arrived and killed him.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/washingtonJC-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/washingtonJC-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/washingtonJC-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/washingtonJC-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/washingtonJC-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/washingtonJC.jpg 1800w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Andrew Washington, seen here with his family, was shot and killed by police in August 2023 when family members say he was experiencing a mental health crisis. (Courtesy of Courtnie Washington)</p><p><span data-preserver-spaces="true">The family of a Jersey City man </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2023/08/30/activists-renew-calls-for-change-after-police-kill-jersey-city-man/" target="_blank" rel="noopener"><span data-preserver-spaces="true">killed by city police last year</span></a><span data-preserver-spaces="true"> has filed a wrongful death lawsuit against the city, Hudson County, and a local hospital, claiming the defendants’ failure to follow standard law enforcement de-escalation techniques during the man’s mental health crisis led to his death and violated his civil rights.</span></p>
+<p><span data-preserver-spaces="true"><a href="https://newjerseymonitor.com/wp-content/uploads/2024/08/Washington-v-JC-et-al.pdf" target="_blank" rel="noopener">The lawsuit</a>, filed Wednesday morning, comes one year after police shot and killed Andrew &#8220;Drew&#8221; Washington at his home, where they were dispatched when his family members say they called a hotline seeking mental health professionals to help him.</span></p>
+<p><span data-preserver-spaces="true">The plaintiff, Courtnie Washington, Andrew’s sister and the administrator of his estate, alleges that her brother’s death could have been avoided and is seeking unspecified damages. She claims that established state and federal law enforcement guidelines for dealing with individuals with mental health conditions were not followed by Jersey City police officers, and also alleges that medical health professionals failed to show adequate care with Washington.</span></p>
+<p><span data-preserver-spaces="true">“Everything the police did was wrong. My brother was not dangerous and they knew that,” Washington told the New Jersey Monitor. “If my brother had a heart attack or he had cancer, would you act this way as police officers? No.”</span></p>
+
+<div class=" newsroomBlockQuoteContainer  ">
+	<div class="newsroomBlockQuoteSVGContainer">
+		<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12.81 9">
+			<g>
+				<path d="M2.7,0A3,3,0,0,0,.7.8,2.64,2.64,0,0,0,0,2.7,2.14,2.14,0,0,0,.8,4.4a2.84,2.84,0,0,0,1.7.7,1.45,1.45,0,0,0,.7-.2,1.45,1.45,0,0,1,.7-.2q.3,0,.3.6A3.47,3.47,0,0,1,3,7.6a4.21,4.21,0,0,1-2.6,1V9a5.51,5.51,0,0,0,4-1.6A5.06,5.06,0,0,0,6,3.7a3.92,3.92,0,0,0-.9-2.6A3.19,3.19,0,0,0,2.7,0Z"/>
+				<path d="M11.8,1.1A2.84,2.84,0,0,0,9.5,0a2.79,2.79,0,0,0-2,.8,2.64,2.64,0,0,0-.7,1.9,2.06,2.06,0,0,0,.7,1.7,2.41,2.41,0,0,0,1.8.7,1.85,1.85,0,0,0,.7-.2,1.45,1.45,0,0,1,.7-.2q.3,0,.3.6A2.94,2.94,0,0,1,9.8,7.6a4.21,4.21,0,0,1-2.6,1V9a5.51,5.51,0,0,0,4-1.6,4.6,4.6,0,0,0,1.6-3.8A3.47,3.47,0,0,0,11.8,1.1Z"/>
+			</g>
+		</svg>
+	</div>
+	<div class="newsroomBlockQuoteQuoteContainer">
+		<p class="newsroomBlockQuote ">This idea of villainizing people with mental health disabilities needs to stop.</p>
+	</div>
+		<div class="newsroomBlockQuoteAuthorContainer">
+		<p style="font-size:13px"><b>– Courtnie Washington, the victim’s sister</b></p>
+	</div>
+	</div>
+
+	
+<p><span data-preserver-spaces="true">The suit cites a series of events that culminated in Washington’s death on August 27, 2023.</span></p>
+<p><span data-preserver-spaces="true">Family members called a mental health hotline asking for the advertised mobile outreach of trained mental health professionals to help Washington, 52, who suffered from multiple mental health disabilities, including bipolar disorder, schizophrenia, and bouts of psychosis that involved auditory hallucinations. However, the mental health team was never dispatched, according to the suit, which says officials instead sent paramedics untrained in mental health issues and a heavily armed “SWAT-like” force trained to respond to armed criminal suspects and terrorism suspects.</span></p>
+<p><span data-preserver-spaces="true">The lawsuit alleges Jersey City police officers then acted aggressively, escalating the situation by repeatedly banging on Washington&#8217;s apartment door rather than de-escalating the matter through established methods, such as allowing distance between them and Washington. Ultimately, the officers broke down the door, and within five seconds tased and shot Washington twice, causing his death, according to the complaint.</span></p>
+<p><span data-preserver-spaces="true">“The JCPD officers who interacted with Drew on August 27, 2023, understood that Drew had a mental health disability, that Drew was in the midst of a mental health episode, and that the police-led interaction was ineffective and agitating Drew more,” the lawsuit states. “Drew was in need of mental health services. Instead, he received a law enforcement response that ultimately killed him.”</span></p>
+<figure id="attachment_14418" class="wp-caption alignleft" style="max-width:100%;width:282px;"><a href="https://newjerseymonitor.com/2024/08/21/jersey-city-sued-over-police-killing-of-man-suffering-mental-health-crisis/image_123650291-4/" rel="attachment wp-att-14418"><img decoding="async" loading="lazy" class="size-medium wp-image-14418" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/image_123650291-4-282x300.jpg" alt="" width="282" height="300" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/image_123650291-4-282x300.jpg 282w, https://newjerseymonitor.com/wp-content/uploads/2024/08/image_123650291-4-961x1024.jpg 961w, https://newjerseymonitor.com/wp-content/uploads/2024/08/image_123650291-4-768x818.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/image_123650291-4.jpg 1179w" sizes="(max-width: 282px) 100vw, 282px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Andrew Washington with his mother, Gloria (Courtesy of Courtnie Washington)</em></p></figure>
+<p><span data-preserver-spaces="true">Attorney Amelia Green said the entire incident that resulted in Washington’s death didn’t have to happen. Washington was alone in his home, not at risk of harm to anyone, and had asked police to leave, Green told the New Jersey Monitor.</span></p>
+<p><span data-preserver-spaces="true">“The violence ensued when the police broke down his door without justification,” said Green, who is lead counsel for the plaintiff. “What the Jersey City police did was unnecessarily escalate the situation in contravention of every basic principle of policing. The New Jersey Attorney General&#8217;s Office has issued clear directives, aligned with the national standard, that when you&#8217;re dealing with individuals with mental health issues, you’re supposed to de-escalate, disengage, and ensure you&#8217;re not doing anything to create a situation where there might be the use of force. Here, the police did the exact opposite of those basic principles.”</span></p>
+<p><span data-preserver-spaces="true">After the shooting, </span><a class="editor-rtfLink" href="https://hudsoncountyview.com/mentally-ill-jersey-city-man-allegedly-charged-at-police-with-a-knife-before-being-fatally-shot/" target="_blank" rel="noopener"><span data-preserver-spaces="true">Jersey City Mayor Steve Fulop defended the officers&#8217; actions</span></a><span data-preserver-spaces="true">, telling reporters, “We do feel those police officers acted properly, we want the public to know that.&#8221; Fulop said anyone would be &#8220;hard-pressed&#8221; to say officers and medical personnel dispatched by Jersey City Medical Center &#8220;could have acted differently in this situation.”</span></p>
+<p><span data-preserver-spaces="true">Fulop also claimed Washington charged at officers with a knife. The complaint says Washington was holding a kitchen knife because “he was scared for his life.” Fulop is </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/briefs/jersey-city-mayor-steve-fulop-announces-run-for-governor-in-2025/" target="_blank" rel="noopener"><span data-preserver-spaces="true">seeking the Democratic nomination for governor</span></a><span data-preserver-spaces="true"> in 2025.</span></p>
+<p><span data-preserver-spaces="true">Green categorically rejected the city’s official response, saying the actions of police officers last August were “a clear violation of New Jersey state directives that they&#8217;re required to follow.”</span></p>
+<p><span data-preserver-spaces="true">“The mayor should have taken accountability, because the Jersey City Police Department botched this entire incident, killing a man. Instead, he has made comments to try and cover up the misconduct in this case and justify what&#8217;s happened, even going as far as suggesting things that simply are not true,” Green said. “The city should be taking accountability for this and make sure this never happens again.”</span></p>
+<p>RWJ Barnabas Health, which runs Jersey City Medical Center, declined to comment.</p>
+<p>&#8220;Any loss of life saddens us. However, we cannot comment on active litigation,&#8221; said Jersey City spokeswoman Kim Wallace-Scalcione.</p>
+<p><span data-preserver-spaces="true">Yannick Wood, director of the criminal justice reform program at the New Jersey Institute for Social Justice, pointed to other recent fatal police-involved shootings in Paterson and </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/08/15/renewed-calls-for-action-on-mental-health-after-police-shoot-and-kill-fort-lee-woman/" target="_blank" rel="noopener"><span data-preserver-spaces="true">Fort Lee</span></a><span data-preserver-spaces="true"> as a sign that more needs to be done to address how police react when they’re dealing with people suffering from mental illness.</span></p>
+<p><span data-preserver-spaces="true">State officials have taken action on this front. The state Attorney General’s Office in 2021 launched <a href="https://newjerseymonitor.com/2024/03/18/records-shed-light-on-program-pairing-cops-with-mental-health-professionals/" target="_blank" rel="noopener">the Arrive Together program</a>, which partners mental health professionals with law enforcement responding to calls involving people exhibiting mental health issues. The program, initially piloted in Cumberland County, has expanded to more than 200 agencies statewide.</span></p>
+<p><span data-preserver-spaces="true">And in January, state lawmakers approved the </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/01/08/bill-to-boost-community-crisis-response-teams-passed-in-wake-of-police-involved-shootings/" target="_blank" rel="noopener"><span data-preserver-spaces="true">Seabrooks-Washington Community-Led Crisis Response Act</span></a><span data-preserver-spaces="true">, which is intended to strengthen community-based teams that can respond to these kinds of episodes. It was named for Washington and Najee Seabrooks, a </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2023/03/16/video-911-calls-released-in-fatal-police-shooting-of-patersons-najee-seabrooks/" target="_blank" rel="noopener"><span data-preserver-spaces="true">Paterson man killed by police in March 2023</span></a><span data-preserver-spaces="true">. Wood believes a stronger and more complete implementation of the bill is merited.</span></p>
+<p><span data-preserver-spaces="true">“What’s really tragic about all of these cases is that they were totally preventable. We can’t be a state where this kind of deadly force is normalized and continues to kill our mentally ill residents who need help.” Wood said. “The lawsuit will not bring Andrew Washington back, but it can provide a modicum of justice for the family.”</span></p>
+<p><span data-preserver-spaces="true">Courtnie Washington knows she cannot get her brother back. But she believes his death doesn’t have to be in vain.</span></p>
+<p><span data-preserver-spaces="true">“This idea of villainizing people with mental health disabilities needs to stop,” Washington said. “Drew was pretty easy to love. He had a really beautiful heart, and he had unwavering faith. He made you feel hope after you talked to him. Drew was the reason why our family even began to talk about mental health, because we had to. I want people to know that. He was our light.”</span></p>
+<p><span data-preserver-spaces="true">    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	</span></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>A hollow victory in fight to bring transparency to cops&#8217; use of facial recognition technology</title>
+		<link>https://newjerseymonitor.com/2024/08/21/a-hollow-victory-in-fight-to-bring-transparency-to-cops-use-of-facial-recognition-technology/</link>
+		
+		<dc:creator><![CDATA[Dana DiFilippo]]></dc:creator>
+		<pubDate>Wed, 21 Aug 2024 10:59:28 +0000</pubDate>
+				<category><![CDATA[Civil Rights + Immigration]]></category>
+		<category><![CDATA[Criminal Justice]]></category>
+		<category><![CDATA[ACLU]]></category>
+		<category><![CDATA[Dillon Reisman]]></category>
+		<category><![CDATA[Francisco Arteaga]]></category>
+		<category><![CDATA[Matt Platkin]]></category>
+		<category><![CDATA[Tamar Lerer]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14364</guid>
+
+					<description><![CDATA[A 2023 ruling requires prosecutors to share the inner workings of facial recognition technology with defendants. Few comply, defense attorneys say.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="736" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7456-1024x736.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7456-1024x736.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7456-300x216.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7456-768x552.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7456-1536x1104.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7456-2048x1472.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Francisco Arteaga spent nearly four years behind bars battling an armed robbery case after police using facial recognition technology identified him as their prime suspect. His court challenge led to a ruling that now requires police departments to reveal the algorithms of the technology in cases where the technology is used. (Dana DiFilippo | New Jersey Monitor) </p><p><span data-preserver-spaces="true">Francisco Arteaga was incarcerated, waiting to appear for a court hearing last fall, when he spotted a huge guy eyeballing him from the other side of the courthouse holding cell.</span></p>
+<p><span data-preserver-spaces="true">“This guy&#8217;s arms are like this, right?” Arteaga said, tracing imaginary Popeye biceps in the air. “He got no neck. He has a bald, shiny head. He&#8217;s looking at me with this mean face. I’m like, ‘Oh, my God!’ He&#8217;s walking towards me. He goes, ‘Your name Arteaga?’ I said, ‘Yeah.’ He opened his big arms, and he hugged me. He goes, ‘Thank you, thank you so much! Because of your case, I&#8217;m going home!’”</span></p>
+<p><span data-preserver-spaces="true">It&#8217;s been 14 months since the court ruling that made Arteaga famous, at least among civil rights advocates, New Jersey defense attorneys, and defendants who have found themselves in legal trouble because of facial recognition technology.</span></p>
+<p><span data-preserver-spaces="true">Police relied on the technology to identify Arteaga as their prime suspect in the 2019 armed robbery of a Hudson County cell phone store. He denied any involvement, police had scant other evidence, and Arteaga, a Queens native, said he’d never even been to New Jersey. But authorities charged him anyway because facial recognition software spit out his mugshot as a match with grainy footage of the robber caught by surveillance cameras.</span></p>
+<p><span data-preserver-spaces="true">Arteaga challenged his arrest and demanded detailed information about the technology police relied on to identify a suspect, aiming to expose its flaws and exonerate himself. He won, with </span><a class="editor-rtfLink" href="https://www.njcourts.gov/system/files/court-opinions/2023/a3078-21.pdf" target="_blank" rel="noopener"><span data-preserver-spaces="true">a state appellate panel ruling last year</span></a><span data-preserver-spaces="true"> that he deserved to get those materials through discovery.</span></p>
+<p><span data-preserver-spaces="true">The decision might have been a watershed moment for criminal justice reformers, offering hope for defendants like Arteaga and his big, bald cellmate who have been charged in otherwise flimsy cases because of such digital deductions.</span></p>
+<p><span data-preserver-spaces="true">But at least in Arteaga’s case, prosecutors said they couldn’t provide details about the facial recognition technology that led to his charges, largely because the match was made in another state — outside their jurisdiction and the New Jersey appellate court’s reach.</span></p>
+<p><span data-preserver-spaces="true">By then, Arteaga had been behind bars as a pretrial detainee for nearly four years. Rather than remain in prison to continue his fight, he pleaded guilty, his mind on his young son, his teenage daughter, and his fiancee.</span></p>
+<p><span data-preserver-spaces="true">“I’m like, do I want to roll the dice knowing that I have children out there? As a father, I see my children hurting. I&#8217;m hurting, but I could hurt, right? I could deal with that. But when I see my hurting is affecting my children, I got to be a father. I got to go home to my kid,” he said.</span></p>
+<p><span data-preserver-spaces="true">Arteaga’s experience exposes gaps in regulation and oversight that are growing as law enforcement agencies increasingly turn to new technological tools to crack cases where traditional sleuthing has failed, said Dillon Reisman, a staff attorney at the American Civil Liberties Union of New Jersey. Reisman specializes in surveillance, artificial intelligence, and other new technologies.</span></p>
+<p><span data-preserver-spaces="true">Policymakers’ inaction to close those gaps puts everyone at risk of wrongful arrest and prosecution, Reisman added.</span></p>
+<p><span data-preserver-spaces="true">“What this case really warned us about is the threat of unchecked surveillance power and the acquisition of all of this surveillance technology with no accompanying accountability framework,” Reisman said. “All of these systems, by their nature, involve interstate cooperation and systems that are bigger than one individual agency, and that makes it extremely difficult to have any sort of transparency, to learn how the system’s used, to learn how the system might be flawed, and to advocate against it.”</span></p>
+<figure id="attachment_14305" class="wp-caption aligncenter" style="max-width:100%;width:1024px;"><a href="https://newjerseymonitor.com/2024/08/21/a-hollow-victory-in-fight-to-bring-transparency-to-cops-use-of-facial-recognition-technology/img_7511/" rel="attachment wp-att-14305"><img decoding="async" loading="lazy" class="wp-image-14305 size-large" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7511-1024x737.jpg" alt="" width="1024" height="737" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7511-1024x737.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7511-300x216.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7511-768x553.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7511-1536x1106.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7511-2048x1474.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Police in West New York charged Francisco Arteaga with an armed robbery at Buenavista Multiservices on Bergenline Avenue. (Dana DiFilippo | New Jersey Monitor)</em></p></figure>
+<p><span data-preserver-spaces="true">    <h4 class="editorialSubhed">&#8216;Window-shopping for a suspect&#8217;</h4>
+
+	</span></p>
+<p><span data-preserver-spaces="true">The appellate ruling lays out how Arteaga wound up in the crosshairs of law enforcement.</span></p>
+<p><span data-preserver-spaces="true">The day after Thanksgiving in 2019, a gunman held up the Buenavista Multiservices store on Bergenline Avenue in West New York, pistol-whipping an employee and escaping with $8,950. The employee described the robber as a “Hispanic male wearing a black skully hat.”</span></p>
+<p><span data-preserver-spaces="true">West New York officers submitted images from store and area surveillance cameras for facial recognition analysis to the New Jersey Regional Operations Intelligence Center, a division of the state police. An investigator there found no matches but offered to repeat the inquiry if detectives produced a better image.</span></p>
+<p><span data-preserver-spaces="true">Instead, detectives sent the raw footage to the New York Police Department’s Real Time Crime Center. A detective there captured several still images, compared them against the center&#8217;s databases, and identified Arteaga&#8217;s mugshot in December 2019 as a &#8220;possible match.” Two store employees — including one who wasn’t at the store at the time of the robbery — confirmed Arteaga from a photo array as the robber. Arteaga&#8217;s mugshot was in the NYPD&#8217;s system from two convictions years earlier on non-robbery offenses in New York.</span></p>
+<p><span data-preserver-spaces="true">Detectives’ decision to farm the case out to the NYPD showed they went “window-shopping for a suspect,” Arteaga said.</span></p>
+<p><span data-preserver-spaces="true">“The police were like, ‘Well, you know what, let&#8217;s send it to New York with no documented reason to do so. We&#8217;re going to abandon our state&#8217;s professionals and we&#8217;re going to go to another state and start looking in their pool right now,” Arteaga said.</span></p>
+<blockquote class="wp-embedded-content" data-secret="ffb38436WZ"><p><a href="https://newjerseymonitor.com/2024/04/15/botched-essex-county-bust-shows-need-for-better-police-misconduct-disclosure-advocates-say/">Botched Essex County bust shows need for better police misconduct disclosure, advocates say</a></p></blockquote>
+<p><iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted" title="&#8220;Botched Essex County bust shows need for better police misconduct disclosure, advocates say&#8221; &#8212; New Jersey Monitor" src="https://newjerseymonitor.com/2024/04/15/botched-essex-county-bust-shows-need-for-better-police-misconduct-disclosure-advocates-say/embed/#?secret=qffZKRkG6s#?secret=ffb38436WZ" data-secret="ffb38436WZ" width="500" height="282" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe></p>
+<p><span data-preserver-spaces="true">Arteaga had an alibi. He told police he was visiting relatives in Croton-on-Hudson in Westchester County the day of the robbery. But police charged him anyway, and a judge ordered him held at the Hudson County jail until his trial.</span></p>
+<p><span data-preserver-spaces="true">His defense attorney filed a motion seeking information about the facial recognition software that identified Arteaga, including its name, manufacturer, algorithms, error rates, and source code, as well as the qualifications of the analyst who ran the search, details about the mugshot database where the analyst got Arteaga’s photo, and any alterations the analyst made on surveillance stills to improve the odds of a match.</span></p>
+<p><span data-preserver-spaces="true">The trial judge denied the motion in May 2022, and Arteaga appealed. A three-judge appellate panel in June 2023 sided with Arteaga and returned the case to trial court, directing the judge to order prosecutors to provide the information the defense sought.</span></p>
+<p><span data-preserver-spaces="true">“Here, the items sought by the defense have a direct link to testing FRT&#8217;s reliability and bear on defendant&#8217;s guilt or innocence. Given FRT&#8217;s novelty, no one, including us, can reasonably conclude without the discovery whether the evidence is exculpatory or ‘merely potentially useful evidence,’” Judge Hany Mawla wrote.</span></p>
+<p><span data-preserver-spaces="true">Courts must work to understand new technology and allow the defense a meaningful opportunity to fully examine it, Mawla wrote, citing a 2021 state appellate </span><a class="editor-rtfLink" href="https://law.justia.com/cases/new-jersey/appellate-division-published/2021/a4207-19.html" target="_blank" rel="noopener"><span data-preserver-spaces="true">ruling.</span></a></p>
+<p><span data-preserver-spaces="true">&#8220;Defendant must have the tools to impeach the State&#8217;s case and sow reasonable doubt,&#8221; he wrote.</span></p>
+<p><span data-preserver-spaces="true">Prosecutors did not appeal the ruling, which means it now carries the weight of law.</span></p>
+<figure id="attachment_14303" class="wp-caption aligncenter" style="max-width:100%;width:1024px;"><a href="https://newjerseymonitor.com/2024/08/21/a-hollow-victory-in-fight-to-bring-transparency-to-cops-use-of-facial-recognition-technology/img_7491/" rel="attachment wp-att-14303"><img decoding="async" loading="lazy" class="wp-image-14303 size-large" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7491-1024x768.jpg" alt="" width="1024" height="768" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7491-1024x768.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7491-300x225.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7491-768x576.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7491-1536x1152.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7491-2048x1536.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Tamar Lerer heads the forensic science unit at the New Jersey Office of the Public Defender. (Dana DiFilippo | New Jersey Monitor)</em></p></figure>
+<p><span data-preserver-spaces="true">Attorneys at the state public defender’s office who represent defendants identified by facial recognition software say they’ve encountered the same problem Arteaga had — prosecutors insisting, despite their constitutional duty to provide exculpatory evidence to the defense, that they have no information on the technology underlying their cases, said Tamar Lerer, who heads the office’s forensic science unit.</span></p>
+<p><span data-preserver-spaces="true">“It&#8217;s a due process violation not to provide it,” Lerer said. “The state is still using facial recognition and I know that attorneys are not being provided with this discovery, and when they&#8217;re asking for it, they&#8217;re told that they can subpoena themselves. So we have a systemic problem with the lack of compliance with this decision.”</span></p>
+<p><span data-preserver-spaces="true">Adding to the complexity, some facial recognition developers require customers to sign non-disclosure agreements to protect their products from competitors. Such secrecy has sparked several lawsuits against the New York Police Department, which <a href="https://www.amnesty.org/en/latest/news/2022/08/usa-nypd-black-lives-matter-protests-surveilliance/" target="_blank" rel="noopener">was ordered in 2022 to release records</a> — and they showed the department has used Clearview AI, a controversial facial recognition technology former New Jersey Attorney General Gurbir Grewal <a href="https://www.nytimes.com/2020/01/24/technology/clearview-ai-new-jersey.html?unlocked_article_code=1.Ek4.r1De.NUiC-2p66n4U&amp;smid=url-share" target="_blank" rel="noopener">banned in 2020</a>.</span></p>
+<p><span data-preserver-spaces="true">“The police departments are very well aware that they&#8217;re utilizing tools of secrecy,” Arteaga said. “So when they take the software recommendation that is built on secrecy to target somebody, that person that has been targeted is sh*t out of luck.”</span></p>
+<p><span data-preserver-spaces="true">Lerer said her office is “waiting to see what’s next.”</span></p>
+<p><span data-preserver-spaces="true">“The defense is not supposed to be a regulatory agency,” she said.</span></p>
+<p><span data-preserver-spaces="true">The West New York store&#8217;s owner didn&#8217;t respond to the New Jersey Monitor&#8217;s request for comment, and a spokeswoman for the Hudson County Prosecutor&#8217;s Office declined to comment.</span></p>
+<p><span data-preserver-spaces="true">In February 2022, the New Jersey Attorney General’s office began <a href="https://newjerseymonitor.com/2022/02/25/a-g-mulls-statewide-policy-on-facial-recognition-technology/" target="_blank" rel="noopener">soliciting public input about facial recognition technology</a> to help shape a statewide policy on its use by law enforcement agencies. No action has been taken since the public comment solicitation, said Michael Symons, a spokesman for the Attorney General Matt Platkin’s office.</span></p>
+<p><span data-preserver-spaces="true">The office doesn&#8217;t track how many agencies in New Jersey use the technology, Symons added.</span></p>
+<p><span data-preserver-spaces="true">Reisman said the need for policymakers to act is becoming increasingly urgent as the industry expands.</span></p>
+<p><span data-preserver-spaces="true">“Facial recognition has been an area of computer science research for well over 30 years, but in the past decade, what we’ve seen is an explosion in the number of companies offering these services and in federal funding for local and state governments to acquire these systems. There&#8217;s a lot of money being thrown at these tools without a lot of accompanying forethought into the sort of controls and safeguards we need,” Reisman said. “It&#8217;s a terrifying place for the state to be.”</span></p>
+<figure id="attachment_14300" class="wp-caption alignleft" style="max-width:100%;width:300px;"><a href="https://newjerseymonitor.com/img_7448/"><img decoding="async" loading="lazy" class="size-medium wp-image-14300" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7448-300x225.jpg" alt="" width="300" height="225" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7448-300x225.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7448-1024x768.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7448-768x576.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7448-1536x1152.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_7448-2048x1536.jpg 2048w" sizes="(max-width: 300px) 100vw, 300px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Francisco Arteaga (Dana DiFilippo | New Jersey Monitor)</em></p></figure>
+<p><span data-preserver-spaces="true">Arteaga considers himself a &#8220;hostage&#8221; for the time he spent behind bars, where conditions can be </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/01/22/county-jail-conditions-hazardous-even-to-a-dog-spur-calls-for-independent-oversight/" target="_blank" rel="noopener"><span data-preserver-spaces="true">notoriously abysmal</span></a><span data-preserver-spaces="true">. Since he got out in November, he has worked to rebuild his life.</span></p>
+<p><span data-preserver-spaces="true">He’s studying holistic medicine online, sells health and nutrition products, and works as a gym teacher at a senior citizens&#8217; center in Queens. He now lives in Union City to better accommodate his monthly meetings with his parole agent and sees his son and fiancee, who still live in Queens, every few weeks.</span></p>
+<p><span data-preserver-spaces="true">While he won his appeal, he said, it felt a bit like winning the battle but losing the war.</span></p>
+<p><span data-preserver-spaces="true">“People be like, ‘Yo, you had a good thing with your case. Why didn&#8217;t you fight all the way?’” Arteaga said. “My question for them was, ‘What would you do if you was me?’”</span></p>
+<p><span data-preserver-spaces="true">He hopes someone else will pick up the fight.</span></p>
+<p><span data-preserver-spaces="true">&#8220;I set up the putt close enough for somebody else to sink it in,&#8221; he said.</span></p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Market problems, poor planning causing price hikes in nation’s largest electric market, critics say</title>
+		<link>https://newjerseymonitor.com/2024/08/21/market-problems-poor-planning-causing-price-hikes-in-nations-largest-electric-market-critics-say/</link>
+		
+		<dc:creator><![CDATA[Robert Zullo]]></dc:creator>
+		<pubDate>Wed, 21 Aug 2024 10:39:51 +0000</pubDate>
+				<category><![CDATA[Energy]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14408</guid>
+
+					<description><![CDATA[After years of climbing electric prices nationwide, customers in the United States’ largest power market are about to get squeezed harder. Last month, PJM, which coordinates the flow of electricity for an area that includes all or parts of 13 states stretching from the Midwest to New Jersey plus the District of Columbia, released capacity [&#8230;]]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="749" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/Brandon-Shores-1024x749.jpeg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/Brandon-Shores-1024x749.jpeg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Brandon-Shores-300x219.jpeg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Brandon-Shores-768x562.jpeg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Brandon-Shores-1536x1123.jpeg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Brandon-Shores-2048x1498.jpeg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Emissions spew from a large stack at the coal fired Brandon Shores Power Plant, on March 9, 2018 in Baltimore, Maryland. Critics say that PJM, which is responsible for coordinating the flow of electricity in 13 states and the District of Columbia, should have been prepared for the retirement of Brandon Shores. (Photo by Mark Wilson/Getty Images.)</p><p>After years of <a href="https://www.eia.gov/electricity/monthly/epm_table_grapher.php?t=epmt_5_03" target="_blank">climbing electric prices nationwide</a>, customers in the United States’ largest power market are about to get squeezed harder.</p>
+<p>Last month, PJM, which coordinates the flow of electricity for an area that includes all or parts of 13 states stretching from the Midwest to New Jersey plus the District of Columbia, released capacity auction results that hit a <a href="https://www.utilitydive.com/news/pjm-interconnection-capacity-auction-vistra-constellation/722872/#:~:text=For%20the%20majority%20of%20the,said%20in%20an%20auction%20report." target="_blank">record high</a>.</p>
+<p>The auction, held by the regional transmission organization to ensure there’s <a href="https://missouriindependent.com/2023/03/15/the-nations-biggest-electric-capacity-market-needs-fixing-critics-say/#:~:text=PJM%2C%20which%20coordinates%20the%20flow,(fhm%2FGetty%20Images)." target="_blank">enough power generation </a>to meet demand spikes, such as during severe weather and other grid emergencies, produced a price of nearly $270 per megawatt day for much of the footprint (with some areas <a href="https://virginiamercury.com/2024/08/07/costs-for-electricity-during-extreme-weather-rising-dominion-says-nothing-to-worry-about-yet/" target="_blank">spiking much higher</a>) compared to nearly $29 per megawatt day during the last auction. That increase, more than 800%, will cost customers across the region of 65 million people nearly $15 billion for the period covered by the auction (June 1, 2025 to May 31, 2026) the Maryland Office of People’s Counsel noted in a <a href="https://opc.maryland.gov/Portals/0/Files/Publications/RMR%20Bill%20and%20Rates%20Impact%20Report_2024-08-14%20Final.pdf?ver=V9hZfyTmjLeNVt2Dg3cTgw%3d%3d" target="_blank">report </a>released last week. The costs will not hit equally across the PJM footprint, however, since utilities that own and operate their own power plants, like <a href="https://www.utilitydive.com/news/dominion-rate-payers-capacity-auction-pjm-generation/723535/" target="_blank">Virginia’s Dominion Energy</a>, are both sellers and buyers in the capacity market, which will blunt the impact for their ratepayers. But Exelon, a company that owns six so-called “wires-only” utilities with 10.5 million customers in PJM states, expects the capacity prices to trigger double-digit rate increases for some customers, <a href="https://www.utilitydive.com/news/exelon-pjm-capacity-auction-bge-talen-data-center/723163/" target="_blank">Utility Dive reported</a>.</p>
+<p>What makes the capacity costs tougher to swallow is that much of the increase can be laid at the feet of planning shortcomings, market design failures and governance problems at PJM, the organization’s critics contend.</p>
+<p>“The tools to enhance reliability are in PJM’s hands,” said Clara Summers, campaign manager for Consumers for a Better Grid, a watchdog group that is part of the Citizens Utility Board of Illinois. “Instead PJM is dragging its feet on the clean energy transition and doing everything it can to keep fossil fuel plants online and ultimately ratepayers are the ones who suffer from this shortsightedness.”</p>
+    <h4 class="editorialSubhed">‘All sorts of problems’</h4>
+
+	
+<p>In particular, critics point to PJM’s long delayed <a href="https://missouriindependent.com/2024/03/19/new-scorecard-rates-nations-grid-managers-on-connecting-renewables/" target="_blank">interconnection queue</a>, which is the waiting list for generation projects looking for permission to connect to the grid. They say that even as PJM complains about fewer power plants entering its capacity auction and the increasing pace of old generating station retirements, it is <a href="https://elibrary.ferc.gov/eLibrary/filelist?accession_number=20240620-5242&amp;optimized=false" target="_blank">seeking exemptions</a> to a landmark<a href="https://nebraskaexaminer.com/2023/07/30/federal-regulators-approve-new-rules-to-ease-power-connection-backlogs/" target="_blank"> new federal rule</a> intended to streamline interconnection processes and get new power resources online quickly.</p>
+<p>“PJM is the place with the most acute need for interconnection reform and they’re refusing to do what they’ve been told to do on it rather than be proactive on it,” said Tom Rutigliano, a senior advocate at the Natural Resources Defense Council who focuses on PJM.</p>
+<p>Jeff Shields, a PJM spokesman, said the organization has been working hard to fix its interconnection process and clear the backlog. He pointed out that many projects that have cleared the queue still aren’t getting built because of supply chain, financing or permitting problems that are beyond PJM’s control.</p>
+<p>“We are not arguing about whether we need queue reform, we have only taken issue with some details,” he said.</p>
+<p>David Lapp, Maryland’s people’s counsel, an advocate for the state’s residential utility customers, said interconnection delays are just part of the problem at PJM.</p>
+<p>Transmission costs — because of a lack of competitive bidding of projects and a failure to plan for the long term, <a href="https://marylandmatters.org/2024/02/05/clean-power-advocates-eye-grid-operators-planning-reforms-warily/" target="_blank">watchdogs argue </a>— have also <a href="https://rmi.org/increased-spending-on-transmission-in-pjm-is-it-the-right-type-of-line/" target="_blank">climbed over the past decade</a>.  And a deficient process for managing power plant retirements, along with <a href="https://www.utilitydive.com/news/ferc-rehearing-pjm-delmarva-capacity-auction/717174/" target="_blank">market errors,</a> have also hurt customers, Lapp said.</p>
+<p>”Our customers are bearing the consequences of all sorts of problems at PJM, whether they be problems with the market structure, problems with the interconnection queue, problems related to planning failures or just mistakes,” Lapp said in an interview with States Newsroom. “PJM really needs to start taking the interest of customers more seriously into account in terms of how it develops its policies.”</p>
+<p>How the retirement of Brandon Shores, a Talen Energy coal-fired power plant southeast of Baltimore, has been handled, exemplifies a lot of what’s wrong with PJM, Lapp added. Lapp and others, including members of <a href="https://www.vanhollen.senate.gov/imo/media/doc/letter_to_pjm_on_brandon_shores__generator_retirement.pdf" target="_blank">Maryland’s congressional delegation</a>, say PJM was caught flat-footed by the plant’s retirement, which should have been foreseeable given the limited amount it was running, a deal <a href="https://www.sierraclub.org/press-releases/2020/11/sierra-club-and-stoney-beach-association-statements-talen-energy-s-commitment" target="_blank">with the Sierra Club to quit burning coal</a> and <a href="https://www.reuters.com/legal/litigation/talen-energy-unit-files-bankruptcy-looks-slash-45-bln-debt-2022-05-10/" target="_blank">financial troubles</a> for its operating company. PJM counters that it was told the plant would switch to burning oil and continue running.</p>
+<p>“It is not reasonable to expect PJM to have anticipated the imminent deactivation of the Brandon Shores units when numerous public statements and direct conversations between PJM and Talen all supported the notion that Brandon Shores was on a path to remain online, albeit using a different fuel source,” PJM President and CEO Manu Asthana wrote in a <a href="https://pjm.com/-/media/about-pjm/who-we-are/public-disclosures/20231205-pjm-board-response-to-sierra-club-letter-regarding-pjm-interconnections-role-in-the-maryland-energy-transition.ashx" target="_blank">December letter</a> to the Sierra Club,</p>
+<p><strong>    <h4 class="editorialSubhed">‘How much sense does that make?’</h4>
+
+	 </strong></p>
+<p>Regardless, PJM now has pushed for an urgent suite of transmission projects that will cost Maryland ratepayers about<a href="https://www.pjm.com/-/media/library/reports-notices/special-reports/2024/20240503-bess-technical-viability-wagner-and-brandon-shores-retirements-study.ashx#:~:text=Significant%20transmission%20reinforcements%20are%20required,power%20into%20the%20BGE%20zone.&amp;text=Transmission%20upgrade%20costs%20are%20approximately,upgrades%20to%20support%20voltage%20control." target="_blank"> $800 million</a> to bring in enough power to make up for the loss of the Brandon Shores station and another nearby Talen plant, <a href="https://www.power-eng.com/coal/boilers/pjm-requests-delayed-retirement-of-maryland-fossil-fired-units-citing-reliability-concerns/#gref" target="_blank">Wagner</a>, that is also retiring. PJM will also keep both plants running under what are known as“reliability must run” arrangements that could cost Maryland ratepayers $629 million through 2028, the People’s Counsel report says, and comes with no guarantee they will actually be able to produce power when called upon. It also means the plants will exit the capacity market, which is designed to increase prices as energy supply tightens to encourage more generation sources to enter the market. “The logic was that you want to treat them as gone to send a price signal for new entry,” Rutigliano said. But even if a new generation source wanted to take advantage of the high capacity prices in the zone affected by the plant closure, the interconnection queue delays mean it could be years before it can participate in the auction.</p>
+<p>“With PJM’s interconnection process so far behind that simply doesn’t work,” Rutigliano said. “Price signals are worthless if you’ve got a six-year delay in responding to them.”</p>
+<p>And since PJM has already decided on a transmission solution to make up for the plant’s retirement, forcing customers to bear the high capacity prices doesn’t make sense, Rutigliano said.</p>
+<p>“They exclude them from the market to get a high price signal but build transmission to ease the load pocket. Those are contradictory,” he said.</p>
+<p>The upshot is that Talen gets a windfall (the Office of the People’s Counsel report found the company’s revenues for the 2025-2026 delivery year are $360 million higher than what they would have been had Wagner and Brandon Shores participated in the capacity market) and electric customers in Maryland will be paying extra for plants that may not run much at all. They will also be paying extra for the loss of that plant to the capacity market in order to create a market signal that won’t matter because of the transmission solution PJM has already decided upon, which will also be paid by local customers. Lapp called it a “triple whammy.”</p>
+<p>“We have the illogical situation where customers are paying big dollars for a plant that is not going to run almost all the time,” Lapp said. “They still have no performance obligation. There are no consequences if PJM says ‘We’re hitting a peak time. We need you to run.’ And Talen says ‘We can’t.’ …  How much sense does that make?”</p>
+<p>Shields, the PJM spokesman, says PJM will continue working to improve markets, transmission planning and generator interconnection. But he added that, of the PJM states, Maryland has the second-fewest projects in the queue over the next few years.  “We encourage Maryland policymakers to analyze why and what can be done to encourage development,” Shields said. “There is no debate – Maryland needs energy infrastructure. Maryland needs generation to produce power for and transmission to move power to the customers who need it. The Maryland Office of People’s Counsel knows all of this to be true, and these critical issues deserve a better discussion than ongoing exercises in finger pointing.”</p>
+<p><strong>    <h4 class="editorialSubhed">Seeking variances</h4>
+
+	 </strong></p>
+<p>Particularly frustrating for PJM reformers are the exemptions it is seeking to a new <a href="https://nebraskaexaminer.com/2023/07/30/federal-regulators-approve-new-rules-to-ease-power-connection-backlogs/" data-type="link" data-id="https://nebraskaexaminer.com/2023/07/30/federal-regulators-approve-new-rules-to-ease-power-connection-backlogs/" target="_blank">Federal Energy Regulatory Commission rule </a>to speed the connection of new power resources to the grid, which seems counterintuitive for an organization that has worried about having enough power to meet demand. PJM did begin <a href="https://www.pjm.com/planning/service-requests/interconnection-process-reform" target="_blank">its own interconnection reforms</a> prior to the FERC order, and its request for variances indicates it wants to stick to that plan rather than conform completely to the new FERC rules, per a coalition of environmental and consumer organizations<a href="https://elibrary.ferc.gov/eLibrary/filelist?accession_number=20240620-5242&amp;optimized=false" target="_blank"> that are challenging the request</a> before the commission.</p>
+<p>“The interconnection queue in PJM is among the longest in the nation, whether measured by the number of projects, total electric capacity, or how long projects languish awaiting studies,” the groups wrote in a FERC filing, noting that PJM won’t review new interconnection applications until 2026 at the earliest. “At the same time, PJM is sounding the alarm about a reliability crisis because new generation cannot come online quickly enough to replace retiring power plants. To accelerate interconnection and bring new generation online to avoid reliability challenges from foreseeable retirements, PJM should welcome Order No. 2023’s reforms with open arms. Instead, PJM resists reform to its interconnection process.”</p>
+<p>Mainly PJM is seeking permission for increased study timelines and a laxer penalty structure  and wants to sidestep reporting requirements on how it evaluates grid-enhancing technologies, which can save time and money over traditional transmission solutions. It also wants to avoid the requirement to realistically consider how energy storage resources will affect peak load.</p>
+<p>Grid-enhancing technologies have been used for years elsewhere in the world to get more out of existing power systems and in many cases are faster and cheaper than building new transmission lines, but they’ve been slow to catch on in the U.S., in part because American utilities make more money by building big, expensive projects rather than more cost-effective solutions, <a href="https://missouriindependent.com/2023/08/23/federal-state-regulators-prod-utilities-to-consider-technology-for-grid-upgrade/" target="_blank">proponents have said</a>.</p>
+<p>PJM wants out of a requirement to demonstrate that it has considered those technologies, said Katie Siegner, a manager who works on markets and electric grids at the Rocky Mountain Institute, a nonprofit focused on decarbonization.</p>
+<p>“What they’re saying is, ‘We already consider them but don’t make us show you how,’” she said.</p>
+<p>The other major exemption PJM wants deals with battery storage resources and what grid upgrades are needed to accommodate them. Some grid operators, including PJM, want to continue to use a worst-case assumption — that the batteries will charge at times of peak electric demand. That flies in the face of the economic model for grid-connected batteries, which seek to charge when prices are low and discharge when they spike.</p>
+<p>“Assuming that storage will charge during a time of peak load is one of those worst-case conditions even though it’s antithetical to the action it will take in the market,” Siegner said. And even if PJM was concerned about that happening, it could write a prohibition into an interconnection agreement, rather than requiring storage developers to pay for expensive grid upgrades that might never be needed, she added.</p>
+<p>“It’s just a nonsensical way of studying these resources that has to change,” Siegner said.</p>
+<p>The bigger problem, said Summers of the Citizens Utility Board, is that at PJM, fossil fuel generators, big utilities and transmission companies hold a lot of sway.</p>
+<p>“Many of these companies came of age in the fossil fuel era and their incentives are to try to prevent the fossil fuel transition or make it as expensive as possible. PJM has a pattern of dragging its feet on the energy transition,” Summers said.</p>
+<p>Indeed, how PJM is governed and how stakeholders are voting in lower level meetings is drawing <a href="https://penncapital-star.com/energy-environment/state-lawmakers-want-to-peel-back-the-curtain-at-the-nations-biggest-electrical-grid-operator/" target="_blank">increasing scrutiny from state lawmakers</a>. Four blue state governors with decarbonization goals also recently <a href="https://marylandmatters.org/2024/06/27/moore-fellow-governors-seek-more-say-over-grid-planning-process/" target="_blank">called for</a> a “robust process for states to engage with PJM” on planning decisions.</p>
+<p>And for many of PJM’s critics, the fact that projects have made it through the queue but haven’t gotten built doesn’t excuse the mess the interconnection process has become.</p>
+<p>“PJM must take responsibility for its role in establishing and maintaining an effective interconnection process,” Siegner said. “The faster that interconnection requests are processed, the easier it is to get financing and navigate supply chain hurdles. It’s a lot harder if you’re waiting in the queue for five years and you have no idea what your network upgrade costs will be.”</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>‘Hope is making a comeback’: The Obamas make the case for Kamala Harris</title>
+		<link>https://newjerseymonitor.com/2024/08/21/hope-is-making-a-comeback-the-obamas-make-the-case-for-kamala-harris/</link>
+		
+		<dc:creator><![CDATA[Jacob Fischler]]></dc:creator>
+		<pubDate>Wed, 21 Aug 2024 10:32:03 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Barack Obama]]></category>
+		<category><![CDATA[Donald Trump]]></category>
+		<category><![CDATA[Kamala Harris]]></category>
+		<category><![CDATA[Michelle Obama]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14405</guid>
+
+					<description><![CDATA[The Obamas painted Donald Trump as an agent of division and called for voters to reject him in favor of a more inclusive nation.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/OBAMAS-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/OBAMAS-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/OBAMAS-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/OBAMAS-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/OBAMAS-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/OBAMAS-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">CHICAGO, ILLINOIS - AUGUST 20: Former U.S. President Barack Obama (L) greets former first lady Michelle Obama as he arrives to speak on stage during the second day of the Democratic National Convention at the United Center on August 20, 2024 in Chicago, Illinois. Delegates, politicians, and Democratic Party supporters are gathering in Chicago, as current Vice President Kamala Harris is named her party's presidential nominee. The DNC takes place from August 19-22. (Photo by Andrew Harnik/Getty Images)</p><p>CHICAGO — As he did in his first speech to a Democratic National Convention 20 years ago, former President Barack Obama emphasized the connections binding Americans together and called for a more positive national atmosphere on the second night of this year’s convention Tuesday, while rallying Democrats to campaign for Vice President Kamala Harris.</p>
+<p>At the United Center, in a convention hosted by their hometown, Obama and former first lady Michelle Obama, who spoke immediately before the former president, scattered references to the 2008 and 2012 White House races he won as they made the case for Harris.</p>
+<p>“America, hope is making a comeback,” Michelle Obama said, referring to the theme of her husband’s 2008 campaign and tying it to Harris.</p>
+<p>The energy among the Democrats since Harris became a presidential candidate a month ago could be described as “the contagious power of hope,” she said.</p>
+<p>The couple also trained criticism on Republican nominee former President Donald Trump, painting him as an agent of division and calling for voters to reject him in favor of a more inclusive nation.</p>
+<p>“Donald Trump wants us to think that this country is hopelessly divided between us and them,” Barack Obama said. “Between the real Americans, who of course support him, and the outsiders who don’t.”</p>
+<p>He called for Americans to turn aside that point of view.</p>
+<p>Republicans in their response also sought to tie Harris to Obama.</p>
+<p>“Democrats want to evoke memories of 2008,” Republican National Committee Chairman Michael Whatley said in a written statement. “But this isn’t Barack Obama’s Democrat Party — Kamala Harris is even more dangerously liberal.”</p>
+<figure id="attachment_14412" class="wp-caption aligncenter" style="max-width:100%;width:1024px;"><a href="https://newjerseymonitor.com/2024/08/21/hope-is-making-a-comeback-the-obamas-make-the-case-for-kamala-harris/img_4440/" rel="attachment wp-att-14412"><img decoding="async" loading="lazy" class="wp-image-14412 size-large" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_4440-1024x681.jpg" alt="" width="1024" height="681" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_4440-1024x681.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_4440-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_4440-768x511.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_4440-1536x1022.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_4440-2048x1363.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Former President Barack Obama speaks at the Democratic National Convention on Aug. 20, 2024. (Photo by Shaun Griswold / Source New Mexico)</em></p></figure>
+    <h4 class="editorialSubhed">Michelle Obama’s change in tone</h4>
+
+	
+<p>In a marked shift from her convention speeches eight and four years ago, when she encouraged Democrats to take the moral high road in response to Trump’s attacks, Michelle Obama took a much more confrontational tone Tuesday night toward the Republican nominee.</p>
+<p>“Who’s gonna tell him the job he is currently seeking might just be one of those Black jobs?” she said, in reference to a comment Trump had made about immigrants taking “Black jobs.”</p>
+<p>Harris would be the second Black president, after Obama.</p>
+<p>Earlier, with veiled shots at Trump, the former first lady contrasted him with Harris.</p>
+<p>Harris “understands that most of us will never be afforded the grace of failing forward,” she said. “Who will never benefit from the affirmative action of generational wealth. If we bankrupt a business or choke in a crisis, we don’t get a second, third or fourth chance.”</p>
+<p>Some Republicans have called Harris, a Black and South Asian woman, a “DEI hire,” an implication that her race and gender were more important than her career and character qualifications. Trump gained an inheritance from his father, who was also a real estate developer.</p>
+<p>Trump oversaw bankrupted businesses before he entered politics. And Democrats have said he bungled the response to the COVID-19 pandemic.</p>
+<p>Barack Obama also leveled attacks on Trump, calling him “a 78-year-old billionaire who has not stopped whining about his problems since he came down off his golden escalator” when he announced his 2016 presidential bid.</p>
+    <h4 class="editorialSubhed">Trump alternative</h4>
+
+	
+<p>Both Obamas said Harris provided a strong alternative to Trump.</p>
+<p>Not born into privilege like Trump, she has the empathy he lacks, Barack Obama said.</p>
+<p>“In other words, Kamala Harris won’t be focused on her problems,” he said. “She’ll be focused on yours.”</p>
+<p>Minnesota Gov. Tim Walz, Harris’ running mate, also provided a counterbalance to Trump, Obama said, adding that he loved Walz’s authentic Midwestern persona.</p>
+<p>Both Obamas called on Democrats to work hard for Harris’ cause over the 11 weeks until Election Day.</p>
+<p>Michelle Obama made “do something” a refrain of her speech.</p>
+<p>“You know what we need to do,” the former first lady said. “Michelle Obama is asking you — no I’m telling y’all — to do something. This election is going to be close. In some states, just a handful of votes in every precinct could decide the winner.”</p>
+<figure id="attachment_14411" class="wp-caption aligncenter" style="max-width:100%;width:1024px;"><a href="https://newjerseymonitor.com/img_4349/"><img decoding="async" loading="lazy" class="wp-image-14411 size-large" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_4349-1024x681.jpg" alt="" width="1024" height="681" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_4349-1024x681.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_4349-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_4349-768x511.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_4349-1536x1022.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/IMG_4349-2048x1363.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Conventiongoers watch former President Barack Obama speak at the Democratic National Convention on Aug. 20, 2024. (Photo by Shaun Griswold / Source New Mexico)</em></p></figure>
+    <h4 class="editorialSubhed">Biden tribute</h4>
+
+	
+<p>Barack Obama dedicated the first portion of his roughly half-hour speech to honoring his vice president, President Joe Biden.</p>
+<p>Biden guided the country out of the COVID-19 pandemic and led a strong economic recovery while lowering health care costs, Obama said.</p>
+<p>And Biden deserved credit for sacrificing his political ambition by bowing out of his reelection race, he said.</p>
+<p>“At a time when the other party had turned into a cult of personality, we needed a leader who was steady, and brought people together and was selfless enough to do the rarest thing there is in politics: putting his own ambition aside for the sake of the country,” Obama said. “History will remember Joe Biden as a president who defended democracy at a time of great danger.”</p>
+<p>He nodded along as the crowd chanted “Thank you, Joe.”</p>
+    <h4 class="editorialSubhed">Appealing to unity</h4>
+
+	
+<p>Both Obamas repeated slogans from campaigns that had his name on the ballot and his presidency, seeking to tie his historic election victory to Harris’ campaign.</p>
+<p>“On health care, we should all be proud of the progress we made through the Affordable Care Act,” Barack Obama said, referring to the major health care law he championed in his first term. “I noticed, by the way, that since it became popular they don’t call it Obamacare no more.”</p>
+<p>Harris “knows we can’t stop there,” he continued, and would work to lower drug costs.</p>
+<p>He also called for Americans to focus on common bonds.</p>
+<p>“The ties that bind us together are still there,” he said. “We still coach Little League and look out for our elderly neighbors. We still feed the hungry in churches and mosques and synagogues and temples.”</p>
+<p>In his keynote address at the 2004 Democratic National Convention, Obama also invoked Little League to stress national unity.</p>
+<p>“The vast majority of us do not want to live in a country this bitter and divided,” he said Tuesday. “We want something better. We want to be better.”</p>
+<p>The excitement for the Harris campaign showed that was a popular idea, he added.</p>
+<p>To close his speech, he invoked the first president nominated at a Chicago convention, elected in the most bitterly divided period of American history — Abraham Lincoln.</p>
+<p>“As much as any policy or program, I believe that’s what we yearn for: A return to an America where we work together and look out for each other, a restoration of what Lincoln called, on the eve of civil war, ‘our bonds of affection,’ when America taps what he called ‘the better angels of our nature,’” he said. “That’s what this election is all about.”</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Democrats celebrate with boisterous state-by-state roll call vote for Harris</title>
+		<link>https://newjerseymonitor.com/2024/08/20/democrats-celebrate-with-boisterous-state-by-state-roll-call-vote-for-harris/</link>
+		
+		<dc:creator><![CDATA[Jennifer Shutt]]></dc:creator>
+		<pubDate>Wed, 21 Aug 2024 02:36:59 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Kamala Harris]]></category>
+		<category><![CDATA[Tim Walz]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14402</guid>
+
+					<description><![CDATA[Tuesday’s lively in-person “celebratory” vote was accompanied by a live DJ who played a different song for every state and territory.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/LilJon-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/LilJon-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/LilJon-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/LilJon-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/LilJon-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/LilJon-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">CHICAGO, ILLINOIS - AUGUST 20: Rapper Lil Jon (R) performs with the Georgia delegation during the Ceremonial Roll Call of States on the second day of the Democratic National Convention at the United Center on August 20, 2024 in Chicago, Illinois. Delegates, politicians, and Democratic Party supporters are gathering in Chicago, as current Vice President Kamala Harris is named her party's presidential nominee. The DNC takes place from August 19-22. (Photo by Chip Somodevilla/Getty Images)</p><p>The Democratic National Convention held a ceremonial roll call of the states Tuesday, giving delegates on the floor of the United Center in Chicago a chance to show their support for Kamala Harris complete with corncob hats, DJ’d music, a surprise appearance from Atlanta rapper Lil Jon and enthusiastic cheers.</p>
+<p>The tradition, which has long been part of presidential nominating conventions, was actually unnecessary this year. Democratic delegates <a href="https://www.newsfromthestates.com/article/kamala-harris-officially-becomes-democratic-presidential-nominee" target="_blank">voted virtually</a> earlier this month to formally make Harris their nominee ahead of ballot deadlines in several states.</p>
+<p>Harris was the only person to qualify for the ballot after President Joe Biden decided to end his reelection bid in late July, following a pressure campaign from Democrats that began after a concerning debate performance.</p>
+<p>Tuesday’s lively in-person “celebratory” vote, accompanied by a live DJ who played a different song for every state and territory, began with delegates from Biden’s home state of Delaware before Democrats in the remaining states and territories voiced their support for the Harris-Walz ticket.</p>
+<p>It ended with unofficial votes being cast by delegates from Minnesota, home of vice presidential nominee Tim Walz, and those from Harris’ home state of California.</p>
+<p>In between, people within the arena and watching on television heard why delegates believe Harris and Walz represent the best path forward for the country.</p>
+<p>Hans Storvick, who said Walz is his neighbor and former teacher, told delegates during Minnesota’s turn to speak that the vice presidential nominee “opened our eyes to the world.”</p>
+<p>“He taught us how to talk about global issues with respect, curiosity and kindness; even and especially when we disagreed,” Storvick said. “But he wasn’t just a great teacher, he was also a great neighbor and friend. In fact, when he was in the midst of a budget battle as governor of our state, he still found time to attend my brother’s funeral.”</p>
+<p>California Gov. Gavin Newsom, who introduced himself as being from the “great state of Nancy Pelosi,” said residents there pride themselves “on our ability to live together and advance together and prosper together across every conceivable and imaginable difference.”</p>
+<p>“But the thing we pride ourselves most on is that we believe the future happens in California first,” Newsom said as Kendrick Lamar played in the background. “And, Democrats, I’ve had the privilege for over 20 years to see that future taking shape with a star in an Alameda courtroom by the name of Kamala Harris.”</p>
+<p>“I saw that star fighting for criminal justice, racial justice, economic justice, social justice,” he added. “I saw that star get even brighter as attorney general of California, as a United States senator and as Vice President of the United States of America.”</p>
+<p>The Georgia delegation, though, might have upstaged all of their fellow Democrats by securing a <a href="https://x.com/cspan/status/1826072599153266776" target="_blank">mini performance </a>from Lil Jon, who sang “turn out for what” to the music of his famous “Turn Down For What” song before the state cast its votes for Harris.</p>
+<p>When the nearly 80 minutes of ceremonial voting wrapped up the DNC displayed a live video of Harris at a campaign rally at the Fiserv Forum in Milwaukee, Wisconsin, the same venue where Republicans held their party convention just last month.</p>
+<p>“We are so honored to be your nominees,” Harris said. “This is a people-powered campaign and together, we will chart a new way forward — a future for freedom, opportunity, of optimism and faith.”</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Civil rights activist honored with new plaque in Atlantic City</title>
+		<link>https://newjerseymonitor.com/2024/08/20/civil-rights-activist-honored-with-new-plaque-in-atlantic-city/</link>
+		
+		<dc:creator><![CDATA[Sophie Nieto-Munoz]]></dc:creator>
+		<pubDate>Tue, 20 Aug 2024 21:31:55 +0000</pubDate>
+				<category><![CDATA[Civil Rights + Immigration]]></category>
+		<category><![CDATA[Fannie Lou Hamer]]></category>
+		<category><![CDATA[Kamala Harris]]></category>
+		<category><![CDATA[Marty Small]]></category>
+		<category><![CDATA[Tahesha Way]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14400</guid>
+
+					<description><![CDATA[The plaque recognizes Fannie Lou Hamer, who traveled to the Democratic National Convention in Atlantic City in 1964 to highlight her experience with racism.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="709" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/mississippi-1024x709.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/mississippi-1024x709.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/mississippi-300x208.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/mississippi-768x531.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/mississippi-1536x1063.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/mississippi.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Lt. Gov. Tahesha Way helps unveil a new marker on the Mississippi Freedom Trail in Atlantic City on Aug. 20, 2024. (Courtesy of Atlantic City)</p><p><span data-preserver-spaces="true">Sixty years after Mississippi civil rights activist Fannie Lou Hamer traveled to the Democratic National Convention in Atlantic City to highlight her experience with racism, the city will now be home to a historical marker commemorating Hamer’s activism. </span></p>
+<p><span data-preserver-spaces="true">Lt. Gov. Tahesha Way said Tuesday’s unveiling of the marker on the city’s boardwalk recognizes a “significant moment in America’s time” and will ensure visitors understand what New Jersey represented in the fight for civil rights.</span></p>
+<p><span data-preserver-spaces="true">“We cannot heal our nation from centuries of racism and discrimination without making this history visible so that all of us can see it and understand it plainly. Now this marker represents a quaint, even painful moment in our past with the hope that in recognizing this history, we can avoid repeating it,” said Way, the second Black woman to serve as the state’s lieutenant governor. </span></p>
+<figure id="attachment_14399" class="wp-caption alignleft" style="max-width:100%;width:204px;"><a href="https://newjerseymonitor.com/hamer/"><img decoding="async" loading="lazy" class="size-medium wp-image-14399" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/hamer-204x300.jpg" alt="" width="204" height="300" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/hamer-204x300.jpg 204w, https://newjerseymonitor.com/wp-content/uploads/2024/08/hamer.jpg 698w" sizes="(max-width: 204px) 100vw, 204px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Fannie Lou Hamer speaking at the 1964 Democratic National Convention in Atlantic City on Aug. 22, 1964. (Warren K. Leffler/courtesy of the Library of Congress)</em></p></figure>
+<p><span data-preserver-spaces="true">On Aug. 22, 1964, when Atlantic City hosted the Democratic Party’s convention at Boardwalk Hall, Hamer delivered a speech calling for integration, voting rights, and representation for Black people. She co-founded and represented the new Mississippi Freedom Democratic Party, aiming to replace the state’s all-white delegation.</span></p>
+<p>&#8220;If the Freedom Democratic Party is not seated now, I question America. Is this America, the land of the free and the home of the brave, where we have to sleep with our telephones off of the hooks because our lives be threatened daily because we want to live as decent human beings in America?&#8221; <a href="https://www.google.com/search?q=fannie+lou+hamer+remarks+1964&amp;oq=fannie+lou+hamer+remarks+1964&amp;gs_lcrp=EgZjaHJvbWUyBggAEEUYOTIICAEQABgWGB4yCAgCEAAYFhgeMg0IAxAAGIYDGIAEGIoFMgoIBBAAGIAEGKIEMgoIBRAAGKIEGIkF0gEIMzU5MGowajeoAgCwAgA&amp;sourceid=chrome&amp;ie=UTF-8#fpstate=ive&amp;vld=cid:b8871864,vid:DFC1nc3IXBM,st:0" target="_blank" rel="noopener">she said</a>.</p>
+<p><span data-preserver-spaces="true">Hamer did not succeed in replacing the white delegation that year, but it was integrated for the next convention in 1968. </span></p>
+<p><span data-preserver-spaces="true">“Witnessing the anguish of her testimony didn’t spark immediate change in her circumstances, but Ms. Hamer did change hearts and minds,” said Way, noting Hamer was also a delegate in 1972. </span></p>
+<p><span data-preserver-spaces="true">Way was joined in Atlantic City by lawmakers, civil rights activists, and Mississippi officials as the Democratic National Convention is in its second day in Chicago. Multiple speakers at this year’s convention have honored Hamer, </span><a class="editor-rtfLink" href="https://www.youtube.com/watch?v=3dtNhprZnqE" target="_blank" rel="noopener"><span data-preserver-spaces="true">including Rep. Maxine Waters</span></a><span data-preserver-spaces="true"> (D-California).</span></p>
+<p><span data-preserver-spaces="true">Atlantic City Mayor Marty Small said Vice President Kamala Harris’ potential to be the first Black woman elected president is representative of the progress Hamer helped achieve. </span></p>
+<p><span data-preserver-spaces="true">The plaque will be the first </span><a class="editor-rtfLink" href="https://www.mississippimarkers.com/civil-rights.html" target="_blank" rel="noopener"><span data-preserver-spaces="true">Mississippi Freedom Trail Marker</span></a><span data-preserver-spaces="true"> located outside of Mississippi. The trail was created in 2011 to commemorate the people and places that played a pivotal role in the Civil Rights Movement, including the grocery store where lynching victim Emmett Till was accused of flirting with a white woman and the bus station where Freedom Riders were arrested for integrating public facilities. </span></p>
+<p><span data-preserver-spaces="true">The new marker includes a description of the events at the 1964 convention and explains Hamer’s activism throughout the Civil Rights Movement. She was arrested for sitting in the whites-only section of a bus and faced eviction from her home and violence when she attempted to register to vote. At a December 1964 New York rally speaking alongside Malcolm X about brutal beatings Black people faced in Mississippi, she delivered one of her most well-known quotes: “I am sick and tired of being sick and tired.” </span></p>
+
+<p><span data-preserver-spaces="true">Activist Roy DeBerry traveled to Atlantic City from Mississippi Tuesday for the first time since that convention six decades ago. He was a teenager at the time but said he remembers picketing outside Boardwalk Hall and sleeping outdoors because they couldn’t afford a place to stay. Hamer left the convention hall to encourage them to keep fighting and sing songs, DeBerry said. </span></p>
+<p><span data-preserver-spaces="true">Dave Dennis, also a member of the Mississippi Freedom Democratic Party who spoke on the boardwalk Tuesday, recalled his friendship with Hamer and other civil rights activists whom he said took “bullets for democracy.” </span><span data-preserver-spaces="true">Dennis urged people to fight legislation aimed at preventing communities of color from voting and to continue teaching America’s history of racism and segregation. </span></p>
+<p><span data-preserver-spaces="true">“Make doggone sure that none of that legislation passes, make sure the changes open up the doors for our children to be able to know these histories and be able to exercise their right to vote,” Dennis said. </span></p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Verbal approval enough for consensual wiretaps, appeals court rules</title>
+		<link>https://newjerseymonitor.com/briefs/verbal-approval-enough-for-consensual-wiretaps-appeals-court-rules/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Tue, 20 Aug 2024 20:34:07 +0000</pubDate>
+				<category><![CDATA[Civil Rights + Immigration]]></category>
+		<category><![CDATA[Courts]]></category>
+		<category><![CDATA[appellate court]]></category>
+		<category><![CDATA[Christopher Barclay]]></category>
+		<category><![CDATA[New Jersey Appellate Division]]></category>
+		<category><![CDATA[Ronald Susswein]]></category>
+		<category><![CDATA[wiretap]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14388</guid>
+
+					<description><![CDATA[State law does not require prosecutors to give written approval for wiretaps consented to by one party of a communication, judges find.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2022/04/GettyImages-1135138396-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2022/04/GettyImages-1135138396-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2022/04/GettyImages-1135138396-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2022/04/GettyImages-1135138396-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2022/04/GettyImages-1135138396-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2022/04/GettyImages-1135138396-2048x1365.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">State law does not require prosecutors to give written approval for wiretaps consented to by one party of a communication, judges find. (Getty Images)</p><p style="font-weight: 400;">A New Jersey appeals court declined on Tuesday to require police to obtain written approval before placing wiretaps after obtaining the consent of one caller, keeping in place rules that allow consensual wiretaps as long as a prosecutor gives verbal approval.</p>
+<p style="font-weight: 400;">The three-judge panel found the New Jersey Wiretapping and Electronic Surveillance Control Act remains silent on the format of prosecutorial approval required for consensual wiretaps, which require the consent of one party to the communication and can be applied without a court order.</p>
+<p style="font-weight: 400;">The ruling is a defeat for an Ocean County man who alleged prosecutors improperly recorded a telephone conversation between him and his daughter after she alleged he sexually assaulted her.</p>
+<p style="font-weight: 400;">“Defendant asks us to read into the Act words the Legislature did not choose to include, and to engraft a procedural requirement the Legislature did not choose to impose,” Judge Ronald Susswein wrote for the panel.</p>
+<p style="font-weight: 400;">Because constitutional privacy concerns require authorities to hew close to the wiretapping law’s text, the court was required to strictly construe its language, and imposing additional requirements outside of its text lay beyond the judges’ authority, Susswein wrote.</p>
+<p style="font-weight: 400;">The panel noted the law explicitly requires police to obtain prosecutorial approval in writing when seeking a court order for a wiretap but did not impose an identical requirement on consensual interceptions.</p>
+<p style="font-weight: 400;">The ruling defeats a bid for post-conviction relief by the Ocean County man, who was found guilty in 2018 of sexually assaulting his daughter over the span of seven years starting when she was 6 years old. The New Jersey Monitor is not identifying the man to avoid identifying his victim.</p>
+<p style="font-weight: 400;">He was sentenced to a 19-year prison term and sought to reverse it, charging the wiretap was illegally obtained and that prior attorneys provided ineffective assistance by failing to raise the issue at trial and an earlier appeal.</p>
+<p style="font-weight: 400;">The judges pointed to prior case law that similarly found there was no requirement approval for consensual wiretaps to be in writing, noting those decisions predate 1999 changes to the wiretapping act. If lawmakers intended written approval to be required, they could have written the requirement into law that year, the judges said.</p>
+<p style="font-weight: 400;">“The Legislature did not do that. Indeed, rather than add any new prerequisites, the 1999 amendment deleted the reasonable-suspicion requirement and expanded the list of officials who could give prior approval,” Susswein wrote.</p>
+<p style="font-weight: 400;">
+<p style="font-weight: 400;">The man&#8217;s attorney did not return a request for comment.</p>
+<p style="font-weight: 400;">    <a href="https://newjerseymonitor.com/donate" style="text-decoration:none;">
+    <div class="donateContainer">
+        <div class="donateTextContainer">
+            <p>SUPPORT NEWS YOU TRUST.</p>
+        </div>
+        <div class="donateButtonContainer">
+            <button>DONATE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Federal funds to clear $100 million in medical debt owed by New Jerseyans</title>
+		<link>https://newjerseymonitor.com/2024/08/20/federal-funds-to-clear-100-million-in-medical-debt-owed-by-new-jerseyans/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Tue, 20 Aug 2024 17:34:49 +0000</pubDate>
+				<category><![CDATA[Gov + Legislature]]></category>
+		<category><![CDATA[Health]]></category>
+		<category><![CDATA[Allison Sesso]]></category>
+		<category><![CDATA[Phil Murphy]]></category>
+		<category><![CDATA[Shabnam Salih]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14390</guid>
+
+					<description><![CDATA[Federal American Rescue Plan funds will be used to clear medical debt for more than 46,000 New Jerseyans.]]></description>
+																						<content:encoded><![CDATA[<img width="800" height="502" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/medical-bill-past-due-getty-1024x643-11718872381.jpeg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/medical-bill-past-due-getty-1024x643-11718872381.jpeg 800w, https://newjerseymonitor.com/wp-content/uploads/2024/08/medical-bill-past-due-getty-1024x643-11718872381-300x188.jpeg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/medical-bill-past-due-getty-1024x643-11718872381-768x482.jpeg 768w" sizes="(max-width: 800px) 100vw, 800px" /><p style="font-size:12px;">Federal American Rescue Plan funds will be used to clear medical debt for more than 46,000 New Jerseyans. (Getty Images)</p><p style="font-weight: 400;">New Jersey will use federal dollars to purchase and forgive $100 million in medical debt held by more than 46,000 residents, Gov. Phil Murphy announced Tuesday.</p>
+<p style="font-weight: 400;">The state will use roughly $550,000 in federal American Rescue Plan funds to purchase the debt through a partnership with Undue Medical Debt, a Long Island-based nonprofit that purchases patients’ debts but does not move to collect them.</p>
+<p style="font-weight: 400;">“Medical debt accumulates very quickly and can follow a person for decades. With this strategic investment and our partnership with Undue, we are wiping the slate clean for thousands of New Jersey families, eliminating their debt, and making a real, tangible impact on their lives,” Murphy said in a statement.</p>
+<p style="font-weight: 400;">The bulk of the debt relief, $61.6 million, will target patient debt held by Prime Healthcare through a partnership with the nonprofit. Prime Healthcare operates the country’s fifth-largest hospital network and runs hospitals in Newark, Denville, Dover, and Passaic.</p>
+<p style="font-weight: 400;">The remaining $38.4 million will be purchased off the secondary debt market, primarily from debt collectors, the governor said.</p>
+<p style="font-weight: 400;">Eligible residents must earn no more than four times the federal poverty level — $60,240 for a single adult and $124,800 for a family of four in 2024 — or hold debts that total 5% or more of their annual income.</p>
+<p style="font-weight: 400;">Because the debt is purchased directly from creditors, there is no application for medical debt relief under the program, nor can it be requested.</p>
+<p style="font-weight: 400;">“We hope the tens of thousands of recipients in this first wave of medical debt relief are encouraged to re-engage with the health care system and feel both financial and emotional relief,” said Allison Sesso, the nonprofit’s CEO.</p>
+<p style="font-weight: 400;">The Gothamist <a href="https://gothamist.com/news/nj-gov-murphy-to-forgive-100m-in-medical-debt-for-almost-50k-residents" target="_blank">first reported</a> Murphy’s debt relief announcement.</p>
+<p style="font-weight: 400;">The move comes roughly a month after <a href="https://newjerseymonitor.com/2024/07/22/gov-murphy-signs-new-medical-debt-protections-into-law/">Murphy signed legislation</a> that barred the reporting of most medical debt to credit-rating agencies and capped interest on such debt to 3%.</p>
+<p style="font-weight: 400;">The law, dubbed the Louisa Carman Medical Debt Relief Act after a Murphy administration health care staffer who died in a January car crash, requires creditors to offer payment plans, creates new grace periods for late payment, and bars wage garnishment to pay medical debts for residents making less than 600% of the federal poverty level.</p>
+<p style="font-weight: 400;">Provisions barring credit reporting of medical debt went into effect immediately after Murphy signed the bill, though the rest of the statute will remain inactive until July 22, 2025.</p>
+<p style="font-weight: 400;">“Today’s announcement will lift the burden of medical debt from tens of thousands of NJ residents and families, and with the Governor’s signing, just last month, of the Louisa Carman Medical Debt Relief Act, more New Jerseyans are shielded against the unfair consequences of credit reporting of medical debt,” said Shabnam Salih, director of the state’s health care affordability and transparency office.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Menendez lawyers ask judge to reverse his &#8216;unjust&#8217; conviction in international bribery scheme</title>
+		<link>https://newjerseymonitor.com/2024/08/20/menendez-lawyers-ask-judge-to-reverse-his-unjust-conviction-in-international-bribery-scheme/</link>
+		
+		<dc:creator><![CDATA[Dana DiFilippo]]></dc:creator>
+		<pubDate>Tue, 20 Aug 2024 16:47:24 +0000</pubDate>
+				<category><![CDATA[Courts]]></category>
+		<category><![CDATA[Menendez on trial]]></category>
+		<category><![CDATA[Adam Fee]]></category>
+		<category><![CDATA[Avi Weitzman]]></category>
+		<category><![CDATA[Bob Menendez]]></category>
+		<category><![CDATA[Sidney H. Stein]]></category>
+		<category><![CDATA[Southern District of New York]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14389</guid>
+
+					<description><![CDATA[Lawyers for Sen. Bob Menendez have asked a federal judge to vacate his recent corruption conviction or grant him a new trial.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/07/GettyImages-2161677407.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/07/GettyImages-2161677407.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/07/GettyImages-2161677407-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/07/GettyImages-2161677407-768x512.jpg 768w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">U.S. Sen. Bob Menendez (D-NJ) speaks to the media as he exits Manhattan federal court on July 16, 2024, in New York City. Menendez and his wife Nadine are accused of taking bribes of gold bars, a luxury car, and cash in exchange for using Menendez's position to help the government of Egypt and other corrupt acts according to an indictment from the Southern District of New York. The jury found Menendez guilty on all counts. (Adam Gray | Getty Images)</p><p><span data-preserver-spaces="true">Lawyers for Sen. Bob Menendez have asked a federal judge to vacate his recent corruption conviction or grant him a new trial, saying prosecutors failed to prove New Jersey’s senior senator sold his office for cash, gold bars, a luxury car, and other valuables.</span></p>
+<p><span data-preserver-spaces="true">In a </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/wp-content/uploads/2024/08/8-19-24-Menendez-motion-new-trial.pdf" target="_blank" rel="noopener"><span data-preserver-spaces="true">brief</span></a><span data-preserver-spaces="true"> filed Monday, attorneys Adam Fee and Avi Weitzman rehashed many of the same arguments they made during the 10-week trial in Manhattan, insisting the conviction was &#8220;unjust&#8221; because his actions were the </span><span data-preserver-spaces="true">normal</span><span data-preserver-spaces="true"> and constitutionally protected actions of a federal lawmaker </span><span data-preserver-spaces="true">and that</span><span data-preserver-spaces="true"> trial testimony was “speculation masked as inference.”</span></p>
+<p><span data-preserver-spaces="true">“Simply put, the government did not show any use of Senator Menendez’s official powers to benefit any of the supposed bribe givers, let alone an agreement to do so in exchange for bribes,” they wrote. “If sustained on such a surprisingly thin reed of evidence, these convictions will make terrible, dangerous law. All of Senator Menendez’s convictions must </span><span data-preserver-spaces="true">be reversed</span><span data-preserver-spaces="true">.”</span></p>
+<p><span data-preserver-spaces="true">They called his conviction as a foreign agent under the federal Foreign Agents Registration Act “unprecedented.” Prosecutors had charged Menendez, who at the time of his indictment last fall chaired the powerful Senate Foreign Relations Committee, with acting to benefit the governments of Egypt and Qatar.</span></p>
+<p><span data-preserver-spaces="true">“We have been unable to identify — and the government has not cited — a single prosecution of any public official for violating this statute since its adoption in 1966,” they wrote. “One would expect such extraordinary charges to </span><span data-preserver-spaces="true">be supported</span><span data-preserver-spaces="true"> by extraordinary evidence. Not so.”</span></p>
+<p><span data-preserver-spaces="true">The Democratic senator’s actions at issue in the trial were permissible political activities and don’t support a conviction under that act</span><span data-preserver-spaces="true">, which</span><span data-preserver-spaces="true"> requires evidence that Menendez took </span><span data-preserver-spaces="true">certain</span><span data-preserver-spaces="true"> actions &#8220;at the order, request, or under the direction or control, of a foreign principal,&#8221; they argued.</span></p>
+<p><span data-preserver-spaces="true">“If it were otherwise, FARA would effectively criminalize congressional service,” the attorneys wrote.</span></p>
+<p><span data-preserver-spaces="true">They repeated their complaint that the trial should have happened in New Jersey, not New York, and a judge’s decision to keep it in the Southern District of New York “stretched the Constitution’s venue requirements beyond their breaking point.”</span></p>
+<p><span data-preserver-spaces="true">Nicholas Biase, a </span><span data-preserver-spaces="true">spokesman for the</span><span data-preserver-spaces="true"> U.S. Attorney’s Office in the Southern District of New York, declined to comment.</span></p>
+<p><span data-preserver-spaces="true">Monday’s filing comes on Menendez’s last day in office after a decades-long career in public service. </span><span data-preserver-spaces="true">The three-term senator, 70, announced last month </span><span data-preserver-spaces="true">he would</span><span data-preserver-spaces="true"> resign on Aug. 20, and on Friday </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/08/16/sen-menendez-pulls-independent-bid-for-senate-ending-congressional-career/" target="_blank" rel="noopener"><span data-preserver-spaces="true">withdrew</span></a><span data-preserver-spaces="true"> his</span><span data-preserver-spaces="true"> bid for reelection as an independent candidate.</span></p>
+<p><span data-preserver-spaces="true">It also comes just over two months before </span><span data-preserver-spaces="true">he’s expected</span><span data-preserver-spaces="true"> to return</span><span data-preserver-spaces="true"> to Manhattan for sentencing. He and his co-defendants, Wael Hana and Fred Daibes, are scheduled to appear before federal Judge Sidney H. Stein for sentencing on Oct. 29. All three face decades behind bars.</span></p>
+<p><span data-preserver-spaces="true">Hana, a halal meat exporter, and Daibes, an Edgewater real estate developer, also filed briefs Monday challenging their convictions. Co-defendant Jose Uribe, who pleaded guilty and </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/06/07/yes-i-did-new-jersey-businessman-tells-jury-he-bribed-sen-menendez/" target="_blank" rel="noopener"><span data-preserver-spaces="true">testified against the senator</span></a><span data-preserver-spaces="true"> at trial, is also scheduled to be sentenced Oct. 29.</span></p>
+<p><span data-preserver-spaces="true">Stein indefinitely postponed the trial of the senator’s wife, </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/05/28/prosecutors-say-messages-between-sen-menendez-wife-reveal-details-of-egypt-focused-scheme/" target="_blank" rel="noopener"><span data-preserver-spaces="true">Nadine,</span></a><span data-preserver-spaces="true"> who also was charged, because she is getting treated for breast cancer.</span></p>
+<p><span data-preserver-spaces="true">Menendez, Hana, and Daibes </span><span data-preserver-spaces="true">were </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/07/16/sen-menendez-convicted-of-bribery-other-charges-in-corruption-trial/" target="_blank" rel="noopener"><span data-preserver-spaces="true">convicted</span><span data-preserver-spaces="true"> on all counts</span></a><span data-preserver-spaces="true"> in an 18-count federal indictment that accused the men of plying the senator and his wife with valuables between 2018 and 2022 in exchange for the senator using his influence to help the men </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/06/06/ex-new-jersey-a-g-shares-a-gross-story-of-strong-arming-at-menendezs-corruption-trial/" target="_blank" rel="noopener"><span data-preserver-spaces="true">evade</span></a><span data-preserver-spaces="true"> </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/06/12/official-testifies-sen-menendez-asked-him-to-look-at-criminal-case-targeting-his-friend/" target="_blank" rel="noopener"><span data-preserver-spaces="true">criminal</span></a><span data-preserver-spaces="true"> </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/06/26/as-feds-closed-in-sen-menendezs-wife-cashed-out-jeweler-tells-jury-in-bribery-trial/" target="_blank" rel="noopener"><span data-preserver-spaces="true">troubles</span></a><span data-preserver-spaces="true"> and profit in their </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/05/17/a-very-shady-meat-monopoly-in-egypt-dominates-day-in-menendez-corruption-trial/" target="_blank" rel="noopener"><span data-preserver-spaces="true">international</span></a><span data-preserver-spaces="true"> </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/06/21/prosecutors-in-sen-menendezs-corruption-trial-shift-focus-to-qatar/" target="_blank" rel="noopener"><span data-preserver-spaces="true">business pursuits.</span></a><span data-preserver-spaces="true"> It was the senator&#8217;s second corruption trial; his first ended in a mistrial in 2017 after jurors deadlocked.</span></p>
+<p><span data-preserver-spaces="true">    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	</span></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>&#8216;Exorbitant&#8217; fees on calls, emails cost inmates and their families $15M annually, report says</title>
+		<link>https://newjerseymonitor.com/2024/08/20/exorbitant-fees-on-calls-emails-cost-inmates-and-their-families-15m-annually-report-says/</link>
+		
+		<dc:creator><![CDATA[Sophie Nieto-Munoz]]></dc:creator>
+		<pubDate>Tue, 20 Aug 2024 11:27:28 +0000</pubDate>
+				<category><![CDATA[Criminal Justice]]></category>
+		<category><![CDATA[Marleina Ubel]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14378</guid>
+
+					<description><![CDATA[People inside prisons often can’t afford to keep in contact with their support system due to the cost of communication, advocates say.]]></description>
+																						<content:encoded><![CDATA[<img width="800" height="601" src="https://newjerseymonitor.com/wp-content/uploads/2024/03/gettyimages-sb10062143p-001-1024x769-11687968532.jpeg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/03/gettyimages-sb10062143p-001-1024x769-11687968532.jpeg 800w, https://newjerseymonitor.com/wp-content/uploads/2024/03/gettyimages-sb10062143p-001-1024x769-11687968532-300x225.jpeg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/03/gettyimages-sb10062143p-001-1024x769-11687968532-768x577.jpeg 768w" sizes="(max-width: 800px) 100vw, 800px" /><p style="font-size:12px;">People inside prisons often can’t afford to keep in contact with their support system due to the cost of communication, advocates say. (Bill Pugliano/Getty Images)</p><p style="font-weight: 400;">Incarcerated people and their families spend $15 million annually to stay in communication with each other, largely at the expense of loved ones on the outside who have to foot the bill, <a href="https://www.njpp.org/wp-content/uploads/2024/08/NJPP-PrisonProfiteers-Aug2024.pdf" target="_blank">according to a new report</a>.</p>
+<p style="font-weight: 400;">This means that people inside prisons, who earn extremely low wages at daily rates, often can’t afford to keep in contact with their support system due to the exorbitant fees imposed by two companies that control prison communications, according to the report, released Monday by progressive think tank New Jersey Policy Perspective.</p>
+<p style="font-weight: 400;">“When you take into account the wages that an incarcerated person makes, realistically, they cannot afford to maintain a relationship. Especially if they’re a parent trying to communicate with their child, you can’t afford to talk to somebody as often as you would like to,” said Marleina Ubel, senior policy analyst with the group. “It’s just not possible.”</p>
+<p style="font-weight: 400;">The new report comes four months after <a href="https://newjerseymonitor.com/2024/04/12/prisons-yank-phone-access-for-thousands-of-incarcerated-people-watchdog-says/">one from the state corrections ombudsperson</a> that said the Department of Corrections yanked phone privileges for thousands of incarcerated people as punishment for disciplinary infractions, sometimes for a year or far longer.</p>
+<p style="font-weight: 400;">To communicate with the outside, incarcerated individuals rely on ViaPath for phone calls and JPay for video calls and emails. Phone calls cost about 4 cents per minute, or about 60 cents for 15 minutes; video calls cost about 33 cents per minute, or $9.95 for 30 minutes; and electronic messaging runs around 35 cents per credit or 70 cents for a message with a photo. The low-tech tablets sold by JPay also cost about $50.</p>
+<p style="font-weight: 400;">These are “extraordinarily expensive” for those incarcerated, said Ubel. Sometimes, people spend their entire daily pay just to receive one email with one photo attached, she added.</p>
+<p>Incarcerated workers earn anywhere from $1.60 to $7.50 for a day of work, with most people earning between $1.60 and $3 on average, according to data the group studied from the New Jersey Department of Corrections.</p>
+<p style="font-weight: 400;">People in prison pay for more than just phone calls. They also buy items from the commissary, pay child support, or need funds to pay for medicine. As a result, the majority of costs fall to family members, disproportionately women of color, according to the report. And 1 in 3 families or support systems of people who are incarcerated go into debt to pay for the communication, the report states.</p>
+<p style="font-weight: 400;">New Jersey has the highest disparity across the country between Black and white people in prisons, with Black people making up about 60% of the prison population, and white people, about 20%, according to <a href="https://www.prisonpolicy.org/profiles/NJ.html#:~:text=Black%20people%20in%20New%20Jersey,times%20higher%20than%20white%20people.&amp;text=The%20cost%20of%20incarcerating%20older,over%20the%20age%20of%2055" target="_blank">Prison Policy Initiative</a>, a nationwide group tracking incarceration rates.</p>
+<p style="font-weight: 400;">“You have folks that are already economically vulnerable for a variety of reasons now trying to pay for these fees set by these private companies just to make sure their children can communicate with their parents,” Ubel said.</p>
+<p style="font-weight: 400;">Ubel said this results in hundreds of millions of dollars in profits for these companies, who have monopolized prison communications. Across the state in 2023, JPay made $1.7 million through electronic messages and video calls, and ViaPath brought in more than $4.8 million in revenue from state and county prisons.</p>
+<p style="font-weight: 400;">Daniel Sperrazza, a spokesman for the Department of Corrections, said state prisons account for about $7.6 million of the $15 million spent on calls, videos, and emails.</p>
+<p style="font-weight: 400;">Sperrazza said the state recognizes the positive benefit for incarcerated people when they have contact with loved ones. The department has made communications more affordable and accessible, including by phasing out commissions collected by the state and reducing fees for various services, he said.</p>
+<p style="font-weight: 400;">“New Jersey maintains one of the lowest costs in the nation for phone calls for incarcerated persons, and negotiations are ongoing with a new vendor to further expand and improve access to phone calls, video visits, and other multimedia messaging,” Sperrazza said.</p>
+<p style="font-weight: 400;">Ubel said the state could eliminate all fees for calls and emails.</p>
+<p style="font-weight: 400;">“We can make these communications free for incarcerated people and their families. Quite frankly, it shouldn’t cost anything to send an email,” she said.</p>
+<p>Monday&#8217;s report notes that $15 million makes up just over 1% of the Department of Corrections&#8217; $1.2 billion budget.</p>
+<p style="font-weight: 400;">A <a href="https://www.njleg.state.nj.us/bill-search/2024/S2526" target="_blank" rel="noopener">bill in the state Legislature</a> would require all adult and juvenile correctional facilities, county jails, and private prisons to allow incarcerated people to make and receive calls, video calls, and emails free of charge to both the sending and receiving party.</p>
+<p style="font-weight: 400;">Under the bill, the costs would be shifted to the correctional facility operator. Other states have moved to similar models, including Connecticut, California, Minnesota, and Massachusetts, along with New York City.</p>
+<p style="font-weight: 400;">Sen. Brian Stack (D-Hudson) is sponsoring the bill in the Senate, and Assemblywoman Carmen Theresa Morales (D-Essex) in the lower chamber. 
+<p style="font-weight: 400;">“Maintaining family and community connection while incarcerated is key to successful reentry, and thus it is in the public interest to reduce the economic burden on incarcerated persons associated with making and receiving calls and messages,” the bill reads.</p>
+<p style="font-weight: 400;">The bill, introduced in February, has not yet been heard in either chamber’s committees.</p>
+<p style="font-weight: 400;">    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Summer judicial confirmations unlikely as August winds to a close</title>
+		<link>https://newjerseymonitor.com/2024/08/20/summer-judicial-confirmations-unlikely-as-august-winds-to-a-close/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Tue, 20 Aug 2024 11:06:11 +0000</pubDate>
+				<category><![CDATA[Courts]]></category>
+		<category><![CDATA[Bill Mergner]]></category>
+		<category><![CDATA[John Hoffman]]></category>
+		<category><![CDATA[John Jay Hoffman]]></category>
+		<category><![CDATA[Lee Solomon]]></category>
+		<category><![CDATA[New Jersey State Bar Association]]></category>
+		<category><![CDATA[Nicholas Scutari]]></category>
+		<category><![CDATA[Phil Murphy]]></category>
+		<category><![CDATA[Tahesha Way]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14377</guid>
+
+					<description><![CDATA[Senate President Nicholas Scutari signaled earlier this year that the state Senate might convene in the summer to approve judges, but that appears unlikely now.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2023/05/Scutari4-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/05/Scutari4-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/05/Scutari4-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/05/Scutari4-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2023/05/Scutari4-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2023/05/Scutari4-2048x1365.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Senate President Nicholas Scutari signaled earlier this year that the state Senate might convene in the summer to approve judges, but that appears unlikely now. (Hal Brown for New Jersey Monitor)</p><p><span data-preserver-spaces="true">New Jersey lawmakers have not met to confirm new judges during their customary summer recess, and </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/08/20/biden-delivers-late-night-farewell-to-democrats-as-he-passes-the-torch-to-harris/" target="_blank" rel="noopener"><span data-preserver-spaces="true">the Democratic National Convention</span></a><span data-preserver-spaces="true">, a procedural deadline, and legislators’ summer schedules could keep them from convening until the fall.</span></p>
+<p><span data-preserver-spaces="true">Senate President Nicholas Scutari (D-Union) in late June suggested his members could return to Trenton in August to confirm </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/06/10/gov-murphy-will-nominate-rutgers-general-counsel-to-supreme-court/" target="_blank" rel="noopener"><span data-preserver-spaces="true">Supreme Court nominee John Jay Hoffman</span></a><span data-preserver-spaces="true"> and other nominees tapped for seats on the Superior Court, but the Senate has not gathered, and it’s not clear the chamber will until September.</span></p>
+<p><span data-preserver-spaces="true">Lawmakers had hoped to confirm Hoffman before the start of the new court session on Sept. 1 to replace Justice Lee Solomon, who reached the mandatory retirement age of 70 on Saturday.</span></p>
+<p><span data-preserver-spaces="true">Meanwhile, judicial vacancies that have plagued the state for much of Gov. Phil Murphy’s time in office were down to 40 at the end of June, their lowest level in years, but have since risen to 43, with one judge due to retire on Sept. 1 and five others set to age out or step down by the end of the year.</span></p>
+<p><span data-preserver-spaces="true">Chief Justice Stuart Rabner and other top judiciary officials have said the courts could operate sustainably with as many as 30 vacancies. </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/briefs/legislature-in-recess-with-judicial-vacancies-still-higher-than-court-officials-want/" target="_blank" rel="noopener"><span data-preserver-spaces="true">Scutari in June said</span></a><span data-preserver-spaces="true"> the state is “no longer in a state of emergency” when it comes to judicial vacancies, but Bill Mergner, president of the New Jersey State Bar Association, objects.</span></p>
+<p><span data-preserver-spaces="true">“I have the greatest respect for the Senate president, have known him his entire legal career. But when it&#8217;s said that the judicial crisis is over, I think that&#8217;s unfair to sitting judges,” Mergner said Monday. “I speak with judges virtually every day, and the most common thing that I hear is how heavy the workload is.”</span></p>
+<p><span data-preserver-spaces="true">Mergner added that he believes the increased workload created by vacancies is causing more judges to retire sooner.</span></p>
+<p><span data-preserver-spaces="true">The Democratic Party’s national convention in Chicago, which some New Jersey lawmakers like Scutari are attending, makes it unlikely the Senate will meet this week (the event wraps Thursday evening).</span></p>
+<p><span data-preserver-spaces="true">A potential meeting in late August would also brush against </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/07/08/possible-august-session-for-senate-would-force-gov-murphy-to-act-on-some-bills/" target="_blank" rel="noopener"><span data-preserver-spaces="true">a procedural deadline in the state constitution</span></a><span data-preserver-spaces="true"> that makes bills that have sat on the governor’s desk for at least 45 days law without the governor’s signature when their chamber of origin next calls a quorum, as the Senate must when it convenes a voting session.</span></p>
+<p><span data-preserver-spaces="true">Lawmakers in both chambers approved a flurry of bills on June 28, and while Murphy has signed some bills, others that began in the Senate are still on his desk after the Aug. 12 45-day-rule deadline.</span></p>
+<p><span data-preserver-spaces="true">Murphy and Lt. Gov. Tahesha Way have so far signed 13 of the 33 Senate bills approved by both chambers in late June.</span></p>
+<p><span data-preserver-spaces="true">The deadline doesn’t guarantee bills will become laws without the governor’s signature. When previously met with that deadline, Murphy has issued a flurry of last-minute bill actions.</span></p>
+<p><span data-preserver-spaces="true">    <h4 class="editorialSubhed">Spots of concern in some counties</h4>
+
+	</span></p>
+<p><span data-preserver-spaces="true">Though overall judicial vacancies remain lower than they have been for much of the past four years, vacancies in a handful of New Jersey counties are approaching levels that could require the courts to pause some trials to direct judges’ limited time to family law and criminal cases the judiciary considers most pressing.</span></p>
+<p><span data-preserver-spaces="true">That would not be unprecedented. Rabner last year </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2023/07/05/civil-divorce-trials-resume-in-three-counties-pause-in-passaic/" target="_blank" rel="noopener"><span data-preserver-spaces="true">paused civil and divorce trials in Passaic County</span></a><span data-preserver-spaces="true"> and </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2023/02/07/courts-suspend-civil-divorce-trials-in-six-counties-amid-stunning-judicial-vacancies/" target="_blank" rel="noopener"><span data-preserver-spaces="true">two multi-county court jurisdictions</span></a><span data-preserver-spaces="true"> where no fewer than 25% of seats there were vacant (trials have since resumed in all three court districts).</span></p>
+<p><span data-preserver-spaces="true">In Vicinage 15, a court jurisdiction covering Cumberland, Gloucester, and Salem counties, a little more than 32% of seats were vacant when Rabner paused some trials there.</span></p>
+<p><span data-preserver-spaces="true">As of Monday, at least 20% of judgeships were vacant in four counties — Mercer, Somerset, Sussex, and Union.</span></p>
+<p><span data-preserver-spaces="true">Somerset and Sussex counties fall within multi-county court districts where overall staffing remains high. The latter county’s small size means there is only one vacancy there, and there are nominees for all three vacancies in Somerset.</span></p>
+<p><span data-preserver-spaces="true">Union and Mercer counties had six and five vacancies, respectively, and none of the nine would-be Superior Court judges awaiting confirmation hailed from those counties. Mergner said some the Bar Association’s judicial and prosecutorial appointments committee had vetted potential judges from Union County.</span></p>
+<p><span data-preserver-spaces="true">“I feel like they&#8217;re working towards a package, but the time lag to do that is such that they&#8217;re sitting there … with very few judges,” Mergner said.</span></p>
+
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>‘Never, ever give up’: Hillary Clinton urges Democrats to fight for Harris win</title>
+		<link>https://newjerseymonitor.com/2024/08/20/never-ever-give-up-hillary-clinton-urges-democrats-to-fight-for-harris-win/</link>
+		
+		<dc:creator><![CDATA[Ariana Figueroa]]></dc:creator>
+		<pubDate>Tue, 20 Aug 2024 10:46:06 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Donald Trump]]></category>
+		<category><![CDATA[Hillary Clinton]]></category>
+		<category><![CDATA[Joe Biden]]></category>
+		<category><![CDATA[Kamala Harris]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14382</guid>
+
+					<description><![CDATA[Clinton, the 2016 Democratic presidential nominee, said that together, women have put “a lot of cracks in the highest, hardest glass ceiling.”]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/Hillary-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/Hillary-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Hillary-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Hillary-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Hillary-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Hillary-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">CHICAGO, ILLINOIS - AUGUST 19: Former U.S. Secretary of State Hillary Clinton speaks onstage during the first day of the Democratic National Convention at the United Center on August 19, 2024 in Chicago, Illinois.  Delegates, politicians, and Democratic party supporters are in Chicago for the convention, concluding with current Vice President Kamala Harris accepting her party's presidential nomination. The DNC takes place from August 19-22. (Photo by Joe Raedle/Getty Images)</p><p>CHICAGO — Hillary Clinton, the first woman to clinch a major political party’s presidential nomination, on the first night of the Democratic National Convention praised Vice President Kamala Harris — the second woman in U.S. history to be nominated — for her bright vision for the nation and her ability to lead the country forward.</p>
+<p>“The story of my life and the history of our country is that progress is possible, but not guaranteed,” Clinton told a packed crowd in the United Center. “We have to fight for it. And never, ever give up.”</p>
+<p>Clinton, the 2016 Democratic presidential nominee, said that together, women have put “a lot of cracks in the highest, hardest glass ceiling.”</p>
+<p>“On the other side of that glass ceiling is Kamala Harris taking the oath of office as our 47th President of the United States,” she said. “When a barrier falls for one of us, it … clears the way for all of us.”</p>
+<p>Clinton said that Harris’ historic nomination, as the first Black and South Asian woman at the top of a major party ticket, is an opportunity for the country to progress.</p>
+<p>Clinton said that every generation has “carried the torch forward,” and that Harris will carry that torch as she pushes for the restoration of abortion access, affordable housing and child care.</p>
+<p>Harris has often promised to restore Roe v Wade, the Supreme Court ruling that gave Americans the constitutional right to an abortion. However, in order to pass legislation in Congress, Democrats would need to control the House and have 60 votes in the Senate to advance legislation past the filibuster.</p>
+    <h4 class="editorialSubhed">Women in history</h4>
+
+	
+<p>Clinton highlighted Democratic women who had broken barriers throughout history. She cited the late U.S. Rep. Shirley Chisholm, the first woman to run for the Democratic Party presidential nomination, and the first Black person to seek to be a major party’s candidate for president, and the late U.S. Rep. Geraldine Ferraro, the first woman nominated for the vice presidency by a major political party.</p>
+<p>Clinton said that accepting the presidential nomination was the greatest honor of her life. She touched on her loss to Donald Trump in 2016, and noted that despite it, there was a wave of women who ran for public office following Trump’s ascension to the White House.</p>
+<p>“We refused to give up on America,” she said.</p>
+<p>Clinton said that when she looks at Harris’ campaign she sees freedom.</p>
+<p>“I see freedom from fear and intimidation, from violence and injustices, from chaos and corruption,” she said.</p>
+<p>Harris indeed has framed her campaign as a fight for freedom, and as an effort to move forward as opposed to Trump and the GOP. Additionally, Beyonce’s song “Freedom” is the campaign’s anthem.</p>
+    <h4 class="editorialSubhed">Harris speaks</h4>
+
+	
+<p>Harris, who made a brief surprise appearance before Clinton spoke, thanked President Joe Biden for his leadership before she stressed that the November elections are a fight for the future.</p>
+<p>“This November, we will come together and declare with one voice, as one people, we are moving forward,” Harris said. “We all have so much more in common than what separates us.”</p>
+<p>Harris is expected to give her speech accepting the nomination on Thursday night.</p>
+<p>Clinton said that Harris would be “for the people,” which was also the theme of the first night of the convention. Clinton criticized Trump and said that the former president only cares about himself, not Americans.</p>
+<p>She said that Democrats have Trump “on the run,” but urged them to not get too comfortable, even as Harris’ campaign has energized Democrats across the nation. Clinton warned Democrats to not rely on the polls, which have shown Harris either gaining on Trump or ahead, and said they must keep campaigning until November.</p>
+<p>Since Biden suspended his reelection campaign, after a disastrous June debate that rattled his party’s belief in his ability to defeat Trump, several battleground states that were leaning toward Republicans, such as Georgia, Nevada and Arizona, moved to a “toss-up,”<a href="https://www.cookpolitical.com/analysis/national/national-politics/presidential-campaign-reset-arizona-georgia-and-nevada-move" target="_blank"> according to The Cook Political Report with Amy Walter. </a></p>
+<p>“No matter what the polls say, we can’t let up,” Clinton said.</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Biden delivers late-night farewell to Democrats as he passes the torch to Harris</title>
+		<link>https://newjerseymonitor.com/2024/08/20/biden-delivers-late-night-farewell-to-democrats-as-he-passes-the-torch-to-harris/</link>
+		
+		<dc:creator><![CDATA[Jacob Fischler]]></dc:creator>
+		<pubDate>Tue, 20 Aug 2024 10:43:52 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Donald Trump]]></category>
+		<category><![CDATA[Joe Biden]]></category>
+		<category><![CDATA[Kamala Harris]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14380</guid>
+
+					<description><![CDATA[In the final minutes of perhaps the final major political speech in a half-century-long career, Biden quoted a song by Gene Scheer. “America, America, I gave my best to you,” he said.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="682" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/BidenDNC-scaled-1-1024x682.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/BidenDNC-scaled-1-1024x682.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/BidenDNC-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/BidenDNC-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/BidenDNC-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/BidenDNC-scaled-1-2048x1365.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">CHICAGO, ILLINOIS - AUGUST 19: U.S. President Joe Biden speaks onstage during the first day of the Democratic National Convention at the United Center on August 19, 2024 in Chicago, Illinois.  Delegates, politicians, and Democratic party supporters are in Chicago for the convention, concluding with current Vice President Kamala Harris accepting her party's presidential nomination. The DNC takes place from August 19-22. (Photo by Chip Somodevilla/Getty Images)</p><p>CHICAGO –– After waiting nearly an hour to deliver a scheduled-for-prime-time speech that was pushed to nearly 11:30 p.m. Eastern time, President Joe Biden waited an extra three minutes at the lectern on the first night of the Democratic National Convention as chants from party faithful drowned out his attempts to begin.</p>
+<p>When planning for the convention began, Biden was expected to speak, as the party’s nominee, on the final night.</p>
+<p>Instead, he spoke Monday as a leader a few months away from retirement, and as a bridge to new Democratic leadership.</p>
+<p>“I love my job,” he said as he approached the end of his remarks. “But I love my country more.”</p>
+<p>In the final minutes of perhaps the final major political speech in a half-century-long career, Biden quoted a song by Gene Scheer.</p>
+<p>“America, America, I gave my best to you,” he said.</p>
+<p>Early and often as he spoke, the thousands of Democratic delegates at the United Center voiced their appreciation, delaying and interrupting him with chants of “We love Joe.”</p>
+<p>Hours after another crowd, protesters opposed to Biden’s handling of Israel’s war with Hamas in the Gaza Strip, gathered outside the convention hall, Biden gave his strongest remarks to date on the conflict, calling for a cease-fire. He conceded the protesters “have a point.”</p>
+<p>Biden’s address provided a glimpse of what an acceptance speech for a second Democratic nomination might have looked like. But instead of promising what he would do in a second term, he said Vice President Kamala Harris would continue the administration’s work.</p>
+<p>Biden endorsed Harris as his replacement on the Democratic ticket when he withdrew from the race last month under pressure from Democratic leaders, following his debate performance in June.</p>
+<p>In a moment that seemed to surprise Biden, Harris and second spouse Doug Emhoff joined the president and first lady on stage directly after the speech.</p>
+    <h4 class="editorialSubhed">‘The best volunteer’</h4>
+
+	
+<p>Throughout the address, Biden promoted his own record and said Harris and her running mate, Minnesota Gov. Tim Walz, possessed the same values and character that would lead to policies Democrats want.</p>
+<p>“I promise I’ll be the best volunteer the Harris and Walz campaign has ever seen,” he said.</p>
+<p>Much of his remarks were also focused on the Republican nominee, former President Donald Trump, whom Biden defeated in the 2020 election.</p>
+<p>Biden’s appearance was bumped out of the prime-time block, as scores of earlier speakers and performers forced Democrats’ debut night further and further off schedule. Some had to be rescheduled.</p>
+<p>“Because of the raucous applause interrupting speaker after speaker, we ultimately skipped elements of our program to ensure we could get to President Biden as quickly as possible so that he could speak directly to the American people,” convention officials said in a statement.</p>
+<p>“We are proud of the electric atmosphere in our convention hall and proud that our convention is showcasing the broad and diverse coalition behind the Harris-Walz ticket throughout the week on and off the stage.”</p>
+    <h4 class="editorialSubhed">Infrastructure, gun safety, prescription drugs</h4>
+
+	
+<p>Biden promoted his record over nearly four years in office. The country was no longer in the throes of the COVID-19 pandemic, he said.</p>
+<p>He said wages were trending up and inflation was moving down, though he noted there was still more to do on those issues.</p>
+<p>He delivered a massive infrastructure bill, signed a bipartisan gun safety law and worked to bring costs of prescription drugs down.</p>
+<p>Promoting the successes of his administration, Biden highlighted Harris’ role.</p>
+<p>When he mentioned the passage of a major Democratic bill in 2022 to boost clean energy production, cap some prescription drug costs and other measures, the crowd responded with a chant of “Thank you, Joe.”</p>
+<p>“Thank you, Kamala, too,” Biden replied.</p>
+    <h4 class="editorialSubhed">Middle East</h4>
+
+	
+<p>Biden also said he had much still to do and addressed an issue that has divided Democrats during the past year of his presidency: Israel’s war in Gaza.</p>
+<p>He said his administration was working to get humanitarian aid into Gaza.</p>
+<p>“And finally, finally, finally deliver a cease-fire and end this war,” he said, pounding the lectern with his fist. “Those protesters out in the street, they have a point. A lot of innocent people are getting killed on both sides.”</p>
+<p>On other issues, he said Harris and Walz would continue his work.</p>
+<p>“Kamala and Tim will make the child tax cut permanent,” he said, referring to a COVID 19-era provision that increased a tax credit for families.</p>
+    <h4 class="editorialSubhed">Contrast with Trump</h4>
+
+	
+<p>Biden called Trump a tool of authoritarian leaders, such as Russian President Vladimir Putin.</p>
+<p>Biden repeated a story he told throughout the 2020 campaign that he decided to run for president and challenge Trump’s reelection after Trump excused a deadly rally of white supremacists in Charlottesville, Virginia.</p>
+<p>Biden rejected political violence and professed a commitment to enduring democracy, a theme he sounded in his 2020 campaign that only gained more relevance after the Jan. 6, 2021, attack on the U.S. Capitol by Trump supporters who sought to keep him in the White House.</p>
+<p>Trump has again not said he would accept the results of an election loss, Biden said.</p>
+<p>Electing Harris was a necessary step in protecting democracy, he said.</p>
+<p>“Democracy has prevailed, democracy has delivered,” he said. “And now, democracy must be preserved.”</p>
+    <h4 class="editorialSubhed">Union message</h4>
+
+	
+<p>As he has through much of his half-century in national politics, Biden appealed to union members, a traditional Democratic constituency.</p>
+<p>“Wall Street didn’t build America,” he said. “The middle class built America, and unions built the middle class.”</p>
+<p>He said he was proud to have walked the picket line with striking member of the United Auto Workers.</p>
+<p>Earlier in the evening, UAW President Shawn Fain in remarks to the crowd praised Biden for making history as the first president to walk a picket line.</p>
+    <h4 class="editorialSubhed">Passing the torch</h4>
+
+	
+<p>Speakers throughout the evening praised Biden for his record in office and for passing the torch to Harris.</p>
+<p>Delaware Sen. Chris Coons, a Biden ally who took Biden’s seat in the Senate after Biden was elected vice president, said Biden helped the nation recover from the COVID-19 pandemic and the Jan. 6 attack.</p>
+<p>“On behalf of our nation, Joe, for your courage in fighting for our democracy, we thank you,” Coons said. “On behalf of our Democratic Party, for fighting for our Democratic values, we thank you.”</p>
+<p>First lady Jill Biden said the president worked for causes larger than himself, which she was reminded of as she saw him “dig deep into his soul and decide to no longer seek reelection and endorse Kamala Harris.”</p>
+<p>U.S. Rep. James Clyburn of South Carolina, the third-ranking Democrat in the House for years, also praised Biden’s decision to make Harris his running mate, and to endorse her when he dropped out.</p>
+<p>Talking to reporters after his official remarks, Clyburn said a Harris victory in November would bookend Biden’s role in Black presidential history. After serving eight years as vice president to the first Black president, Clyburn said, Biden chose the first Black vice president, Harris.</p>
+<p>If Harris wins the November election, Clyburn said, “Joe Biden goes down in history as probably the most transformational president this country’s ever had.”</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>‘We can sleep when we’re dead’: Walz rallies Wisconsin sprint to Election Day</title>
+		<link>https://newjerseymonitor.com/2024/08/19/we-can-sleep-when-were-dead-walz-rallies-wisconsin-sprint-to-election-day/</link>
+		
+		<dc:creator><![CDATA[Jacob Fischler]]></dc:creator>
+		<pubDate>Mon, 19 Aug 2024 18:07:46 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Kamala Harris]]></category>
+		<category><![CDATA[Tim Walz]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14375</guid>
+
+					<description><![CDATA[Minnesota Gov. Tim Walz told a crowd gathered in Chicago for the Democratic National Convention to focus not only on defeating Donald Trump but to take motivation from their own agenda.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="768" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/Facetune_08-08-2024-04-32-29-2048x1536-1-1024x768.jpeg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/Facetune_08-08-2024-04-32-29-2048x1536-1-1024x768.jpeg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Facetune_08-08-2024-04-32-29-2048x1536-1-300x225.jpeg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Facetune_08-08-2024-04-32-29-2048x1536-1-768x576.jpeg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Facetune_08-08-2024-04-32-29-2048x1536-1-1536x1152.jpeg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Facetune_08-08-2024-04-32-29-2048x1536-1.jpeg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Minnesota Gov. Tim Walz told a crowd gathered in Chicago for the Democratic National Convention to focus not only on defeating Donald Trump but to take motivation from their own agenda. (Anna Liz Nichols)</p><p>CHICAGO –– Minnesota Gov. Tim Walz, the Democratic candidate for vice president, made a surprise appearance at a Democratic National Convention breakfast program for the delegation from Wisconsin — one of a handful of battleground states — to encourage attendees to continue their hard campaign push to the Nov. 5 election.</p>
+<p>Repeating a refrain from his short time on the campaign trail so far, Walz urged the Wisconsinites to sprint to Election Day to elect Vice President Kamala Harris. She is scheduled to deliver an acceptance speech as the party’s presidential nominee Thursday evening.</p>
+<p>“We’ve got 78 days of hard work,” said Walz. “We can sleep when we’re dead.”</p>
+<p>Harris’ entrance into the race less than a month ago — following President Joe Biden’s decision to withdraw — has energized Democrats, leading to a flurry of new volunteers signing up for the campaign, Walz said.</p>
+<p>Walz told the crowd to focus not only on defeating former President Donald Trump, the Republican nominee, but to take motivation from their own agenda.</p>
+<p>“It’s not just beating those guys,” Walz said. “It’s about the idea of the things that we believe in, whether it’s democracy or freedom or the strength of our public schools.”</p>
+<p>Maryland Gov. Wes Moore sounded a similar tone in his remarks to the delegation.</p>
+<p>“The reason we are all fired up … is not because we are afraid of the alternative,” Moore said. “We don’t need to spend any more time talking about how dangerous that alternative is. The reason that we are going to fight, the reason that we are going to win, is not because we are afraid of the alternative, it is because we are so hopeful and so optimistic about what the future is going to be like in a Harris-Walz administration.”</p>
+<p>A Democratic administration would address housing insecurity, child poverty and gun violence, Moore said.</p>
+<p>The message of Democratic unity resonated with Michael Jones, a Wisconsin delegate and special education teacher in Madison.</p>
+<p>“While we all understand how terrible the alternative is, we’re not just talking about that, but we’re also talking about the joy and the positivity of when we come together,” he said.</p>
+    <h4 class="editorialSubhed">Swing state</h4>
+
+	
+<p>Speakers noted the importance of Wisconsin as one of a handful of toss-up states in the presidential election.</p>
+<p>“You know what you have to do,” New York Gov. Kathy Hochul told the group. “The nation is counting on you.”</p>
+<p>Wisconsin Gov. Tony Evers told reporters, following his prepared remarks, that Democrats in the state would work to turn out voters in the presidential election.</p>
+<p>“That’s our job,” he said. “We can’t expect Tim Walz or Kamala Harris to be showing up in Wisconsin every day. So we’re going to do it.”</p>
+<p>U.S. Senate Majority Leader Chuck Schumer of New York also addressed the delegation, saying Wisconsin Sen. Tammy Baldwin’s reelection race was critical to retaining a Democratic majority in the chamber.</p>
+<p>“We can’t keep the Senate without” Baldwin winning, he said.</p>
+<p>Schumer promoted Baldwin’s work in the Senate, including on a bipartisan bill to promote microchips manufacturing.</p>
+    <h4 class="editorialSubhed">Education a top issue</h4>
+
+	
+<p>The drop-in from Walz energized delegates, including Terri Wenkman, from Jefferson, Wisconsin.</p>
+<p>“I was excited most about the surprise visit from Tim Walz,” Wenkman, a former school board member, said. “Public education is a huge piece for me, so the selection of somebody that was a public school teacher and a true huge advocate for public education, I really identify with that.”</p>
+<p>Wenkman added that Walz’s message to drive hard to the finish line resonated, saying that the shortened campaign season may benefit Democrats.</p>
+<p>Walz’s background as a high school teacher and football coach came through in his delivery, Jones said.</p>
+<p>Evers, also a former teacher and state schools superintendent, made a reference during his prepared remarks to Walz’s teaching career.</p>
+<p>“We know what happens when we elect teachers,” he said.</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>What does the history of rail service in New Jersey tell us about its ongoing dysfunction?</title>
+		<link>https://newjerseymonitor.com/2024/08/19/what-does-the-history-of-rail-service-in-new-jersey-tell-us-about-its-ongoing-dysfunction/</link>
+		
+		<dc:creator><![CDATA[Dan Cassino]]></dc:creator>
+		<pubDate>Mon, 19 Aug 2024 11:02:51 +0000</pubDate>
+				<category><![CDATA[Commentary]]></category>
+		<category><![CDATA[Transportation]]></category>
+		<category><![CDATA[NJ Transit]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14371</guid>
+
+					<description><![CDATA[A new book on the northeast corridor by SUNY Buffalo professor David Alff shows that few of the problems that NJ Transit is facing now are new.]]></description>
+																						<content:encoded><![CDATA[<img width="799" height="533" src="https://newjerseymonitor.com/wp-content/uploads/2022/05/28154850317_f5d8c37920_c.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2022/05/28154850317_f5d8c37920_c.jpg 799w, https://newjerseymonitor.com/wp-content/uploads/2022/05/28154850317_f5d8c37920_c-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2022/05/28154850317_f5d8c37920_c-768x512.jpg 768w" sizes="(max-width: 799px) 100vw, 799px" /><p style="font-size:12px;">A new book on the northeast corridor by SUNY Buffalo professor David Alff shows that few of the problems that NJ Transit is facing now are new. (Photo by Edwin J. Torres/NJ Governor's Office)</p><p style="font-weight: 400;">Despite decades of promises and the efforts of governors of both parties, NJ Transit <a href="https://newjerseymonitor.com/2024/08/15/nj-transit-will-be-free-for-a-week-as-apology-for-ugly-summer-governor-says/" target="_blank" rel="noopener">still isn’t working</a>.</p>
+<p style="font-weight: 400;">This past summer saw days of mass cancellations and delays due to drooping power lines. The last time the service met its own goal of 94.7% on time was more than six months ago (and that’s even with their rather flexible definition of what “on time” means). As anyone who’s traveled to the European Union, Japan, or China can attest, rail service in other countries is generally faster, cheaper, and more reliable than it is here. The question is why, and what can be done about it.</p>
+<p style="font-weight: 400;">Some of the answers come from the history of rail service in New Jersey, as presented in <a href="https://press.uchicago.edu/ucp/books/book/chicago/N/bo212886389.html" target="_blank" rel="noopener">“The Northeast Corridor: The Trains, the People, the History, the Region,”</a> by David Alff. Alff — an English professor at SUNY Buffalo — has put together a history of northeast corridor train service and shows that few of the problems that we’re facing now are new, and almost all of them are rooted in a confluence of cut corners and short-sighted, strategy-free decision making.</p>
+<p style="font-weight: 400;">Alff’s historical work documents the extent to which current problems are nothing new. During the Civil War, riders complained that Camden &amp; Amboy train cars in New Jersey were “crammed to suffocation” and “prone to delay.” One lawmaker accused the line of fraud “almost as pernicious” as that of the Confederacy. Still, it’s a little upsetting to read about John Quincy Adams measuring the speed of a train outside of New York City that’s faster than some NJ Transit trains hit on that line of track today (though Adams also saw the car behind him explode shortly afterward).</p>
+<p style="font-weight: 400;">The biggest reason trains on the northeast corridor will never go as fast as their global counterparts isn’t a lack of ingenuity, investment, or interest, but the bends in the tracks: trains have to slow down to tackle curves, and New Jersey rail is lousy with them. In many cases, the rails follow Native American trails that predate European colonization; in others, like the s-curve that runs through Elizabeth, they follow towpaths and highways from the 1770s. One area of track in South Jersey swings around what was once the estate of Joseph Bonaparte, who won a case at the Supreme Court preventing a rail line through his property. Attempts to build straighter lines meant going through towns, leading in some cases to local riots, or landslides; it was easier to build tracks along the meandering highways and turnpikes that already existed. Even when track straightening did happen — as it did after the Civil War around Princeton — it didn’t make things any more convenient: That straightening meant moving the trains to Princeton Junction, and doomed decades to the Dinky.</p>
+<p style="font-weight: 400;">For almost a century, there have been attempts to run high-speed trains through New Jersey. In the 1930s, the diesel-electric Comet was hitting 110 miles per hour on the New Haven line. The TurboTrain of the 1960s could hit 170 outside of Princeton Junction (those straight tracks paid off), but averaged about 60. The Metroliner, first run in 1969, could go 160, but drew too much power from the overhead lines to be reliable. The Acela — and its upcoming replacement — was marred by a botched rollout but has been, by far, the best attempt at bringing high-speed rail to New Jersey. But without straight tracks, nothing approaching the trains of other developed countries is likely to happen.</p>
+<p style="font-weight: 400;">Some have argued that the problem is government ownership, and that private industry would do a better job (or at least couldn’t do worse). Alff quotes Heritage Foundation economist Stephen Moore writing, in 1990, “Imagine what Donald Trump could do with passenger rail service” (eventually Moore was on then-President Trump’s economic team and authored a chapter of the now infamous “Project 2025” book). Of course, Amtrak was formed largely because passenger rail hadn’t been profitable in decades, and despite a statutory requirement to the contrary, Amtrak has never turned a profit, nor had enough money to do everything that customers and legislators want it to do, and that was before Reagan-era funding cuts, which reduced its subsidy in half over the 1980s. The trains of the northeast corridor were run by a succession of private companies until the formation of Amtrak, and their record of deferring maintenance and paying dividends rather than serving travelers is consistent. If nothing else, there are a lot fewer major rail accidents than there were when private companies were in charge.</p>
+<p style="font-weight: 400;">Many of the delays this summer were caused by power line problems. Alff makes it clear that these issues, too, have roots in the deep history of the corridor. A horrific wreck near Danbury led to a ban on steam trains; a series of electrocutions led to a ban on third-rail designs. Catenary lines were the one technology of the time that was left; trains built with them in mind means that we can’t replace them without rebuilding the trains and tracks from the ground up.</p>
+
+<div class=" newsroomBlockQuoteContainer  ">
+	<div class="newsroomBlockQuoteSVGContainer">
+		<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12.81 9">
+			<g>
+				<path d="M2.7,0A3,3,0,0,0,.7.8,2.64,2.64,0,0,0,0,2.7,2.14,2.14,0,0,0,.8,4.4a2.84,2.84,0,0,0,1.7.7,1.45,1.45,0,0,0,.7-.2,1.45,1.45,0,0,1,.7-.2q.3,0,.3.6A3.47,3.47,0,0,1,3,7.6a4.21,4.21,0,0,1-2.6,1V9a5.51,5.51,0,0,0,4-1.6A5.06,5.06,0,0,0,6,3.7a3.92,3.92,0,0,0-.9-2.6A3.19,3.19,0,0,0,2.7,0Z"/>
+				<path d="M11.8,1.1A2.84,2.84,0,0,0,9.5,0a2.79,2.79,0,0,0-2,.8,2.64,2.64,0,0,0-.7,1.9,2.06,2.06,0,0,0,.7,1.7,2.41,2.41,0,0,0,1.8.7,1.85,1.85,0,0,0,.7-.2,1.45,1.45,0,0,1,.7-.2q.3,0,.3.6A2.94,2.94,0,0,1,9.8,7.6a4.21,4.21,0,0,1-2.6,1V9a5.51,5.51,0,0,0,4-1.6,4.6,4.6,0,0,0,1.6-3.8A3.47,3.47,0,0,0,11.8,1.1Z"/>
+			</g>
+		</svg>
+	</div>
+	<div class="newsroomBlockQuoteQuoteContainer">
+		<p class="newsroomBlockQuote ">Few of the problems that we’re facing now are new, and almost all of them are rooted in a confluence of cut corners and short-sighted, strategy-free decision making.</p>
+	</div>
+		<div class="newsroomBlockQuoteAuthorContainer">
+		<p style="font-size:13px"><b>– Dan Cassino</b></p>
+	</div>
+	</div>
+
+	
+<p style="font-weight: 400;">A point Alff makes repeatedly is the difference in approaches between the train system in the United States and that of other countries. Rail service in other countries is seen as a technology to move people around efficiently: its infrastructure is no different than highways and not expected to make money. Moreover, just as many developed countries with universal health care got it in the wake of World War II, when widespread devastation left a vacuum, it may have been easier to build straight, efficient, fast rail lines in areas that had been destroyed.</p>
+<p style="font-weight: 400;">The other part of the problem is national politics. There have always been proponents of rail trying to better fund the system. But the people living along the corridor are disproportionately Democratic (Alff puts the figure at 70% supporting Joe Biden in the 2020 presidential election), and disproportionately wealthy. Getting officials from other parts of the country to fund rail service for this one area has been difficult.</p>
+<p style="font-weight: 400;">Alff’s history of the northeast corridor ends on upbeat notes about Moynihan Hall and the success of the Acela, and as illuminating as the history is, it doesn’t provide much hope for fixing the problems that our rail system faces now. These problems facing our trains are nothing new, and neither are the responses from our leaders. Alff quotes an Amtrak ad from 1971, which pleads that fixing rail will “take time and work. But we’re going to do it. Just be patient.” More than fifty years later, we’re still waiting.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>&#8216;Let’s get this thing done:&#8217; Harris and Walz campaign in Pennsylvania</title>
+		<link>https://newjerseymonitor.com/2024/08/19/lets-get-this-thing-done-harris-and-walz-campaign-in-pennsylvania/</link>
+		
+		<dc:creator><![CDATA[Kim Lyons]]></dc:creator>
+		<pubDate>Mon, 19 Aug 2024 10:45:36 +0000</pubDate>
+				<category><![CDATA[Election 2024]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14369</guid>
+
+					<description><![CDATA[Sunday marked Vice President Harris’ eighth visit to Pennsylvania this year, and her 18th visit since being sworn into office.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167293512-kamala-pgh-8-2024.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167293512-kamala-pgh-8-2024.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167293512-kamala-pgh-8-2024-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-2167293512-kamala-pgh-8-2024-768x512.jpg 768w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">PITTSBURGH, PENNSYLVANIA - AUGUST 18:  Democratic presidential candidate, U.S. Vice President Kamala Harris and Democratic vice presidential candidate Minnesota Gov. Tim Walz arrive to a campaign event at Wright Bros. Aero, Inc. on August 18, 2024 in Pittsburgh, Pennsylvania. Harris and Walz will take part in a Pennsylvania bus tour and visit multiple cities in western Pennsylvania.  (Photo by Anna Moneymaker/Getty Images)</p><p>PITTSBURGH — Vice President Kamala Harris and Minnesota Gov. Tim Walz campaigned in western Pennsylvania on Sunday, taking a bus to communities in Allegheny and Beaver counties to speak directly with voters in this crucial swing state.</p>
+<p>Joined by their spouses Doug Emhoff and Gwen Walz, Sunday was the running mates’  first appearance in the western end of the state together, and came the day before the Democratic National Convention opens in Chicago.</p>
+<p>Harris and Walz arrived at Pittsburgh International Airport shortly after 1 p.m. and were greeted by a cheering crowd of roughly 100 people, posing for selfies before boarding the tour bus and hitting the road. They visited several key Pittsburgh-area locales in the roughly six-hour visit, including a Primanti Bros. and a Sheetz – where Harris picked up some Doritos.</p>
+<p>To start the tour, the candidates and their spouses boarded a tour-style bus with their names emblazoned on the side, and headed first to a campaign field office in Rochester, where they participated in a phone bank and spoke to supporters.</p>
+<p>Walz told the gathering in Rochester that Harris was drawing such large crowds at her rallies because she is “bringing out the joy” to the campaign. “It is so much better to be for something rather than against something, to be for the future,” Walz said. He added he could remember a time “when you could go to Thanksgiving, watch a Steelers game with your relatives and not complain about politics the whole time.”</p>
+<p>Walz, a former high school football coach, spoke about coming into football country, and used a game metaphor to describe the stakes of the election.</p>
+<p>“When that game’s over, you want to know you left it all on the field, and that’s all we’re asking. Let’s give it all the field. Let’s get this thing done,” he said.</p>
+<p>Harris told the gathering in Rochester her campaign was born out of love for her country.</p>
+<p>“When you know what you stand for, you know what to fight for,” she said. “When you stand for working people, you fight for working people. When you stand for freedom, whether it be to make decisions about your own body or love who you love, you fight for those things.”</p>
+<p>“That’s what our election is about,” she added.</p>
+<p>She also spoke about a “perversion” in politics over the past few years that suggests “that the measure of the strength of a leader is based on who you beat down, when what we know is the real and true measure of the strength of a leader is based on who you lift up.”</p>
+<p>The bus tour stopped next at a firehouse in Aliquippa, where Harris presented the firefighters with a burnt almond torte from Prantl’s Bakery, a specialty of western Pennsylvania. They headed next to Aliquippa High School’s football stadium, home of the <a href="https://www.easternpafootball.com/the-2023-aliquippa-quips-are-the-first-undefeated-state-champion-in-school-history-beating-dallas-60-14-in-the-4a-final/#:~:text=2024%20Season!!!-,The%202023%20Aliquippa%20Quips%20are%20the%20first%20undefeated%20state%20champion,Follow%20Joseph%20Santoliquito%20on%20Twitter." target="_blank">2023 undefeated state champion Quips</a> team.</p>
+<p>Harris told the team that it was not easy being a role model, but that she was counting on them to be the next generation of leaders.</p>
+<p>“Being a role model means that members of your family, people you know in the neighborhood, others in your classes, they watch to see what you do,” she said. “And you all take on that responsibility …  and inspire people you may not even know to want to be like you.”</p>
+<p>Harris and Walz were joined on the tour by U.S. Rep. Chris Deluzio (D-17th District), whose district includes parts of Allegheny and Beaver counties, and U.S. Sen. Bob Casey (D-Pa.), as well as former Steelers running back Jerome Bettis (a fitting guest for a bus tour, given that his nickname as a player was “The Bus.”)</p>
+<p>Deluzio, a Navy veteran, blasted Harris’ Republican opponent, former President Donald Trump, for his <a href="https://www.washingtonpost.com/politics/2024/08/16/trump-medal-of-honor-much-better/" target="_blank">comments</a> about veterans and <a href="https://www.theatlantic.com/politics/archive/2020/09/trump-americans-who-died-at-war-are-losers-and-suckers/615997/" target="_blank">members of the military.</a></p>
+<p>“In almost any family around here, someone’s worn a uniform, someone stepped up to serve,” Deluzio said. “It’s who we are, and they spit on that service. Think about that. It’s not just disrespecting our culture, it’s disrespecting our service.”</p>
+<p>Trump campaign spokesperson Kush Desai criticized Harris’ economic proposal and “flip-flops” on policy issues in a statement Sunday. “Kamala Harris has a lot of questions to answer for everyday Pennsylvanians,” Desai said. “And while Kamala hasn’t been and won’t be answering unscripted questions any time soon, Pennsylvanians know better than to buy her lies, spin, and gaslighting anyway.”</p>
+<p>Harris did speak with reporters, however, answering questions after greeting diners at a Primanti Bros’ restaurant in Moon, the tour’s final stop before heading back to the airport. There was a sizable group of Trump supporters protesting outside the restaurant as Harris and the tour bus arrived.</p>
+<p>She declined to “speak for” Israeli Prime Minister Benajamin Netanyahu, when asked if she thought he was ready to agree to a ceasefire deal. “I will tell you that these conversations are ongoing and we are not giving up,” Harris said. “We are going to continue to work very hard on this. We’ve got to get a ceasefire, and we’ve got to get the hostages.”</p>
+<p>Harris also was asked if she felt like she had to make up ground in Pennsylvania.</p>
+<p>“I feel like we need to earn every vote, and that means being on the road, being in communities where people are, where they live,” she said, “So I’m gonna be out here with Tim, with the second gentleman, with Mrs. Walz, and we’re gonna be working on earning every vote between now and November.”</p>
+<p>Harris officially became the <a href="https://penncapital-star.com/election-2024/kamala-harris-officially-becomes-the-democratic-presidential-nominee/" target="_blank">Democratic presidential nominee earlier this month</a> by a roll call vote of Democratic National Committee delegates, after President Joe Biden bowed out of his reelection bid July 21 and endorsed her.</p>
+<p>Sunday marked Harris’ eighth visit to Pennsylvania this year, and her 18th visit since being sworn into office. She introduced Walz as her running mate on Aug. 6 in Philadelphia. She also appeared <a href="https://penncapital-star.com/election-2024/vice-president-kamala-harris-comes-to-philadelphia-to-court-asian-american-voters/" target="_blank">in Philadelphia to court Asian-American voters</a> on July 13 and has also made stops <a href="https://penncapital-star.com/transportation-infrastructure/vice-president-harris-visits-pittsburgh-to-tout-5-8-billion-for-clean-water-lead-pipe-removal/" target="_blank">this cycle in Pittsburgh</a> to tout the administration’s infrastructure investments; in <a href="https://penncapital-star.com/election-2024/vp-kamala-harris-in-philadelphia-to-tout-biden-administrations-latest-student-debt-relief/" target="_blank">Philadelphia to discuss student debt with educators</a>; and in Montgomery County to <a href="https://penncapital-star.com/abortion-policy/weve-got-to-have-these-conversations-out-loud-vp-harris-talks-abortion-in-pennsylvania/" target="_blank">speak in support of reproductive rights</a>.</p>
+<p>Although he visited the eastern half of the state several times in 2024, Biden only made one campaign stop in western Pennsylvania, visiting the United Steelworkers in April ahead of the state’s primary election.</p>
+<p>Trump campaigned in Wilkes-Barre on Saturday, and is holding a press conference in York on Monday. His running mate, U.S. Sen. J.D. Vance (R-Ohio) will also be in Pennsylvania on Monday, at a separate press conference in Philadelphia.</p>
+<p>Trump did not mention abortion at the rally in Wilkes-Barre, a key issue that Harris has led on for the Biden administration and during the campaign. But in addition to declaring “I’m a better looking person than Kamala”  at Saturday’s rally, Trump criticized Harris’ economic policies.</p>
+<p>“Inflation has been devastating under this group of people that have no idea what the hell they’re doing,” Trump said. “Are you better off with Kamala and Biden than you were under President Donald J. Trump? I don’t think so.”</p>
+<p>The annual<a href="https://www.cnbc.com/2024/08/14/july-consumer-price-index.html" target="_blank"> inflation rate was 2.9% in July</a>, the lowest rate since 2021, but <a href="https://apnews.com/article/harris-economy-inflation-food-prices-campaign-c3bbfd8aa3bfd2be3e98d021f0a182ac" target="_blank">both campaigns have put the economy</a> front and center, as it remains top of mind for voters. Harris unveiled an economic proposal on Friday which included plans to ease rent increases, boost first-time home buyers, end grocery price gouging and bolster the child tax credit.</p>
+<p>A <a href="https://poll.qu.edu/poll-release?releaseid=3902" target="_blank">Quinnipiac University poll released Aug. 14</a> shows Harris slightly leading Trump among likely voters in Pennsylvania, with three third-party candidates factored in. Harris polled especially well with women, Quinnipiac found.</p>
+<p>“With all five contenders factored in, Harris has an edge overall, with strong support from women in must-win Pennsylvania,” Quinnipiac University Polling Analyst Tim Malloy said in a press release.</p>
+<p>After Sunday’s tour of western Pennsylvania, Harris and Walz were scheduled to head to Chicago. He’ll address the DNC on Wednesday, and she will formally accept Democrats’ nomination for president on Thursday.</p>
+<p><em><a href="https://penncapital-star.com" target="_blank">Pennsylvania Capital-Star</a> is part of States Newsroom, a nonprofit news network supported by grants and a coalition of donors as a 501c(3) public charity. Pennsylvania Capital-Star maintains editorial independence. Contact Editor Kim Lyons for questions: <a href="mailto:info@penncapital-star.com">info@penncapital-star.com</a>. Follow Pennsylvania Capital-Star on <a href="https://facebook.com/penncapitalstar" target="_blank">Facebook</a> and <a href="https://x.com/PennCapitalStar" target="_blank">X</a>.</em></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Move over, presidential race. These state governments also are up for grabs.</title>
+		<link>https://newjerseymonitor.com/2024/08/19/move-over-presidential-race-these-state-governments-also-are-up-for-grabs/</link>
+		
+		<dc:creator><![CDATA[Kevin Hardy]]></dc:creator>
+		<pubDate>Mon, 19 Aug 2024 10:41:46 +0000</pubDate>
+				<category><![CDATA[Election 2024]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14366</guid>
+
+					<description><![CDATA[While Republicans are primed to maintain their national advantage in statehouse control, several legislative chambers could flip.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="717" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/Minnesota-Capitol.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/Minnesota-Capitol.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Minnesota-Capitol-300x210.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Minnesota-Capitol-768x538.jpg 768w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">The Minnesota State Capitol in St. Paul is photographed as the sun sets on Election Day 2020. Minnesota is among the states that could see partisan legislative control change after November’s elections, according to experts at the National Conference of State Legislatures. Tony Webster/For Minnesota Reformer</p><p>The presidential race gets the hype, but the nearly 6,000 state legislative races across the country in November’s elections could reshape power dynamics in some states.</p>
+<p>While Republicans are primed to maintain their national advantage in statehouse control, several legislative chambers could flip, said Ben Williams, associate director of elections and redistricting at the National Conference of State Legislatures.</p>
+<p>The GOP currently controls 57 legislative chambers, while Democrats control 41 (Nebraska’s unicameral legislature is nonpartisan). But, with narrow majorities in some chambers, Williams is eyeing several where a different party could take over. And divided government in more legislatures could result in more moderate policymaking on a host of controversial issues.</p>
+<p>Only one state — Pennsylvania — currently has a split legislature.</p>
+<div class="newsroomSidebarContainer ">
+<div class="newsroomSidebar">
+<h4>    <h4 class="editorialSubhed">State chamber races</h4>
+
+	</h4>
+<p>These state chambers are considered in play in November’s election:</p>
+<p>Arizona House</p>
+<p>Arizona Senate</p>
+<p>Michigan House</p>
+<p>Minnesota House</p>
+<p>New Hampshire House</p>
+<p>New Hampshire Senate</p>
+<p>Pennsylvania House</p>
+<p>Pennsylvania Senate</p>
+<p>Wisconsin House</p>
+<p>Wisconsin Senate</p>
+</div>
+</div>
+<p>“If you are at a historic low for divided government nationwide, it’s a generally pretty safe bet to assume it’s going to go up,” Williams said. He laid out his predictions for the fall elections at the organization’s annual summit earlier this month.</p>
+<p>He pointed to 10 competitive chambers to watch: the Arizona House, Arizona Senate, Michigan House, Minnesota House, New Hampshire House, New Hampshire Senate, Pennsylvania House, Pennsylvania Senate, Wisconsin House and the Wisconsin Senate.</p>
+<p>Only three governor’s races — in New Hampshire, North Carolina and Washington — are <a href="https://www.cookpolitical.com/ratings/governor-race-ratings" target="_blank">characterized as competitive</a> by the Cook Political Report, a nonpartisan newsletter that analyzes state and federal races.</p>
+<h4>    <h4 class="editorialSubhed">Voter concerns</h4>
+
+	</h4>
+<p>Nationally, the issues of inflation, abortion, immigration and foreign policy are at the forefront for voters, Williams said. But voters often have different concerns in state elections.</p>
+<p>“Just because you see these national trends does not mean that that always reflects down to the state level,” he said. “There are local dynamics that are always at play that can make a difference.”</p>
+<p>Republicans and Democrats are working to break apart trifectas (when a single party controls both chambers of the legislature and the governor’s office) or veto-proof majorities in several states.</p>
+<p>That’s true in Kansas, where Republicans hold veto-proof majorities in both chambers.</p>
+<p>In the state Senate, Democrats would need to flip three seats to break the supermajority of Republicans, <a href="https://ballotpedia.org/Kansas_State_Senate" target="_blank">who currently holds 29 of the chamber’s 40 seats.</a> Erasing a veto-proof majority would give more policymaking influence to Democratic Gov. Laura Kelly, said state Sen. Dinah Sykes, the state Senate minority leader.</p>
+<p>If Democrats weren’t facing veto-proof majorities, Sykes said the <a href="https://kansasreflector.com/2024/06/18/kansas-senate-votes-to-approve-tax-package-negotiated-by-gop-leaders-democratic-governor/" target="_blank">state’s recent $2 billion tax cut </a>probably would have been more favorable to low-income earners. And breaking supermajorities would give the governor a better shot at getting a vote on Medicaid expansion — a long-standing Democratic priority. <a href="https://stateline.org/2024/07/19/in-the-10-states-that-didnt-expand-medicaid-1-6m-cant-afford-health-insurance/#:~:text=The%20Affordable%20Care%20Act%2C%20also,care%20for%20low%2Dincome%20people." target="_blank">Kansas is among the 10 states</a> not to have expanded the safety net program.</p>
+<p>“I don’t think by any means it’s going to be super-progressive, but I think we can get kind of more middle of the road, which is what Kansans actually like,” she said.</p>
+<h4>    <h4 class="editorialSubhed">Divided government</h4>
+
+	</h4>
+<p>For Republicans, winning one or both chambers in Maine would force more compromise from Democrats, said state Rep. Billy Bob Faulkingham, a Republican and the House minority leader.</p>
+<p>With a trifecta, Maine Democrats have been able to circumvent GOP lawmakers, Faulkingham said.</p>
+
+<div class=" newsroomBlockQuoteContainer  ">
+	<div class="newsroomBlockQuoteSVGContainer">
+		<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12.81 9">
+			<g>
+				<path d="M2.7,0A3,3,0,0,0,.7.8,2.64,2.64,0,0,0,0,2.7,2.14,2.14,0,0,0,.8,4.4a2.84,2.84,0,0,0,1.7.7,1.45,1.45,0,0,0,.7-.2,1.45,1.45,0,0,1,.7-.2q.3,0,.3.6A3.47,3.47,0,0,1,3,7.6a4.21,4.21,0,0,1-2.6,1V9a5.51,5.51,0,0,0,4-1.6A5.06,5.06,0,0,0,6,3.7a3.92,3.92,0,0,0-.9-2.6A3.19,3.19,0,0,0,2.7,0Z"/>
+				<path d="M11.8,1.1A2.84,2.84,0,0,0,9.5,0a2.79,2.79,0,0,0-2,.8,2.64,2.64,0,0,0-.7,1.9,2.06,2.06,0,0,0,.7,1.7,2.41,2.41,0,0,0,1.8.7,1.85,1.85,0,0,0,.7-.2,1.45,1.45,0,0,1,.7-.2q.3,0,.3.6A2.94,2.94,0,0,1,9.8,7.6a4.21,4.21,0,0,1-2.6,1V9a5.51,5.51,0,0,0,4-1.6,4.6,4.6,0,0,0,1.6-3.8A3.47,3.47,0,0,0,11.8,1.1Z"/>
+			</g>
+		</svg>
+	</div>
+	<div class="newsroomBlockQuoteQuoteContainer">
+		<p class="newsroomBlockQuote ">If people are being honest, probably the best form of government is a divided government.</p>
+	</div>
+		<div class="newsroomBlockQuoteAuthorContainer">
+		<p style="font-size:13px"><b>– Maine Republican state Rep. Billy Bob Faulkingham</b></p>
+	</div>
+	</div>
+
+	
+<p><span style="font-size: 16px;">Last year, Democrats passed a two-year, nearly $10 billion budget in a legislative maneuver that one Republican </span><a style="font-size: 16px;" href="https://apnews.com/article/maine-legislature-budget-b1d7bb93f4984b5c5dc6098db84af72b" target="_blank">described as the “tyranny of the majority.”</a><span style="font-size: 16px;"> The move allowed Democrats to pass the budget with a simple majority — rather than the two-thirds majority that is usually required.</span></p>
+<p>Faulkingham said gaining control of even one chamber will result in more moderate policymaking.</p>
+<p>“I think that all of a sudden, you would see people actually come to the table and negotiate, which you haven’t seen for the last six years,” he said. “If people are being honest, probably the best form of government is a divided government.”</p>
+<p>If the elections turn out to be a red wave, with Republicans making significant gains across the board, NCSL expects the Democratic-controlled House and Senate chambers in Delaware, Maine, Nevada and Oregon to be in play.</p>
+<p>Conversely, if Democrats do well nationally, the GOP-controlled chambers in Alaska and Georgia could be competitive.</p>
+<p>“These states are not as red as some might believe,” Williams told Stateline in an interview. “In Alaska’s House, the Republicans have a bare majority in each chamber. And in Georgia, Democrats only need to flip around 10 seats. So, it’s not an insurmountable task.”</p>
+<p>The Alaska legislature is governed by bipartisan majority coalitions, even though voters send more Republicans to Juneau.</p>
+<p>State Sen. Gary Stevens, a Republican who leads the Senate majority, said he doesn’t expect November’s election results to disrupt the majority coalition, even if Democrats or more conservative Republicans pick up seats.</p>
+<p>Alaska has the nation’s smallest state Senate, with 20 members. The 17-member Senate majority currently shares power between parties and is largely focused on more moderate issues, Stevens said.</p>
+<p>“It means we can’t deal with extreme issues — either far left or far right,” he said. “It simply means that we need to concentrate on those things in the middle that need to be done.”</p>
+<p>After years of planning, Minnesota Democrats <a href="https://www.mprnews.org/story/2022/11/09/minnesota-democrats-win-capitol-trifecta" target="_blank">seized the trifecta</a> in 2022, when they flipped the Senate and maintained control of the House and governorship.</p>
+<p>Since then, the legislature has approved bills that guarantee the right to abortion, provide free meals for kids at school, restore voting rights to felons released from prison and make the state a “trans refuge” for children seeking gender-affirming care. Those were <a href="https://minnesotareformer.com/2024/08/07/heres-what-tim-walz-has-done-as-governor-of-minnesota/" target="_blank">all signed into law by Gov. Tim Walz</a>, who is now Vice President Kamala Harris’ running mate in the presidential election.</p>
+<p>Those were hard-won progressive achievements, Democratic state Rep. Leigh Finke said. With only a <a href="https://ballotpedia.org/Minnesota_State_Senate" target="_blank">one-seat advantage</a> in the Senate, policy negotiations were fierce, as the majority worked to get all of their fellow Democrats on board.</p>
+<p>“It may seem frustrating at times, but I think it really made our policy better because we knew we were going to have to fight for it,” she said.</p>
+<p><em><a href="https://stateline.org" target="_blank">Stateline</a> is part of States Newsroom, a nonprofit news network supported by grants and a coalition of donors as a 501c(3) public charity. Stateline maintains editorial independence. Contact Editor Scott S. Greenberger for questions: <a href="mailto:info@stateline.org">info@stateline.org</a>. Follow Stateline on <a href="https://facebook.com/statelinenewsroom" target="_blank">Facebook</a> and <a href="https://x.com/stateline_news" target="_blank">X</a>.</em></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Sen. Menendez pulls independent bid for Senate, ending Congressional career</title>
+		<link>https://newjerseymonitor.com/2024/08/16/sen-menendez-pulls-independent-bid-for-senate-ending-congressional-career/</link>
+		
+		<dc:creator><![CDATA[Sophie Nieto-Munoz]]></dc:creator>
+		<pubDate>Fri, 16 Aug 2024 19:35:49 +0000</pubDate>
+				<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Menendez on trial]]></category>
+		<category><![CDATA[Politics]]></category>
+		<category><![CDATA[Bob Menendez]]></category>
+		<category><![CDATA[Congress]]></category>
+		<category><![CDATA[elections]]></category>
+		<category><![CDATA[Nadine Menendez]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14362</guid>
+
+					<description><![CDATA[N.J.'s senior senator's decision to withdraw from the race comes days just before he was set to resign on Aug. 20.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/07/GettyImages-2161674431.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/07/GettyImages-2161674431.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/07/GettyImages-2161674431-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/07/GettyImages-2161674431-768x512.jpg 768w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">U.S. Sen. Bob Menendez (D-NJ) exits Manhattan federal court on July 16, 2024, in New York City. Menendez and his wife Nadine are accused of taking bribes of gold bars, a luxury car, and cash in exchange for using Menendez's position to help the government of Egypt and other corrupt acts according to an indictment from the Southern District of New York. The jury found Menendez guilty on all counts. (Adam Gray | Getty Images)</p><p><span style="font-weight: 400;">Sen. Bob Menendez is withdrawing his bid as an independent candidate for a fourth term in the U.S. Senate, ending a once-storied political career marred by accusations and an eventual <a href="https://newjerseymonitor.com/2024/07/16/sen-menendez-convicted-of-bribery-other-charges-in-corruption-trial/">conviction on bribery and corruption charges. </a></span></p>
+<p><span style="font-weight: 400;">Menendez, 70, informed the New Jersey Division of Elections by email Friday afternoon in a letter that was publicly released by the Secretary of State’s office, which oversees elections. The deadline to withdraw from the Nov. 5 election is Friday at 11:59 p.m. </span></p>
+<p><span style="font-weight: 400;">His withdrawal from the race comes four days before he was expected to resign. Gov. Phil Murphy <a href="https://newjerseymonitor.com/2024/08/16/governor-murphy-appoints-former-chief-of-staff-to-menendezs-senate-seat/">announced Friday morning that his former chief of staff, George Helmy,</a> will fill the seat until voters pick a new senator in November. </span></p>
+<p>&#8220;I am advising you that I wish to have my name withdrawn from the ballot,&#8221; Menendez wrote in an email sent to Donna Barber, acting director of the state Division of Elections.</p>
+<p><span style="font-weight: 400;">Menendez, a Democrat, filed in June to run as an independent candidate while he sat almost daily in a Manhattan courthouse fighting 16 federal charges of bribery, extortion, acting as an agent of a foreign government, obstruction of justice, and fraud. In mid July, he was convicted on all counts. </span></p>
+<p><span style="font-weight: 400;">He has steadfastly maintained his innocence since his September indictment and throughout his 10-week trial and vowed to appeal. Amid pressure from top Democrats including Senate Majority Leader Chuck Schumer and Sen. Cory Booker, Menendez <a href="https://newjerseymonitor.com/2024/07/23/sen-menendez-to-resign-ending-storied-career-capped-by-bribery-conviction/">announced shortly after his conviction that he’d resign. </a></span></p>
+<p><span style="font-weight: 400;">Menendez’s political career began at age 20, when he was elected to the Union City School Board of Education, and later served as Union City’s mayor. He was first appointed to the Senate in 2006 by then-Gov. Jon Corzine to fill a vacant seat. He was re-elected three times since then, eventually becoming chairman of the powerful Senate Foreign Relations Committee. </span></p>
+<p><span style="font-weight: 400;">Throughout his tenure in Congress, Menendez, the son of Cuban immigrants, was well-known for fighting for immigrants&#8217; rights and<a href="https://newjerseymonitor.com/2024/07/22/close-the-chapter-move-on-latinos-say-after-sen-menendezs-bribery-conviction/"> was revered by the Latino community.</a> He also served on the finance and banking committees. </span></p>
+<p><span style="font-weight: 400;">His latest criminal troubles weren’t his first. In 2015, he was charged with bribery for accepting gifts from Salomon Melgen, a Florida eye doctor and major donor, in exchange for his political influence. That case ended in a 2017 mistrial, and Menendez was re-elected the following year. </span></p>
+<p><span style="font-weight: 400;">In his current case, federal prosecutors in New York <a href="https://newjerseymonitor.com/2023/09/22/sen-menendez-faces-bribery-related-offenses-in-second-criminal-case/">accused</a> the senator last fall and in several superseding indictments of trying to disrupt the criminal probes and prosecutions of friends and associates, working to help his friends&#8217; business interests, and doing political favors for Egypt and Qatar in exchange for cash, gold bars, a Mercedes-Benz convertible, and other valuables.</span><span style="font-weight: 400;"> <a href="https://newjerseymonitor.com/wp-content/uploads/2024/03/3-5-24-Menendez-indcitment.pdf">In March,</a> prosecutors added obstruction of justice charges, after Menendez repaid some of the money he and his wife Nadine received and claimed it was loans. </span></p>
+<p><span style="font-weight: 400;">His trial began in May, with <a href="https://newjerseymonitor.com/2024/06/10/businessman-describes-asking-sen-menendez-for-help-in-killing-criminal-probe/">colorful testimony</a> from <a href="https://newjerseymonitor.com/2024/06/06/ex-new-jersey-a-g-shares-a-gross-story-of-strong-arming-at-menendezs-corruption-trial/">powerful political players </a>that revealed the senator&#8217;s <a href="https://newjerseymonitor.com/2024/06/05/jurors-at-menendez-corruption-trial-hear-about-a-boozy-dinner-and-an-unusual-offer/">secret meetings in steakhouses</a> and stories of how <a href="https://newjerseymonitor.com/2024/06/18/adviser-testifies-about-menendez-schemes-to-bully-the-press-blame-the-white-house/">advisors schemed to plant articles in the press</a>. Menendez did not testify at the trial, and jurors found him guilty on all counts after three days of deliberations.</span></p>
+<p><span style="font-weight: 400;">He was tried alongside two businessmen, Wael Hana and Fred Daibes, who were also convicted on all counts. A third businessman, Jose Uribe, pleaded guilty and testified against the three men. Nadine Menendez was also charged, but the judge delayed her trial indefinitely after she was diagnosed with breast cancer. </span></p>
+<p><span style="font-weight: 400;">The senator, Hana, and Daibes are expected to be sentenced Oct. 29 in federal court in Manhattan. </span></p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>The big moment arrives for Harris: Democratic convention kicks off Monday in Chicago</title>
+		<link>https://newjerseymonitor.com/2024/08/16/the-big-moment-arrives-for-harris-democratic-convention-kicks-off-monday-in-chicago/</link>
+		
+		<dc:creator><![CDATA[Ariana Figueroa]]></dc:creator>
+		<pubDate>Fri, 16 Aug 2024 17:31:30 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Politics]]></category>
+		<category><![CDATA[Kamala Harris]]></category>
+		<category><![CDATA[Tim Walz]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14359</guid>
+
+					<description><![CDATA[Vice President Kamala Harris will accept the Democratic nomination in her presidential bid Thursday at the party’s convention in Chicago.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/DNCSigns-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/DNCSigns-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/DNCSigns-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/DNCSigns-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/DNCSigns-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/DNCSigns-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Signs marking states' seating sections are installed and adjusted ahead of the Democratic National Convention at the United Center on Aug. 15, 2024, in Chicago. The convention will be held Aug. 19-22.  (Chip Somodevilla | Getty Images)</p><p>Just a little over a month after she became a candidate for president in the biggest shakeup in generations of presidential politics, Vice President Kamala Harris on Thursday will deliver a widely anticipated speech accepting the Democratic nomination at the party’s convention in Chicago.</p>
+<p>Harris’ ascent to the top of the ticket after President Joe Biden changed course and said he would not seek reelection has breathed new life into the Democratic bid, with polls showing Harris — who is already <a href="https://www.newsfromthestates.com/article/kamala-harris-will-be-democratic-presidential-nominee-dnc-announces" target="_blank">the party’s official nominee</a> after a virtual roll call earlier this month — faring much better than Biden was against Republican rival Donald Trump.</p>
+<p>Over the course of four days, Democrats will look to capitalize on their base’s newfound enthusiasm for the campaign, with leading speakers aiming to rally the faithful around the party’s positions on reproductive rights, gun safety and voting rights, while<a href="https://www.newsfromthestates.com/article/harris-ballot-democrats-work-build-momentum-bigger-youth-vote" target="_blank"> making a strong pitch to young voters</a>. Harris will also be expected to further lay out her policy positions.</p>
+<p>Harris’ nomination is historic. The daughter of immigrants, Harris is the first Black and South Asian woman selected to lead a major party ticket. She would be the first woman of any race to guide the nation as chief executive.</p>
+<p>The party has not released an official detailed schedule of speakers, but a convention official confirmed that “current and past presidents are expected to participate in convention programming.” Biden and two former presidents, Barack Obama and Bill Clinton, as well as former nominee Hillary Clinton, will all speak, <a href="https://www.nytimes.com/2024/08/12/us/politics/dnc-speakers-biden-obama-clinton.html" target="_blank">according to the New York Times.</a></p>
+<p>Vice presidential candidate Minnesota Gov. Tim Walz is expected to address the convention Wednesday evening, with Harris’ acceptance speech closing out the convention Thursday, the convention official said.</p>
+<p>The evening programming block will run from 6:30 p.m. to 11 p.m. Eastern Time on Monday and 7 p.m. to 11 p.m. the rest of the week.</p>
+<p>In addition to the usual television broadcasts, the convention will livestream on several social media platforms, including YouTube, X, Instagram and TikTok. The official live stream will be available on <a href="https://demconvention.us9.list-manage.com/track/click?u=d68a84b1a4b0303a9452770cd&amp;id=e86e03e670&amp;e=a21b6b7198" target="_blank">DemConvention.com</a>.</p>
+<p>Scores of Democratic caucus and council meetings, as well as state delegation breakfasts and gatherings, are also scheduled throughout the week’s daytime hours. Media organizations and outside groups are also holding daytime events that will feature Democratic officeholders and candidates.</p>
+<p>Protests are also expected over the Biden administration’s handling of the Israel-Hamas war, with the backdrop of a <a href="https://minnesotareformer.com/2024/04/08/israel-hamas-war-sets-progressive-and-young-voters-on-collision-course-with-white-house/" target="_blank">delegation of uncommitted voters</a> who oppose the war.</p>
+<p>As many as 25,000 protestors are expected over the course of the convention, according to DemList, a newsletter for Democratic officials and allies.</p>
+    <h4 class="editorialSubhed">A contest transformed</h4>
+
+	
+<p>Harris’ entry into the race, nearly immediately after Biden <a href="https://www.newsfromthestates.com/article/president-joe-biden-bows-out-reelection-campaign-harris-vows-win-nomination-8" target="_blank">announced on July 21</a> he would no longer seek reelection, energized Democrats distressed over Biden’s poor showings in polls against Trump, whose reelection bid Biden turned back in 2020.</p>
+<p>A Monmouth University <a href="https://www.monmouth.edu/polling-institute/reports/monmouthpoll_US_081424/" target="_blank">poll published Aug. 14</a> showed a huge jump in enthusiasm for Democrats. The survey found 85% of Democratic respondents were excited about the Harris-Trump race. By comparison, only 46% of Democratic respondents said in June they were excited about a Biden-Trump race.</p>
+<p>Harris is also seeing better polling numbers in matchups against Trump, with battleground-state and national surveys consistently shifting toward the Democratic ticket since Biden left the race.</p>
+<p>Polls of seven battleground states <a href="https://www.cookpolitical.com/survey-research/2024-swing-state-project/fight-redefine-2024-race-president" target="_blank">published</a> by The Cook Political Report With Amy Walter on Aug. 14 showed Harris narrowly leading in five states — Arizona, Michigan, North Carolina, Pennsylvania and Wisconsin — and tied in Georgia and trailing in Nevada. All were improvements from Biden’s standing in the same poll in May.</p>
+<p><a href="https://poll.qu.edu/poll-release?releaseid=3902" target="_blank">An Aug. 14 survey from Quinnipiac University</a> showed Harris with a 48%-45% edge in Pennsylvania. The 3-point advantage for Harris was within the poll’s margin of error.</p>
+<p>Democrats hope to carry the momentum through the convention. Polls typically favor a party during and immediately after its national party gathering.</p>
+<p>Despite the recent polling, Harris and Walz continue to describe themselves <a href="https://www.youtube.com/watch?v=WkwZ_A49hb8" target="_blank">as underdogs in the race</a>.</p>
+    <h4 class="editorialSubhed">Campaign themes</h4>
+
+	
+<p>In her short time on the campaign trail, Harris has emphasized a few core messages.</p>
+<p>She’s made reproductive rights a central focus, including the slogan “We are not going back” in her stump speech after describing Republicans’ position on abortion. Additionally, a Texas woman who had to leave the state for an emergency abortion will speak at the DNC, <a href="https://www.reuters.com/world/us/texas-woman-who-left-state-abortion-back-harris-convention-2024-08-15/" target="_blank">according to Reuters.</a></p>
+<p>Harris has also played up her background as a prosecutor, drawing a contrast with Trump’s legal troubles.</p>
+<p>Walz has highlighted his working-class background and military service, while attacking Republican positions to restrict reproductive rights and ban certain books in schools.</p>
+<p>Walz’s <a href="https://www.newsfromthestates.com/article/walz-first-solo-speech-vp-candidate-touts-dem-tickets-labor-union-ties" target="_blank">first solo campaign stop</a> since Harris selected him as her running mate was at a union convention, where he emphasized his union background as a high school teacher.</p>
+<p>Walz was not initially considered the favorite to be Harris’ running mate, but his appeal as a Midwesterner with a record of winning tough elections and enacting progressive policies <a href="https://www.newsfromthestates.com/article/minnesota-gov-tim-walz-picked-harris-her-running-mate-democratic-ticket" target="_blank">led to his selection</a> Aug. 6.</p>
+<p>Harris has faced criticism for not sitting down for a formal media interview or holding a press conference since she became a candidate.</p>
+    <h4 class="editorialSubhed">Platform in flux</h4>
+
+	
+<p>Democrats have not finalized their platform for 2024. Adopting a party platform is generally among the official items at a convention.</p>
+<p>The party set <a href="https://democrats.org/news/dnc-releases-2024-party-platform-draft-outlining-historic-record-and-bold-agenda-for-president-biden-and-vice-president-harris-to-finish-the-job/" target="_blank">a draft platform</a> in July just eight days before Biden dropped his reelection bid. The document centered on the theme of “finishing the job” and mentioned Biden, then the presumptive nominee, 50 times and Harris 12.</p>
+<p>Party spokespeople did not respond to an inquiry this week about plans for an update to the platform.</p>
+<p>Reproductive rights will likely be a focus point of any policy wishlist.</p>
+<p>Harris, during her time as vice president, has led the administration’s messaging on reproductive rights after the Supreme Court overturned the constitutional right to an abortion in the summer of 2022.</p>
+<p>In her campaign speeches, she has often stressed the need to “trust women” and that the government should not be deciding reproductive health.</p>
+<p>Harris has often promised that if she is elected, she will restore those reproductive rights, but unless Democrats control a majority in the U.S. House and 60 Senate votes, it’s unlikely she would be able to achieve that promise.</p>
+<p>Since <a href="https://tennesseelookout.com/2022/06/24/updated-u-s-supreme-court-overturns-right-to-abortion-in-landmark-decision/" target="_blank">Roe v. Wade was overturned</a> in that Supreme Court decision, Democrats have campaigned on reproductive rights that expand beyond abortion and include protections for in vitro fertilization.</p>
+<p><a href="https://democrats.org/where-we-stand/party-platform/" target="_blank">The 2020 party platform</a> focused on recovering from the coronavirus pandemic, the economy, quality health care, investing in education, protecting democracy and combating climate change.</p>
+<p>Democrats are likely to continue to criticize the Project 2025 playbook — a blueprint by the Heritage Foundation, a think tank, to implement conservative policies across the federal government should Trump win in November.</p>
+<p>Trump has disavowed the document, but has not detailed his own policy plans.</p>
+    <h4 class="editorialSubhed">Chicago conventions</h4>
+
+	
+<p>The Democratic National Convention will take place in Chicago, a city with a long history of hosting the event. Democrats have held their convention in Chicago 11 times, first in 1864 and most recently in 1996.</p>
+<p>This year’s will be the first in-person Democratic National Convention since 2016. It was upended due to the coronavirus pandemic and held virtually in 2020.</p>
+<p>Throughout the four-day convention, there will be speeches and side events hosted by state Democratic party leaders.</p>
+<p>The ceremonial roll call vote with delegates on the convention floor will take place Tuesday. The vice presidential nomination speech by Walz will be Wednesday night and on Thursday night, Harris will give her nomination acceptance speech.</p>
+<p>The city is also preparing for massive protests from several groups on reproductive rights, LGBTQ protections, housing and an immediate ceasefire in Gaza, <a href="https://www.wbez.org/government-politics/dnc-2024/2024/08/12/dnc-democratic-national-convention-protests-kamala-harris-israel-gaza-lgbtq-reproductive-rights-cpd-police" target="_blank">according to WBEZ News. </a></p>
+<p>The City Council of Chicago in January approved a ceasefire resolution, with Chicago Mayor Brandon Johnson the tiebreaker, making it the largest city to call for an end to the Israel-Hamas war, in which<a href="https://apnews.com/article/gaza-war-hamas-dead-graves-40000-988d16b648e06e222f04964dc9440da0?taid=66bdedd74b96700001cc25c8&amp;utm_campaign=TrueAnthem&amp;utm_medium=AP&amp;utm_source=Twitter" target="_blank"> more than 40,000 Palestinians have died</a>.</p>
+<p>The war followed an Oct. 7 attack from Hamas, in which <a href="https://www.aljazeera.com/news/longform/2023/10/9/israel-hamas-war-in-maps-and-charts-live-tracker" target="_blank">nearly 1,200 people</a> were killed in Israel and hundreds taken hostage.</p>
+    <h4 class="editorialSubhed">Road to nomination</h4>
+
+	
+<p>Harris’ acceptance speech will cap a five-year journey to her party’s nomination.</p>
+<p>In 2019, the California senator announced a bid for president in the next year’s election, but <a href="https://www.npr.org/2019/12/03/784443227/kamala-harris-drops-out-of-presidential-race" target="_blank">dropped out</a> before the first primary or caucus votes were cast after she failed to catch on with Democratic voters.</p>
+<p>Biden later picked her as a running mate, and the two defeated Trump and then-Vice President Mike Pence in the 2020 election.</p>
+<p>Biden launched a reelection campaign for 2024, but stepped aside after a disastrous debate performance in June spurred questions about his ability to campaign and serve for another four-year term.</p>
+<p>After Biden bowed out, Harris <a href="https://www.newsfromthestates.com/article/democratic-delegates-swiftly-give-harris-enough-support-clinch-presidential-nomination" target="_blank">quickly secured 99%</a> of delegates <a href="https://www.newsfromthestates.com/article/kamala-harris-officially-becomes-democratic-presidential-nominee" target="_blank">to become the party’s likely nominee</a>. The virtual five-day vote secured her official nomination.</p>
+<p>With less than three months until Election Day, Harris and Walz already have sprinted through battleground states including Arizona, Pennsylvania and North Carolina.</p>
+<p>Their campaign has also pulled in more than $300 million, according to the campaign. Official Federal Election Commission records will be released in mid-October.</p>
+<p>Harris and Trump have <a href="https://nebraskaexaminer.com/2024/08/08/trump-agrees-to-sept-10-debate-with-harris-claims-two-more-upcoming/" target="_blank">agreed to a Sept. 10 </a>debate hosted by ABC News in Philadelphia. Trump proposed two more debates, and Harris has said she would be open to another one between the first debate and Election Day.</p>
+<p>Walz and Republican vice presidential candidate Sen. J.D. Vance of Ohio have <a href="https://www.newsfromthestates.com/article/mark-your-calendar-vp-candidates-walz-and-vance-debate-oct-1" target="_blank">agreed to an Oct. 1</a> debate on CBS News, in New York City.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>What to know about the Democratic National Convention</title>
+		<link>https://newjerseymonitor.com/2024/08/16/what-to-know-about-the-democratic-national-convention/</link>
+		
+		<dc:creator><![CDATA[Jacob Fischler]]></dc:creator>
+		<pubDate>Fri, 16 Aug 2024 17:30:02 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Politics]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14353</guid>
+
+					<description><![CDATA[Democrats will gather in Chicago for their once-every-four-years convention, beginning Monday, with 5,000 delegates expected to attend.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/DNCUnitedCenter-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/DNCUnitedCenter-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/DNCUnitedCenter-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/DNCUnitedCenter-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/DNCUnitedCenter-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/DNCUnitedCenter-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Workers prepare the United Center for the start of the Democratic National Convention (DNC) on Aug. 15, 2024, in Chicago. The DNC runs Aug. 19-22. (Joe Raedle | Getty Images)</p><p>Democrats will gather in Chicago for their once-every-four-years convention, beginning Monday. Here’s a rundown:</p>
+    <h4 class="editorialSubhed">What is it?</h4>
+
+	
+<p>National political conventions are large gatherings of party officeholders, candidates and allies. They meet every four years to officially nominate candidates for president and vice president; to adopt a party platform, the list of policy proposals most party members agree on; and to celebrate and network.</p>
+<p>This year, Vice President Kamala Harris has already been officially nominated through a virtual roll call vote earlier this month. A ceremonial roll call is still expected to be a part of the convention, and Harris will officially accept the nomination.</p>
+    <h4 class="editorialSubhed">When should I tune in?</h4>
+
+	
+<p>The convention runs from Monday, Aug. 19 to Thursday, Aug. 22.</p>
+<p>Major news networks and a host of streaming platforms will broadcast the nightly events — usually speeches from high-profile members of the party — live. The prime-time program runs from 6:30 p.m. to 11 p.m. Eastern Time on Monday and 7 p.m. to 11 p.m. Eastern Time on Tuesday, Wednesday and Thursday.</p>
+<p>Full schedules for prime-time speeches have not been disclosed, but the vice presidential candidate usually accepts the nomination on Wednesday night and the presidential nominee’s acceptance speech closes out the convention on Thursday night.</p>
+<p>Former presidents and presidential nominees are also likely to have speaking roles.</p>
+<p>During the day, delegates and party officials will hold various events and meetings, only some of which will be broadcast or even open to reporters, as the convention doubles as a huge networking event for Democratic politicians, strategists, activists and others.</p>
+    <h4 class="editorialSubhed">How can I watch?</h4>
+
+	
+<p>Network and cable news TV stations generally air the prime-time programming from start to finish.</p>
+<p>National Public Radio will also broadcast much of the convention.</p>
+<p>Convention organizers will also be livestreaming the event on a host of platforms, including YouTube, X and TikTok. A full list of official livestreams is available <a href="https://demconvention.com/news/press-releases/how-to-watchdemocratic-national-convention-announces-streaming-partners-and-first-ever-vertical-streaming-platforms/" target="_blank">here</a>.</p>
+    <h4 class="editorialSubhed">Where is the convention this year?</h4>
+
+	
+<p>Chicago is hosting the Democratic convention for the 12th time, the most of any city.</p>
+<p>The major addresses in the evening will be at the United Center, an arena that fits tens of thousands for the city’s professional basketball and hockey teams, concerts or other events.</p>
+<p>Daytime activities will be more spread out, with locations at McCormick Place, about 6 miles southeast of the United Center, and the River North neighborhood, about 2 ½ miles to the northeast.</p>
+    <h4 class="editorialSubhed">How many people will be there?</h4>
+
+	
+<p>About 5,000 Democratic delegates, who have the formal duty of voting to approve the nominees for president and vice president, are expected to attend.</p>
+<p>A total of about 50,000 people could be in town for the event, according to <a href="https://chicago2024.com/faqs/" target="_blank">the city</a>.</p>
+    <h4 class="editorialSubhed">Will any celebrities be there? </h4>
+
+	
+<p>The 2016 Democratic National Convention — the last in-person convention Democrats held, since they moved the 2020 version online in the midst of the coronavirus pandemic — that nominated Hillary Clinton featured celebrities including singer Katie Perry and screenwriter/actor Lena Dunham.</p>
+<p>The Republican National Convention in July included appearances by musical artist Kid Rock and professional wrestler Hulk Hogan during prime time.</p>
+<p>A full list of participants for the Democratic convention this year has not yet been shared, but that has not stopped some fans of major music acts from <a href="https://sign.moveon.org/petitions/taylor-swift-and-beyonce-to-perform-together-at-the-dnc-convention-and-formally-support-harris" target="_blank">wishing</a> they’ll see their favorites at the event.</p>
+    <h4 class="editorialSubhed">Where can I find fair, fearless and free reporting about the convention?</h4>
+
+	
+<p><a href="http://newsfromthestates.com/" target="_blank">Right here!</a> And from your state’s newsroom, which you can find on <a href="https://statesnewsroom.com/newsrooms/" data-type="link" data-id="https://statesnewsroom.com/newsrooms/" target="_blank">this map. </a>States Newsroom is sending multiple reporters to cover the convention and will have in-depth coverage of the major events and more.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Harris unveils plan to curb price gouging, boost child tax credit, tackle rent hikes</title>
+		<link>https://newjerseymonitor.com/2024/08/16/harris-unveils-plan-to-curb-price-gouging-boost-child-tax-credit-tackle-rent-hikes/</link>
+		
+		<dc:creator><![CDATA[Jennifer Shutt]]></dc:creator>
+		<pubDate>Fri, 16 Aug 2024 17:08:58 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Economy]]></category>
+		<category><![CDATA[Kamala Harris]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14356</guid>
+
+					<description><![CDATA[Democratic presidential candidate Kamala Harris wants to end price-gouging, ease rent hikes, and expand the child tax credit. ]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/KamalaMaryland-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/KamalaMaryland-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/KamalaMaryland-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/KamalaMaryland-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/KamalaMaryland-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/KamalaMaryland-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">U.S. Vice President Kamala Harris looks back as she walks offstage after the end of her remarks at Prince George’s Community College on Aug. 15, 2024 in Largo, MD. Harris and U.S. President Joe Biden held the event to talk about their administration's efforts to lower drug costs. This event is the first time President Biden and Vice President Harris have appeared in public together since Biden announced he would be stepping down from running for re-election. (Anna Moneymaker | Getty Images)</p><p>Democratic presidential candidate Kamala Harris released her first detailed economic policy proposal Friday, laying out how she’d like to ease rent increases, boost first-time home buyers, end grocery price gouging and bolster the child tax credit.</p>
+<p>The Harris campaign’s announcement said the proposals, most of which would need approval from Congress, would “address some of the sharpest pain points American families are confronting and bolster their financial security.”</p>
+<p>“Vice President Harris has made clear that building up the middle class will be a defining goal of her presidency,” the announcement stated. “She will deliver for Americans who are demanding a new way forward towards a future that lifts up all Americans so that they can not just get by, but get ahead.”</p>
+<p>Harris <a href="https://ncnewsline.com/briefs/harris-walz-campaign-launches-offices-in-rural-nc/" target="_blank">will campaign later Friday</a> in Raleigh, North Carolina, ahead of the Democratic National Convention beginning Monday, as both campaigns focus on a handful of swing states.</p>
+<p>The economic plank of her plan seeks to curb the expenses that often come with building a family by expanding the child tax credit to the $3,600 per child that existed under the COVID-19 spending law that Democrats approved during the first months of the Biden administration. That provision has since expired.</p>
+<p>Harris proposes increasing that credit to $6,000 for families that have children under a year old.</p>
+<p>The maximum child tax credit is currently $2,000 per qualifying child for an individual making less than $200,000 annually or a couple filing jointly that makes less than $400,000.</p>
+<p>There are several <a href="https://www.irs.gov/credits-deductions/individuals/child-tax-credit" target="_blank">qualifications</a> to receive a child tax credit, including that the child was under the age of 17 at the end of the year and that they are a U.S. citizen, U.S. national or U.S. resident alien.</p>
+<p>The Earned Income Tax Credit, or EITC, would expand “to cover individuals and couples in lower-income jobs who aren’t raising a child in their home, cutting their taxes by up to $1,500,” according to the announcement.</p>
+<p>Harris also pledged that no one making less than $400,000 annually would see an increase in new taxes, matching a promise that President Joe Biden has made throughout his time in the Oval Office.</p>
+    <h4 class="editorialSubhed">Grocery price gouging</h4>
+
+	
+<p>The proposal says that if elected, Harris would seek Congress’ passage of a law to implement a ban on price gouging on groceries and other food as well as establish “rules of the road” that would bar companies from “excessive profits on food and groceries.”</p>
+<p>Rising prices on groceries have been a major pain point for consumers, and Republican presidential nominee Donald Trump on Thursday <a href="https://www.newsfromthestates.com/article/%C2%A0im-entitled-personal-attacks-against-harris-trump-asserts" target="_blank">made the case</a> that prices are too high for American families, laying the blame for inflation at the feet of the Biden-Harris administration and insisting he’s the only person able to get prices back down.</p>
+<p>To implement her grocery gouging plan, Harris proposes providing the Federal Trade Commission and state attorneys general with new authority to “impose strict new penalties” on companies that price gouge.</p>
+<p>“Many big grocery chains that have seen production costs level off have nevertheless kept prices high and have seen their highest profits in two decades,” the proposal states. “While some food companies have passed along these savings, others still have not.”</p>
+<p>“Price fluctuations are normal in free markets, but Vice President Harris recognizes there is a big difference between fair pricing and the excessive prices unrelated to the costs of doing business that Americans have seen in the food and grocery industry,” it says.</p>
+<p>A Harris administration would also address “unfair mergers and acquisitions” that can contribute to higher prices on food and groceries, the Harris plan says.</p>
+    <h4 class="editorialSubhed">Expansion of drug pricing controls</h4>
+
+	
+<p>Harris hopes to expand a price ceiling for insulin that Democrats established in their signature climate change, health care and tax package known as the Inflation Reduction Act or IRA.</p>
+<p>That section of the law, which only applies to Medicare,<a href="https://aspe.hhs.gov/sites/default/files/documents/bd5568fa0e8a59c2225b2e0b93d5ae5b/aspe-insulin-affordibility-datapoint.pdf" target="_blank"> caps the price of insulin</a> per month at $35. Harris’ proposal looks to expand that to “everyone” while setting the maximum out-of-pocket cost for other prescriptions at $2,000.</p>
+<p>The plan would increase the pace that Medicare is allowed to negotiate drug prices with pharmaceutical companies.</p>
+<p>“Vice President Harris and Governor Walz will also work with states to cancel medical debt for millions of Americans and to help them avoid accumulating such debt in the future, because no one should go bankrupt just because they had the misfortune of becoming sick or hurt,” according to the proposal.</p>
+    <h4 class="editorialSubhed">Boosting home building</h4>
+
+	
+<p>The economic plan released Friday includes numerous changes that could ease the increasing costs of renting and purchasing a home for the first time.</p>
+<p>Harris would seek to bolster home building throughout the country by 3 million units during the next four years by taking “down barriers that stand in the way of building new housing, including at the state and local levels.”</p>
+<p>A Harris-Walz administration would call on Congress to create a tax incentive for construction companies that build “starter homes” that would then be sold to first-time home buyers.</p>
+<p>The announcement says the new tax incentive would “complement the Neighborhood Homes Tax Credit that encourages investment in homes that would otherwise be too costly or difficult to develop or rehabilitate.”</p>
+<p>Harris’ proposal calls for up to $25,000 in down payment assistance for first-time home buyers who have paid rent on time for at least two years.</p>
+<p>The proposal says that if implemented, the down payment financial aid would go out to more than 4 million people over four years.</p>
+<p>Harris also pressed lawmakers to address the rising cost of rent by approving two bills that have been introduced in Congress, but haven’t gained any ground.</p>
+<p>One <a href="https://www.congress.gov/bill/118th-congress/senate-bill/2224" target="_blank">bill</a> would reduce the incentive for large firms to buy more than 50 single-family rental homes. The legislation would bar those companies “from deducting interest or depreciation on those properties,” according to a <a href="https://www.brown.senate.gov/newsroom/press/release/sherrod-brown-colleagues-bill-crack-down-corporate-investors-buy-local-homes-housing-prices" target="_blank">summary</a> of the measure.</p>
+<p>The second rental proposal asks Congress to approve a <a href="https://www.congress.gov/bill/118th-congress/senate-bill/3692" target="_blank">bill</a> that would “crack down on companies that help landlords increase rents in already high-priced markets,” according to a <a href="https://www.welch.senate.gov/welch-and-wyden-introduce-legislation-to-crack-down-on-companies-that-inflate-rents-with-price-fixing-algorithms/" target="_blank">summary</a>.</p>
+<p>“Vice President Harris knows that our nation’s housing affordability crisis is making it hard for tens of millions of Americans to make ends meet while putting the American Dream of homeownership out of reach for too many working families,” the proposal states. “That’s why she will launch an urgent and comprehensive four-year plan to lower housing costs for working families and end America’s housing shortage.”</p>
+<p>The Harris-Walz campaign also announced Friday that the ticket would<a href="https://penncapital-star.com/election-2024/harris-and-walz-to-kick-off-pennsylvania-bus-tour-in-pittsburgh/" data-type="link" data-id="https://penncapital-star.com/election-2024/harris-and-walz-to-kick-off-pennsylvania-bus-tour-in-pittsburgh/" target="_blank"> hold a bus tour</a> in Pittsburgh, Pennsylvania, and the surrounding area on Sunday, just ahead of the Democratic National Convention.</p>
+<p>Harris; her running mate, Minnesota Gov. Tim Walz; second gentleman Doug Emhoff; and first lady of Minnesota Gwen Walz will all participate in the tour of Allegheny and Beaver counties.</p>
+    <h4 class="editorialSubhed">Trump campaign responds</h4>
+
+	
+<p>Trump campaign officials hosted a call with reporters Friday afternoon to criticize many of the policy proposals in Harris’ economic plan, but declined to weigh in directly on a potential boost to the child tax credit.</p>
+<p>“We’re going to have a number of additional policy discussions on economics. I think you’ve seen President Trump himself in a couple public events and press availabilities in just the last few days, speaking directly to his policies,” said Brian Hughes, senior communications adviser to the Trump campaign. “I think today we will focus on the rest of the discussion about, you know, Harris’ extremely liberal agenda.“</p>
+<p>Campaign officials on the call declined to answer a separate question about how Trump proposing tariffs on certain products would impact the U.S. economy and prices.</p>
+<p>Kevin Hassett, former senior adviser and chairman to the Council of Economic Advisers during the Trump administration, said the purpose of Friday’s call was to focus on proposals from the Harris campaign.</p>
+<p>“I think that having a future call about tariffs and President Trump’s agenda is something that I’m sure the campaign is eager to set up,” Hassett said. “But, you know, we were instructed to focus on Kamala’s proposals today. And it seems to me that supporters of Kamala probably don’t want to talk about her proposals.”</p>
+<p>Hassett said Harris’ economic proposals fell into one of two categories. The first, he said, were policies that Trump has already proposed, while the second category encompassed politics that don’t “make any sense at all.”</p>
+<p>Stephen Moore, policy adviser to Trump, said that the proposals to limit price spikes on food and groceries could force some stores to go out of business, potentially increasing food instability.</p>
+<p>He argued the proposal for up to $25,000 in down payment assistance for first time home buyers wouldn’t address the main issue preventing people from buying a home, which he said is high interest rates.</p>
+<p>“If you were to cut taxes, deregulate the economy, produce more energy — all of those policies are deflationary, not inflationary,” Moore said. “And those are the policies that would get inflation back down to the 1 ½% to 2% rate that we had under Donald J. Trump.”</p>
+<p>The Federal Reserve began lowering interest rates during the COVID-19 pandemic in an attempt to prevent the country’s economy from going into a tailspin.</p>
+<p>The Fed has kept interest rates higher than is typical in an attempt to curb inflation that began spiking as pandemic restrictions began to ease following a widespread vaccination effort.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Governor Murphy to appoint former chief of staff to Menendez&#8217;s Senate seat</title>
+		<link>https://newjerseymonitor.com/2024/08/16/governor-murphy-appoints-former-chief-of-staff-to-menendezs-senate-seat/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Fri, 16 Aug 2024 15:54:40 +0000</pubDate>
+				<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Gov + Legislature]]></category>
+		<category><![CDATA[Andy Kim]]></category>
+		<category><![CDATA[Curtis Bashaw]]></category>
+		<category><![CDATA[George Helmy]]></category>
+		<category><![CDATA[Phil Murphy]]></category>
+		<category><![CDATA[Tammy Murphy]]></category>
+		<category><![CDATA[Tony Bucco]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14322</guid>
+
+					<description><![CDATA[George Helmy will hold Sen. Bob Menendez's seat in the upper chamber until officials certify a general election victor.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/George-Helmy-1024x683.jpeg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/George-Helmy-1024x683.jpeg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/George-Helmy-300x200.jpeg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/George-Helmy-768x512.jpeg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/George-Helmy-1536x1024.jpeg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/George-Helmy-2048x1366.jpeg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Gov. Phil Murphy announced Friday he will appoint his former chief of staff George Helmy to take over Sen. Bob Menendez's seat when the indicted senator steps down, as he's expected to do later this month. (Photo courtesy of New Jersey Governor's Office)</p><p>Gov. Phil Murphy announced Friday that he will appoint George Helmy, his former chief of staff, to Sen. Bob Menendez’s seat in the upper chamber after the convicted senator steps down later this month.</p>
+<p>Helmy, who was the top staffer in Murphy’s administration for five years before departing in September to become chief external affairs and policy officer at RWJBarnabas Health Medical Group, is expected to ascend to the seat after Menendez resigns, as the three-term Democrat is expected to do on Aug. 20.</p>
+<p>&#8220;He has devoted years of his life to untangling the red tape of government to help New Jerseyans access the benefits and resources they deserve. From helping veterans to get the health care they need to assisting senior citizens who depend on Social Security and everything in between, George knows how to navigate the complexities of government and make life easier for our families,&#8221; Murphy said at the announcement in Newark.</p>
+<p>State law allows Helmy, a commissioner of the Port Authority of New York and New Jersey, to serve until the Board of State Canvassers certifies a general election victor on Nov. 20. Murphy said Friday that he intends to appoint the election&#8217;s victor to the seat after one is certified, giving them a weeks-long advantage in Senate seniority over their newly elected peers.</p>
+<p>&#8220;I have never, nor will I ever, seek elected office. As a matter of fact as the governor alluded to, the idea of being called &#8216;senator&#8217; bothers me deeply,&#8221; Helmy said. &#8220;But our residents deserve a functioning Senate office upon which they can call for help. Our nonprofits and local governments deserve an office that will fight for them for their grants and support them in navigating the arcane maze of federal agencies.&#8221;</p>
+<p>Menendez last month announced he would resign after he was <a href="https://newjerseymonitor.com/2024/07/16/sen-menendez-convicted-of-bribery-other-charges-in-corruption-trial/">found guilty</a> in July of bribery and other corruption charges following a lengthy trial that saw him accused of trading official favors for gold bars, cash, furniture, and a Mercedes-Benz convertible, among other things.</p>
+<p>The governor’s decision aligns with Republican calls for him to appoint a caretaker to the seat rather than a candidate.</p>
+<p>&#8220;George Helmy is not only a trusted and well-respected leader, he’s also a proven public servant who I consider a good friend and an even better man,” said state Sen. Tony Bucco (R-Morris). “I applaud the Governor’s decision to follow the tradition of appointing a placeholder and letting the voters have their say this November.&#8221;</p>
+<p>Rep. Andy Kim (D-03) and hotelier Curtis Bashaw will vie for the Senate seat in November, and Kim is heavily favored to win that race. Republicans have not won a U.S. Senate race in New Jersey since the state reelected Sen. Clifford Case in 1972.</p>
+<p>The New Jersey Globe first reported Murphy’s intent to appoint Helmy to the Senate.</p>
+<p>Sen. Cory Booker, a Democrat who will become the state&#8217;s senior senator when Menendez retires, praised the pick in advance of Friday&#8217;s announcement. Helmy was previously Booker&#8217;s state director and an aide to late Sen. Frank Lautenberg.</p>
+<p>&#8220;He&#8217;s going to be able to hit the ground running and be an impact player in the United States Senate. So I&#8217;m thrilled with the choice,&#8221; Booker said at an unrelated event Thursday.</p>
+<p>By passing over Kim, who faced a bitter primary against first lady Tammy Murphy before she <a href="https://newjerseymonitor.com/2024/03/27/tammy-murphy-calls-for-democratic-unity-after-ending-senate-bid-but-offers-no-endorsement-yet/">suspended</a> her campaign ahead of June’s primary, Murphy will avert the need for a second special House election this year.</p>
+<p dir="ltr">“Having led Senator Booker’s state operations for a number of years, George Helmy knows how to navigate the Senate and can step in immediately to keep delivering services for our state,&#8221; Kim said in a statement Friday. &#8220;That’s incredibly important experience with so many challenging issues facing our state and our nation. I look forward to working with him in the Capitol.”</p>
+<p>Tammy Murphy in July said she would not accept an appointment to the Senate seat.</p>
+<p>Voters in New Jersey’s 10th congressional district <a href="https://newjerseymonitor.com/2024/07/15/11-dems-vie-in-special-election-to-succeed-late-rep-donald-payne-jr/">will choose a successor</a> to late Rep. Donald Payne Jr. (D-Newark) on Sept. 18.</p>
+<p>Kim would have been required to cede his House seat to ascend to the upper chamber, though that departure would not necessarily have triggered a special election. State law only mandates the governor call a special election for a House vacancy if more than six months are left in the lawmaker’s unexpired term.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>NJ Transit needs a long-term fix, not a weeklong gimmick</title>
+		<link>https://newjerseymonitor.com/2024/08/16/nj-transit-needs-a-long-term-fix-not-a-weeklong-gimmick/</link>
+		
+		<dc:creator><![CDATA[Terrence T. McDonald]]></dc:creator>
+		<pubDate>Fri, 16 Aug 2024 15:10:46 +0000</pubDate>
+				<category><![CDATA[Commentary]]></category>
+		<category><![CDATA[NJ Transit]]></category>
+		<category><![CDATA[Phil Murphy]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14346</guid>
+
+					<description><![CDATA[Gov. Phil Murphy's plan to offer a week of free rides on NJ Transit does nothing to help fix the agency's problems.]]></description>
+																						<content:encoded><![CDATA[<img width="800" height="533" src="https://newjerseymonitor.com/wp-content/uploads/2022/05/48904171566_80c7460c75_c.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2022/05/48904171566_80c7460c75_c.jpg 800w, https://newjerseymonitor.com/wp-content/uploads/2022/05/48904171566_80c7460c75_c-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2022/05/48904171566_80c7460c75_c-768x512.jpg 768w" sizes="(max-width: 800px) 100vw, 800px" /><p style="font-size:12px;">Gov. Phil Murphy's plan to offer a week of free rides on NJ Transit does nothing to help fix the agency's problems. (Photo by Edwin J. Torres/N.J. Governor’s Office)</p><p style="font-weight: 400;">Freelance writer and editor Kim Kavin was at the Peapack train station in Somerset County on July 30, excited for a night out in New York City with a friend from California she hadn’t seen in years.</p>
+<p style="font-weight: 400;">Unfortunately for Kavin, she was planning on NJ Transit getting her to and from the city. But after a 20-minute delay, the train was canceled. Kavin, who had already bought a round-trip ticket, asked NJ Transit to refund her $36.50 and has yet to hear back.</p>
+<p style="font-weight: 400;">Kavin does not think much of Gov. Phil Murphy’s Thursday announcement that, as an apology for the transit agency’s abysmal performance this summer, <a href="https://newjerseymonitor.com/2024/08/15/nj-transit-will-be-free-for-a-week-as-apology-for-ugly-summer-governor-says/">all riders will get free trips on NJ Transit</a> for a week starting Aug. 26.</p>
+<p style="font-weight: 400;">“I don’t need a ride. I needed a ride when my friend was visiting from California. Now I need my $36.50 back. That’s what I want from Phil Murphy,” she said.</p>
+<p style="font-weight: 400;">Listen, riders aren’t itching to get one or two train or bus trips for free; they want good, reliable public transportation year-round. And the prospect of a few on-the-house NJ Transit rides the week before a holiday weekend will not reassure them that, after the fare holiday ends, service will get any better.</p>
+<p style="font-weight: 400;">“This fare holiday is a gimmick,” said Alex Ambrose, a policy analyst with progressive think tank New Jersey Policy Perspective. “It does nothing to actually address the structural problems that exist in NJ Transit, one of the biggest of which is that lawmakers have neglected to adequately fund transit for decades.”</p>
+<p style="font-weight: 400;">This is a rare issue where progressive wonks and business leaders agree.</p>
+<p style="font-weight: 400;">Michele Siekerka, president and CEO of the New Jersey Business &amp; Industry Association, also opposes the fare holiday, though for a different reason. Siekerka hates it because it represents a bait-and-switch by Murphy’s administration.</p>
+<p style="font-weight: 400;">Murphy helped push through <a href="https://newjerseymonitor.com/2024/06/27/lawmakers-advance-new-business-surtax-aimed-at-funding-nj-transit/">a new surtax</a> on some of the state’s most profitable businesses, which he said would help give the financially beleaguered NJ Transit a steady revenue stream for the next few years. Instead, Siekerka noted, the $1 billion the surtax is expected to generate in its first year is going to the state’s general fund — not to NJ Transit.</p>
+<p style="font-weight: 400;">“If there was such a desperate need, why did we money-grab a billion dollars from the business community to stick in surplus for a year? It makes no sense,” she said. “It’s illogical, it’s nonsensical, it’s irrational, and it’s very, very difficult to have a legitimate discussion about.”</p>
+<p style="font-weight: 400;">It’s not just the business community paying more to help fund public transit. NJ Transit approved <a href="https://newjerseymonitor.com/2024/04/11/nj-transit-ceo-says-fare-hikes-will-keep-agency-from-death-spiral/">a big fare hike this year</a> — some fares rose 15% — and will tack on 3% fare hikes annually starting next July.</p>
+<p style="font-weight: 400;">So after raising taxes and hiking fares to rescue NJ Transit from its a budget crisis, the Murphy administration will take $19 million the agency was expected to make from fares the last week of August and flush it down the toilet.</p>
+<p style="font-weight: 400;">What sense does this make?</p>
+<p style="font-weight: 400;">Murphy offering an apology to NJ Transit users is good, though he undercut it with his don’t-blame-me attitude (“A lot of this is out of our hands,” said our powerful governor who claims to have a close relationship with the president of the United States). What the apology should come with is not a gimmick to appease riders for one week, but a concrete plan to make sure NJ Transit service is frequent, reliable, and accessible. Hopefully we see that soon.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>AI will play a role in election misinformation. Experts are trying to fight back</title>
+		<link>https://newjerseymonitor.com/2024/08/16/ai-will-play-a-role-in-election-misinformation-experts-are-trying-to-fight-back/</link>
+		
+		<dc:creator><![CDATA[Paige Gross]]></dc:creator>
+		<pubDate>Fri, 16 Aug 2024 10:29:48 +0000</pubDate>
+				<category><![CDATA[Election 2024]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14344</guid>
+
+					<description><![CDATA[OpenAI said in May that it would be working to provide more transparency about its AI tools during this election year.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1744769333-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1744769333-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1744769333-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1744769333-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1744769333-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1744769333-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Deep fake, AI and face swap in video edit. Deepfake and machine learning. Facial tracking, detection and recognition technology. Digital identity interchange. Computer software mockup. Fraud picture.</p><p>In June, amid a bitterly contested Republican gubernatorial primary race, a short video began circulating on social media showing <a href="https://www.abc4.com/news/politics/deepfake-video-utah-elections/" target="_blank">Utah Gov. Spencer Cox</a> purportedly admitting to fraudulent collection of ballot signatures.</p>
+<p>The governor, however, never said any such thing and <a href="https://utahnewsdispatch.com/2024/08/13/utah-supreme-court-denies-phil-lyman-demand-to-annul-election-results/" target="_blank">courts have upheld his election victory</a>.</p>
+<p>The false video was part of a growing wave of election-related content created by artificial intelligence. At least some of that content, experts say, is false, misleading or simply designed to provoke viewers.</p>
+<p>AI-created likenesses, often called “deepfakes,” have increasingly become a point of concern for those battling misinformation during election seasons. Creating deepfakes used to take a team of skilled technologists with time and money, but recent advances and accessibility in AI technology have meant that nearly anyone can create convincing fake content.</p>
+<p>“Now we can supercharge the speed and the frequency and the persuasiveness of existing misinformation and disinformation narratives,” Tim Harper, senior policy analyst for democracy and elections at the Center for Democracy and Technology, said.</p>
+<p>AI has advanced remarkably since just the last presidential election in 2020, Harper said, noting that OpenAI’s release of ChatGPT in November 2022 brought accessible AI to the masses.</p>
+<p><a href="https://www.statista.com/topics/12221/global-elections-in-2024/" target="_blank">About half</a> of the world’s population lives in countries that are holding elections this year. And the question isn’t really if AI will play a role in misinformation, Harper said, but rather how much of a role it will play.</p>
+    <h4 class="editorialSubhed">How can AI be used to spread misinformation?</h4>
+
+	
+<p>Though it is often intentional, misinformation caused by artificial intelligence can sometimes be accidental, due to flaws or blindspots baked into a tool’s algorithm. AI chatbots search for information in the databases they have access to, so if that information is wrong, or outdated, it can easily produce wrong answers.</p>
+<p><a href="https://openai.com/index/how-openai-is-approaching-2024-worldwide-elections/" target="_blank">OpenAI said in May</a> that it would be working to provide more transparency about its AI tools during this election year, and the company endorsed the bipartisan <a href="https://www.govtrack.us/congress/bills/118/s2770/text/is" target="_blank">Protect Elections from Deceptive AI Act</a>, which is pending in Congress.</p>
+<p>“We want to make sure that our AI systems are built, deployed, and used safely,” the company said in the May announcement. “Like any new technology, these tools come with benefits and challenges. They are also unprecedented, and we will keep evolving our approach as we learn more about how our tools are used.”</p>
+<p>Poorly regulated AI systems can lead to misinformation. Elon Musk was recently called upon <a href="https://washingtonstatestandard.com/2024/08/05/a-chatbot-spread-falsehood-about-wa-elections-the-secretary-of-state-wants-it-fixed/" target="_blank">by several secretaries of state</a> after his AI search assistant Grok, built for social media platform X, falsely told users Vice President Kamala Harris was ineligible to appear on the presidential ballot in nine states because the ballot deadline had passed. The information stayed on the platform, and was seen by millions, for more than a week before it was corrected.</p>
+<p>“As tens of millions of voters in the U.S. seek basic information about voting in this major election year, X has the responsibility to ensure all voters using your platform have access to guidance that reflects true and accurate information about their constitutional right to vote,” reads the letter signed by the secretaries of state of Washington, Michigan, Pennsylvania, Minnesota and New Mexico.</p>
+<p>Generative AI impersonations also pose a new risk to the spread of misinformation.  In addition to the fake video of Cox in Utah, a deepfake video <a href="https://www.forbes.com/sites/petersuciu/2023/09/02/there-is-now-a-deep-fake-video-of-ron-desantis-dropping-out-of-the-2024-race/" target="_blank">of Florida Governor Ron DeSantis</a> falsely showed him dropping out of the 2024 presidential race.</p>
+<p>Some misinformation campaigns happen on huge scales like these, but many others are more localized, targeted campaigns. For instance, bad actors may imitate the online presence of a neighborhood political organizer, or send AI-generated text messages to listservs in certain cities. Language minority communities have been harder to reach in the past, Harper said, but generative AI has made it easier to translate messages or target specific groups.</p>
+<p>While <a href="https://www.elon.edu/u/news/2024/05/15/ai-and-politics-survey/" target="_blank">most adults are aware that AI will play a role</a> in the election, some hyperlocal, personalized campaigns may fly under the radar, Harper says.</p>
+<p>For example, someone could use data about local polling places and public phone numbers to create messages specific to you. They may send a text the night before election day saying that your polling location has changed from one spot to another, and because they have your original polling place correct, it doesn’t seem like a red flag.</p>
+<p>“If that message comes to you on WhatsApp or on your phone, it could be much more persuasive than if that message was in a political ad on a social media platform,” Harper said. “People are less familiar with the idea of getting targeted disinformation directly sent to them.”</p>
+<p><strong>    <h4 class="editorialSubhed">Verifying digital identities</h4>
+
+	 </strong></p>
+<p>The deepfake video of Cox helped spur a partnership between a public university and a new tech platform with the goal of combating deepfakes in Utah elections.</p>
+<p>From July 2024, through Inauguration Day in January 2025, students and researchers at the <strong> </strong>Gary R. Herbert Institute for Public Policy and the Center for National Security Studies at Utah Valley University will work with SureMark Digital. Together, they’ll verify digital identities of politicians to study the impact AI-generated content has on elections.</p>
+<p>Through the pilot program, candidates seeking one of Utah’s four congressional seats and the open senate seat will be able to authenticate their digital identities at no cost through SureMark’s platform, with the goal of increasing trust in Utah’s elections.</p>
+<p>Brandon Amacher, director of the Emerging Tech Policy Lab at UVU, said he sees AI playing a similar role in this election as the emergence of social media did in the 2008 election — influential but not yet overwhelming.</p>
+<p>“I think what we’re seeing right now is the beginning of a trend which could get significantly more impactful in future elections,” Amacher said.</p>
+<p>In the first month of the pilot, Amacher said, the group has already seen how effective these simulated video messages can be, especially in short-form media like TikTok and Instagram Reels. A shorter video is easier to fake, and if someone is scrolling these platforms for an hour, a short clip of misinformation likely won’t get very much scrutiny, but it could still influence your opinion about a topic or a person.</p>
+<p>SureMark Chairman Scott Stornetta explained that the verification platform, which rolled out in the last month, allows a user to acquire a credential. Once that’s approved, the platform goes through an authorization process of all of your published content using cryptographic techniques that bind the identity of a person to the content that features them. A browser extension then identifies to users if content was published by you or an unauthorized actor.</p>
+<p>The platform was created with public figures in mind, especially politicians and journalists who are vulnerable to having their images replicated. Anyone can download the SureMark browser extension to see accredited content across different media platforms, not just those that get accredited. Stornetta likened the technology to an X-ray.</p>
+<p>“If someone sees a video or an image or listens to a podcast on a regular browser, they won’t know the difference between a real and a fake,” he said. “But if someone that has this X-ray vision sees the same documents in their browser, they can click on a button and basically find out whether it’s a green check or red X.”</p>
+<p>The pilot program is currently working to credential the state’s politicians, so it will be a few months before they start to glean results, but Justin Jones, the executive director of the Herbert Institute, said that every campaign they’ve connected with has been enthusiastic to try the technology.</p>
+<p>“All of them have said we’re concerned about this and we want to know more,” Jones said.</p>
+    <h4 class="editorialSubhed">What’s the motivation behind misinformation?</h4>
+
+	
+<p>Lots of different groups with varying motivations can be behind misinformation campaigns, Michael Kaiser, CEO of Defending Digital Campaigns, told States Newsroom.</p>
+<p>There is sometimes misinformation directed at specific candidates, like in the case of Governors Cox and DeSantis’ deepfake videos. Campaigns around geopolitical events, like wars, are also common to sway public opinion.</p>
+<p>Russia’s influence on the 2016 and 2020 elections is well-documented, and efforts will likely continue in 2024, with a goal of undermining U,S, support of Ukraine, <a href="https://blogs.microsoft.com/wp-content/uploads/prod/sites/5/2024/04/MTAC-Report-Elections-Report-Nation-states-engage-in-US-focused-influence-operations-ahead-of-US-presidential-election-04172024.pdf" target="_blank">a Microsoft study</a> recently reported.</p>
+<p>There’s sometimes a monetary motivation to misinformation, Amacher said, as provocative, viral content can turn into payouts on platforms that pay users for views.</p>
+<p>Kaiser, whose work focuses on providing cybersecurity tools to campaigns, said that while interference in elections is sometimes the goal, more commonly, these people are trying to cause a general sense of chaos and apathy toward the elections process.</p>
+<p>“They’re trying to divide us at another level,” he said. “For some bad actors, the misinformation and disinformation is not about how you vote. It’s just that we’re divided.”</p>
+<p>It’s why much of the AI-generated content is inflammatory or plays on your emotions, Kaiser said.</p>
+<p>“They’re trying to make you apathetic, trying to make you angry, so maybe you’re like, ‘I can’t believe this, I’m going to share it with my friends,’” he said. “So you become the platform for misinformation and disinformation.”</p>
+    <h4 class="editorialSubhed">Strategies for stopping the spread of misinformation </h4>
+
+	
+<p>Understanding that emotional response and eagerness to share or engage with the content is a key tool to slowing the spread of misinformation. If you’re in that moment, there’s a few things you can do, the experts said.</p>
+<p>First, try to find out if an image or sound bite you’re viewing has been reported elsewhere. You can use reverse image search on Google to see if that image is found on reputable sites, or if it’s only being shared by social media accounts that appear to be bots. Websites that fact check manufactured or altered images may point you to where the information originated, Kaiser said.</p>
+<p>If you’re receiving messages about election day or voting, double check the information online through your state’s voting resources, he added.</p>
+<p>Adding two-factor authentication on social media profiles and email accounts can help ward off phishing attacks and hacking, which can be used to spread  misinformation, Harper said.</p>
+<p>If you get a phone call you suspect may be AI-generated, or is using someone’s voice likeness, it’s good to confirm that person’s identity by asking about the last time you spoke.</p>
+<p>Harper also said that there’s a few giveaways to look out for with AI-generated images, like an extra finger or distorted ear or hairline. AI has a hard time rendering some of those finer details, Harper said.</p>
+<p>Another visual clue, Amacher said, is that deepfake videos often feature a blank background, because busy surroundings are harder to simulate.</p>
+<p>And finally, the closer we are to the election, the likelier you are to see misinformation, Kaiser said. Bad actors use proximity to the election to their advantage — the closer you are to election day, the less time your misinformation has to be debunked.</p>
+<p>Technologists themselves can take some of the onus of misinformation in the way they build AI, Harper said. He recently published <a href="https://cdt.org/insights/brief-election-integrity-recommendations-for-generative-ai-developers/" target="_blank">a summary of recommendations for AI developers </a>with suggestions for best practices.</p>
+<p>The recommendations included refraining from releasing text-to-speech tools that allow users to replicate the voices of real people, refraining from the generation of realistic images and videos of political figures and prohibiting the use of generative AI tools for political ads.</p>
+<p>Harper suggests that AI tools disclose how often a chatbot’s training data is updated relating to election information, develop machine-readable watermarks for content and promote authoritative sources of election information.</p>
+<p>Some tech companies already voluntarily follow many of these transparency best practices, but much of the country is following a “patchwork” of laws that haven’t developed at the speed of the technology itself.</p>
+<p>A <a href="https://www.congress.gov/bill/118th-congress/senate-bill/2770#:~:text=The%20bill%20generally%20prohibits%20individuals,or%20(2)%20solicit%20funds." target="_blank">bill prohibiting the use of deceptive AI-generated </a>audio or visual media of a federal candidate was introduced in congress last year, but it has not been enacted. Laws focusing on AI in elections <a href="https://www.newsfromthestates.com/article/states-strike-out-their-own-ai-privacy-regulation" target="_blank">have been passed on a state level</a> in the last two years, though, and primarily either ban messaging and images created by AI or at least require specific disclaimers about the use of AI in campaign materials.</p>
+<p>But for now, these young tech companies that want to do their part in stopping or slowing the spread of misinformation can seek some direction from the CDT report or pilot programs like UVU’s.</p>
+<p>“We wanted to take a stab at creating a kind of a comprehensive election integrity program for these companies,” Harper said. “understanding that unlike the kind of legacy social media companies, they’re very new and quite young and have no time or kind of the regulatory scrutiny required to have created strong election integrity policies in a more systematic way.”</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Renewed calls for action on mental health after police shoot and kill Fort Lee woman</title>
+		<link>https://newjerseymonitor.com/2024/08/15/renewed-calls-for-action-on-mental-health-after-police-shoot-and-kill-fort-lee-woman/</link>
+		
+		<dc:creator><![CDATA[Sophie Nieto-Munoz]]></dc:creator>
+		<pubDate>Fri, 16 Aug 2024 00:56:43 +0000</pubDate>
+				<category><![CDATA[Criminal Justice]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14339</guid>
+
+					<description><![CDATA[The police killing of a 26-year-old Korean American woman led to new calls for a better approach to how authorities respond when people are suffering from mental health issues.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="768" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/Victoria-Lee-1-1024x768.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/Victoria-Lee-1-1024x768.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Victoria-Lee-1-300x225.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Victoria-Lee-1-768x576.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Victoria-Lee-1-1536x1152.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Victoria-Lee-1-2048x1536.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Victoria Lee's family says she was unarmed when police fatally shot her July 28 during a mental health episode. (Sophie Nieto-Munoz | New Jersey Monitor) </p><p><span data-preserver-spaces="true">The police killing of a 26-year-old Korean American woman has led to new calls for a better approach to how authorities respond when people are suffering from mental health issues.</span></p>
+<p><span data-preserver-spaces="true">Friends of Victoria Lee and activists in the Asian American community gathered Thursday in front of a Fort Lee community center to urge officials to release body camera footage of Lee’s death.</span></p>
+<p><span data-preserver-spaces="true">“This investigation needs to be swift and transparent. No games played. No tricks,” said Amber Reed, co-executive director of AAPI Montclair. “They deserve at least that from this state that has failed them so terribly.”  </span></p>
+<p><span data-preserver-spaces="true">Lee died in the early morning hours of July 28 after her family called 911 to report she was holding a knife and needed to go to the hospital because she was suffering from a mental health crisis, </span><a class="editor-rtfLink" href="https://www.njoag.gov/update-ags-office-releases-identities-of-the-decedent-and-fort-lee-police-officer-involved-in-fatal-police-involved-shooting-in-fort-lee-n-j-on-july-28-2024/" target="_blank" rel="noopener"><span data-preserver-spaces="true">according to the Attorney General’s Office</span></a><span data-preserver-spaces="true">. After the family attempted to prevent responding officers from entering their apartment, cops forced their way in, Lee approached officers in a hallway, and Officer Tony Pickens Jr. fired a single shot to her chest, killing her, authorities said.</span></p>
+<p><span data-preserver-spaces="true">The Attorney General’s Office is investigating the shooting, as it does with all fatal police-involved shootings. </span></p>
+<p><span data-preserver-spaces="true">Lee’s family maintains she was not holding a knife when she was shot, as authorities claim, but a five-gallon water jug.</span></p>
+<p><span data-preserver-spaces="true">Henry Cho, attorney for the family, said the body cam footage will be released after the family sees it, which he expects to be Friday. He also said the family intends to file a wrongful death lawsuit against the police officer and Fort Lee, but they are still processing the incident. </span></p>
+<p><span data-preserver-spaces="true">“They are still very upset, agitated, and crying so much,” Cho said. “We just want to pray for them. That’s all we can do right now.” </span></p>
+<p><span data-preserver-spaces="true">The family’s supporters urged Fort Lee officials to opt into the state’s Arrive Together program, which pairs police officers with mental health experts when responding to some emergency calls. Currently, more than 200 departments participate in the program, including seven in Bergen County. </span></p>
+<p><span data-preserver-spaces="true">Others called for authorities to overhaul how they respond to mental health crisis calls. They argued police shouldn’t be involved at all, and that social workers or mental health experts should respond instead.</span></p>
+<figure id="attachment_14338" class="wp-caption alignleft" style="max-width:100%;width:300px;"><a href="https://newjerseymonitor.com/yannik-wood-2/"><img decoding="async" loading="lazy" class="size-medium wp-image-14338" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/Yannik-Wood-2-300x225.jpg" alt="" width="300" height="225" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/Yannik-Wood-2-300x225.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Yannik-Wood-2-1024x768.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Yannik-Wood-2-768x576.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Yannik-Wood-2-1536x1152.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/Yannik-Wood-2-2048x1536.jpg 2048w" sizes="(max-width: 300px) 100vw, 300px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Yannick Wood of the New Jersey Institute for Social Justice speaks out at a rally held for Victoria Lee, a 26-year-old woman who was shot and killed by Fort Lee police during a mental health episode. (Sophie Nieto-Munoz | New Jersey Monitor)</em></p></figure>
+<p><span data-preserver-spaces="true">Yannick Wood of the New Jersey Institute for Social Justice called Lee’s death the “latest example of New Jersey police using deadly force when compassion and clinical treatment was necessary.” Wood cited the deaths of Najee Seabrooks in Paterson and Andrew Washington in Jersey City, who were both experiencing mental health crises when officers fatally shot them. </span></p>
+<p><span data-preserver-spaces="true">Wood urged officials to fully implement </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/01/08/bill-to-boost-community-crisis-response-teams-passed-in-wake-of-police-involved-shootings/" target="_blank" rel="noopener"><span data-preserver-spaces="true">the Seabrooks-Washington Community-Led Response Act</span></a><span data-preserver-spaces="true">. That law, signed by the governor in January, created a new state advisory council aimed at determining best practices to handle emergency responses. But the 13-member council has not met, despite the law mandating the council meet within 45 days of the bill signing, </span><a class="editor-rtfLink" href="http://northjersey.com/" target="_blank" rel="noopener"><span data-preserver-spaces="true">according to northjersey.com</span></a><span data-preserver-spaces="true">. </span></p>
+<p><span data-preserver-spaces="true">Family members across the state are scared to call 911 for help out of fear of how police will respond, said Zellie Thomas, an organizer with Black Lives Matter Paterson. Non-police responses mean mental health crises will not turn into tragedies, he said.</span></p>
+<p><span data-preserver-spaces="true">“When you call 911 for help, you should get help and not bullets,” he said. “It doesn’t matter if you are armed or unarmed.”</span></p>
+<p style="font-weight: 400;">Tara Oliver, a spokeswoman for the Attorney General’s Office, which oversees Arrive Together, said more than 50% of New Jersey residents live in the 219 municipalities served by the program, and ultimately the state would like it available for every resident. The current state budget allocates $20.1 million intended to fund an expansion of the program, Oliver said.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>‘I’m entitled to personal attacks’ against Harris, Trump asserts at N.J. country club</title>
+		<link>https://newjerseymonitor.com/2024/08/15/im-entitled-to-personal-attacks-against-harris-trump-asserts/</link>
+		
+		<dc:creator><![CDATA[Jennifer Shutt]]></dc:creator>
+		<pubDate>Thu, 15 Aug 2024 23:21:12 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Donald Trump]]></category>
+		<category><![CDATA[Kamala Harris]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14340</guid>
+
+					<description><![CDATA[Trump argued that there was no need to limit his personal criticism of Harris because she has called him “weird” several times.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/TrumpBedminster-scaled-1-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/TrumpBedminster-scaled-1-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/TrumpBedminster-scaled-1-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/TrumpBedminster-scaled-1-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/TrumpBedminster-scaled-1-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/TrumpBedminster-scaled-1-2048x1366.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">BEDMINSTER, NEW JERSEY - AUGUST 15:  Republican presidential candidate, former U.S. President Donald Trump holds a news conference outside the Trump National Golf Club Bedminster on August 15, 2024 in Bedminster, New Jersey. Trump's campaign leaders announced they were expanding his staff as the reelection campaign heads in to its final few months. (Photo by Adam Gray/Getty Images)</p><p>Republican presidential nominee Donald Trump said Thursday he sees no need to switch the tactics or tone of his bid for the White House now that Vice President Kamala Harris is the Democratic nominee instead of President Joe Biden.</p>
+<p>Speaking during a press conference at his golf club in New Jersey, the former president began with 45 minutes of comments on a myriad of issues before he took more than a dozen questions from reporters.</p>
+<p>Trump argued that there was no need to limit his personal criticism of Harris since there are several criminal trials ongoing against him and because she has called him “weird” several times.</p>
+<p>“I think I’m entitled to personal attacks,” Trump said. “I don’t have a lot of respect for her. I don’t have a lot of respect for her intelligence. And I think she’ll be a terrible president.”</p>
+<p>Numerous Republicans, including former South Carolina Gov. Nikki Haley, who challenged Trump for the nomination though she now says <a href="https://www.cnn.com/2024/05/22/politics/nikki-haley-donald-trump/index.html" target="_blank">she will vote for him</a>, have called for Trump to focus more on the policy differences between the two political parties, and less on his personal grievances with Harris.</p>
+<p>Trump, for example, sought to question Harris’ racial identity during his <a href="https://www.newsfromthestates.com/article/trump-insults-harris-makes-false-claims-quarrels-black-journalists-conference" target="_blank">panel interview</a> at the National Association of Black Journalists late last month.</p>
+<p>Trump gave Thursday’s press conference outside and spoke while standing in between two tables of groceries and what appeared to be a large, blue doll house.</p>
+<p>He used the props to make a case that prices are too high for American families, laying the blame for inflation at the feet of the Biden-Harris administration and insisting he’s the only person able to get prices back down.</p>
+<p>Trump brushed aside his polling numbers in swing states, some of which have him trailing or inside the margin of error, in the match-up with Harris.</p>
+<p>“I tend to poll low,” Trump said. “In some cases, really low.”</p>
+<p>He also said that if reelected in November he hoped to develop a “friendly” relationship with Iran and to “get along” with China. The GOP has repeatedly criticized Democrats for being too lenient with both countries.</p>
+    <h4 class="editorialSubhed">‘Another public meltdown’</h4>
+
+	
+<p>The Harris-Walz campaign released a mock advisory for the press conference before it began Thursday, writing in an email that Trump was preparing to “hold another public meltdown in Bedminster, New Jersey.”</p>
+<p>“Not so fresh off NABJ, Florida, and Twitter glitches, Donald Trump intends to deliver another self-obsessed rant full of his own personal grievances to distract from his toxic Project 2025 agenda, unpopular running mate, and increasing detachment from the reality of the voters who will decide this election,” the campaign wrote. “These remarks will not be artificial intelligence, but they certainly will lack intelligence.”</p>
+<p>Spokesperson James Singer released a written statement afterward that Trump “huffed and puffed his opposition to lowering food costs for middle and working class Americans and prescription drug costs for seniors before pivoting back to his usual lies and delusions.”</p>
+    <h4 class="editorialSubhed">Race remains in flux</h4>
+
+	
+<p>Despite the new momentum at the top of the Democratic presidential ticket and Trump insisting he’s on track to win, neither candidate yet has a clear path to victory this November, experts say.</p>
+<p>The Cook Political Report with Amy Walter, a nonpartisan publication that analyzes campaigns and rates whether races are leaning toward one political party or the other, has placed six states in its “toss-up” category for the Electoral College.</p>
+<p>Arizona’s 11, Georgia’s 16, Michigan’s 15, Nevada’s six, Pennsylvania’s 19 and Wisconsin’s 10 Electoral College votes could go to either Harris or Trump when voting wraps up, according to the political publication’s <a href="https://www.cookpolitical.com/ratings/presidential-race-ratings" target="_blank">reporting</a>.</p>
+<p>Minnesota, Nebraska’s 2nd Congressional District and New Hampshire are all rated as leaning toward Harris with a total of 15 votes, while North Carolina and its 16 votes are leaning toward Trump.</p>
+<p>All the other states are categorized as “solid” or “likely” going to either Trump or Harris, underlining the close nature of the campaign.</p>
+<p>Walter told reporters on a call Thursday that Harris has a chance to sway swing voters during her speech to the Democratic National Convention next week.</p>
+<p>“She has an opportunity here in that people are going to be more interested in watching this convention, certainly, than they were a month ago when Biden was on the top of the ticket,” she said. “And it’s an opportunity to speak beyond the Democratic base.”</p>
+<p>The prime-time speech will give Harris a forum to address the major criticisms of her presidential run, including that she’s too liberal, isn’t the best person to handle the economy and that she’s weak on immigration policy, Walter said.</p>
+    <h4 class="editorialSubhed">Trump and his temperament</h4>
+
+	
+<p>Greg Strimple, president of GS Strategy Group, which is partnering with the Cook Political Report on a swing state project looking at voters’ views toward the candidates, said one of the bigger challenges for Trump’s campaign is getting the candidate to stay on message.</p>
+<p>“This race has shifted from being a referendum on Biden’s age and economy to being a referendum on Trump and his temperament,” Strimple said on the call. “And despite the fact that Donald Trump is unable to get out of his way at the moment, his campaign is running ads that are right on message.”</p>
+<p>If Trump and his campaign aligned to push their belief that Harris is “too liberal, too inexperienced and a continuation of Biden on the economy,” that could help them to regain ground in polling and with voters ahead of Election Day, he said.</p>
+<p>“There’s a lot of talk right now about the race being over, and I just kind of caution everyone that there is a path for Trump — it’s just whether he can take it,” Strimple said.</p>
+<p>Patrick Toomey, a partner at BSG, which is also part of the swing state project, said on the call that voters shouldn’t rule out ups and downs in support for the candidates in the months ahead, citing potential upheaval from hurricane season or the ongoing wars in the Middle East.</p>
+<p>“It’s just worth keeping in mind how many dramatic twists and turns there have been in this race so far,” Toomey said. “And the idea that because we’ve had this reset now things are set and nothing is going to change going forward, would be a mistake.”</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Trump asks New York judge to delay felony sentencing past Election Day</title>
+		<link>https://newjerseymonitor.com/2024/08/15/trump-asks-new-york-judge-to-delay-felony-sentencing-past-election-day/</link>
+		
+		<dc:creator><![CDATA[Jacob Fischler]]></dc:creator>
+		<pubDate>Thu, 15 Aug 2024 20:48:53 +0000</pubDate>
+				<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Donald Trump]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14329</guid>
+
+					<description><![CDATA[A sentencing proceeding could improperly affect voters’ perception of Trump leading up to Election Day, Trump's lawyers say.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/05/TrumpGuilty-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/05/TrumpGuilty-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/05/TrumpGuilty-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/05/TrumpGuilty-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/05/TrumpGuilty-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/05/TrumpGuilty-2048x1365.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">A sentencing proceeding could improperly affect voters’ perception of Trump leading up to Election Day, Trump's lawyers say. (Photo by Seth Wenig-Pool/Getty Images)</p><p>Former President Donald Trump asked a New York court Thursday to delay until after November’s presidential election his sentencing for the 34 state felonies the court convicted him of in May.</p>
+<p>Judge Juan Merchan scheduled a sentencing hearing for Sept. 18. But that date overlaps with early voting in the presidential election and gives Trump too little time to appeal a potential ruling against him on a request to vacate the conviction, which Merchan is scheduled to issue two days prior, attorneys Todd Blanche and Emil Bove wrote to Merchan<a href="https://www.documentcloud.org/documents/25045316-20240814-letter-to-justice-merchan-re-sentencing-adjournment" target="_blank"> in a letter</a> dated Wednesday.</p>
+<p>The one-page letter was not on the court’s official docket Thursday morning, but Blanche provided a copy to States Newsroom and said it had been filed with the court.</p>
+<p>Merchan’s schedule is unrealistic and ignores several related issues, Trump’s attorneys wrote.</p>
+<p>A sentencing proceeding could improperly affect voters’ perception of Trump leading up to Election Day, and Merchan’s daughter’s ties to elected Democrats could undermine the public’s faith in the court, they wrote.</p>
+<p>While Merchan has rejected three requests from Trump that he recuse himself from the case because of his daughter’s employment at a company that produces advertising campaigns for Democrats, Trump’s lawyers said delaying the sentencing would help mitigate any potential appearance of a conflict of interest.</p>
+<p>Trump’s Democratic rival, Vice President Kamala Harris, and her running mate, Minnesota Gov. Tim Walz, continue to discuss the case on the campaign trail. And the founder of the firm where Merchan’s daughter works has expressed his support for Harris on social media, Blanche and Bove wrote.</p>
+    <h4 class="editorialSubhed">Election entanglements</h4>
+
+	
+<p>The Sept. 18 sentencing is also scheduled “after the commencement of early voting in the Presidential election,” they wrote.</p>
+<p>“By adjourning the sentencing until after that election … the Court would reduce, even if not eliminate, issues regarding the integrity of any future proceedings,” they wrote.</p>
+<p>Pennsylvania law allows the earliest voting, according to a<a href="https://www.ncsl.org/elections-and-campaigns/early-in-person-voting" target="_blank"> database</a> compiled by the National Conference of State Legislatures. Pennsylvania counties are permitted to hold early voting 50 days before Election Day, which is Sept. 16.</p>
+<p>It is unclear if any counties in the key battleground state are planning to make voting available that soon.</p>
+<p>No other states allow voting before Sept. 18, according to the NCSL database. Blanche did not answer an emailed question about what early voting he was referring to in the letter.</p>
+    <h4 class="editorialSubhed">Presidential immunity</h4>
+
+	
+<p>Trump’s attorneys said the sentencing hearing should also be moved to accommodate another issue in the case: Trump’s presidential immunity argument.</p>
+<p>Trump has asked for his conviction to be overturned following a U.S. Supreme Court decision that ruled presidents were entitled to a broad definition of criminal immunity for acts they take in office.</p>
+<p>Merchan set a Sept. 16 date to rule on the request the state conviction be set aside, but Trump’s attorneys said that does not leave enough time for Trump to appeal a potentially unfavorable ruling on the immunity issue.</p>
+<p>“The requested adjournment is also necessary to allow President Trump adequate time to assess and pursue state and federal appellate options in response to any adverse ruling,” they wrote.</p>
+<p>The Supreme Court decision that established presidential immunity arose from a pretrial appeal, they wrote.</p>
+<p>A New York jury<a href="https://www.newsfromthestates.com/article/trump-found-guilty-34-felony-counts-ny-hush-money-trial-10" target="_blank"> convicted</a> Trump in May of 34 felony counts of falsified business records, making him the first former president to be convicted of a felony. Trump was accused of sending $130,000, through attorney  Michael Cohen, to adult film star Stormy Daniels in the weeks before the 2016 election to buy her silence about<a href="https://www.newsfromthestates.com/article/porn-star-stormy-daniels-nyc-hush-money-trial-alleges-sexual-encounter-trump" target="_blank"> an alleged sexual encounter</a> years earlier.</p>
+<p>Merchan initially set sentencing for July 11.</p>
+<p>But after the Supreme Court<a href="https://www.newsfromthestates.com/article/presidential-immunity-covers-some-official-acts-supreme-court-rules-trump-case" target="_blank"> ruled on July 1</a> that presidents enjoy full immunity from criminal charges for their official acts, the New York judge agreed to delay sentencing to first rule on how the Supreme Court decision affected the New York case.</p>
+<p>While much of the conduct alleged in the New York case took place before Trump was in office, his attorneys have argued that the prosecution also included investigations into Oval Office meetings with Cohen that could be impermissible under the Supreme Court’s standard.</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Feds, state resolve claims Monmouth courts discriminated against people with poor English skills</title>
+		<link>https://newjerseymonitor.com/briefs/feds-state-resolve-allegations-that-monmouth-courts-discriminated-against-people-with-poor-english-skills/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Thu, 15 Aug 2024 20:33:02 +0000</pubDate>
+				<category><![CDATA[Civil Rights + Immigration]]></category>
+		<category><![CDATA[Courts]]></category>
+		<category><![CDATA[Kristen Clarke]]></category>
+		<category><![CDATA[Pete McAleer]]></category>
+		<category><![CDATA[Philip Sellinger]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14326</guid>
+
+					<description><![CDATA[Courts will translate more documents, boost training after the U.S. Department of Justice found non-English speakers were effectively denied access.]]></description>
+																						<content:encoded><![CDATA[<img width="958" height="720" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/1707233117090.jpeg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/1707233117090.jpeg 958w, https://newjerseymonitor.com/wp-content/uploads/2024/08/1707233117090-300x225.jpeg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/1707233117090-768x577.jpeg 768w" sizes="(max-width: 958px) 100vw, 958px" /><p style="font-size:12px;">A new agreement resolves allegations charging the Monmouth vicinage failed to provide assistance to residents with limited proficiency in English. (Courtesy of New Jersey Courts)</p><p><span data-preserver-spaces="true">Monmouth County courts entered into an agreement with federal authorities to resolve allegations the vicinage discriminated against residents with limited English language proficiency.</span></p>
+<p><a class="editor-rtfLink" href="https://content.govdelivery.com/attachments/USDOJUSAO/2024/08/15/file_attachments/2968062/NJ_Courts_Final_MOA_508.pdf" target="_blank" rel="noopener"><span data-preserver-spaces="true">The agreement</span></a><span data-preserver-spaces="true">, approved Tuesday and announced Thursday, settles claims that the Monmouth vicinage failed to provide assistance to residents with limited proficiency in English, thereby depriving them of access to courts there based on race or national origin in violation of the federal Civil Rights Act.</span></p>
+<p><span data-preserver-spaces="true">“People with limited English proficiency can lose their children, homes and fundamental rights when they face language barriers in our court systems,” Assistant Attorney General Kristen Clarke of the U.S. Department of Justice said in a statement. “The Civil Rights Division will continue fighting to ensure that courts remove language barriers for the public.”</span></p>
+<p><span data-preserver-spaces="true">The agreement will require the judiciary to provide a list of reforms to improve access for residents with limited English proficiency by Sept. 12 and it must implement those reforms no more than 120 days after they are approved by the Department of Justice.</span></p>
+<p><span data-preserver-spaces="true">It mandates that judiciary workers who may encounter residents with limited English receive training on how to identify and aid such residents, as well as court requirements on remote and on-site interpreters, among other things.</span></p>
+<p><span data-preserver-spaces="true">“Dispensing justice fairly and equitably is a cornerstone of our democratic system,” said U.S. Attorney Philip R. Sellinger. “We remain committed to ensuring that all litigants in New Jersey have equal access to New Jersey’s court system regardless of language barriers.</span></p>
+<p><span data-preserver-spaces="true">The deal requires the judiciary to continue translating forms and documents to Spanish, Portuguese, Haitian-Creole, Korean, and Polish — the five languages most commonly spoken by court users with limited English.</span></p>
+<p><span data-preserver-spaces="true">As of Tuesday, the judiciary had translated 167 forms into Spanish and 66 forms to the other four languages.</span></p>
+<p><span data-preserver-spaces="true">“The Judiciary, like the Department of Justice, is committed to ensuring equal access to the courts for all. Many of the improvements detailed in the memorandum were already in place,” said state courts spokesman Pete McAleer.</span></p>
+<p><span data-preserver-spaces="true">He added the Monmouth vicinage had already taken steps to comply with the agreement and would continue to do so.</span></p>
+<p><span data-preserver-spaces="true">The memorandum will additionally require the judiciary to pay $89,718 to a court worker who alleged retaliation after raising concerns about court access for non-English speakers, and it requires the courts to excise mentions of discipline the worker faced over the complaint from their personnel files.</span></p>
+<p>As is typical of such agreements, the memorandum does not include an admission or declaration of guilt.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Moody&#8217;s boosts N.J.&#8217;s credit outlook, citing pension payments and surplus</title>
+		<link>https://newjerseymonitor.com/2024/08/15/moodys-boosts-n-j-s-credit-outlook-citing-pension-payments-and-surplus/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Thu, 15 Aug 2024 18:24:25 +0000</pubDate>
+				<category><![CDATA[Economy]]></category>
+		<category><![CDATA[credit ratings]]></category>
+		<category><![CDATA[Liz Muoio]]></category>
+		<category><![CDATA[Moody's]]></category>
+		<category><![CDATA[Phil Murphy]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14321</guid>
+
+					<description><![CDATA[The ratings agency said continued full pension payments and a strong surplus warrant optimism despite New Jersey's structural deficit.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/03/New_Jersey_Monitor_Budget_Illustration_2-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/03/New_Jersey_Monitor_Budget_Illustration_2-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/03/New_Jersey_Monitor_Budget_Illustration_2-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/03/New_Jersey_Monitor_Budget_Illustration_2-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/03/New_Jersey_Monitor_Budget_Illustration_2-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/03/New_Jersey_Monitor_Budget_Illustration_2.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">The ratings agency said continued full pension payments and a strong surplus warrant optimism despite New Jersey's structural deficit. (Illustration by Alex Cochran for New Jersey Monitor)</p><p style="font-weight: 400;">Ratings firm Moody’s improved New Jersey’s credit outlook on Wednesday but kept ratings static for the state as a whole, praising continued full pension payments but warning that reliance on one-shot revenue items and a drained surplus could lead to credit downgrades.</p>
+<p style="font-weight: 400;">The firm upgraded the state’s rating outlook to positive, signaling New Jersey is well positioned for a credit upgrade and predicting strong economic and revenue growth that would allow the Garden State to continue making full pension payments in the next fiscal year.</p>
+<figure id="attachment_14324" class="wp-caption alignleft" style="max-width:100%;width:300px;"><a href="https://newjerseymonitor.com/2024/08/15/moodys-boosts-n-j-s-credit-outlook-citing-pension-payments-and-surplus/52719759061_0c2b3ac361_c/" rel="attachment wp-att-14324"><img decoding="async" loading="lazy" class="size-medium wp-image-14324" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/52719759061_0c2b3ac361_c-300x202.jpg" alt="" width="300" height="202" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/52719759061_0c2b3ac361_c-300x202.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/52719759061_0c2b3ac361_c-768x517.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/52719759061_0c2b3ac361_c.jpg 800w" sizes="(max-width: 300px) 100vw, 300px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  State Treasurer Liz Muoio (OIT/NJ Governor’s Office).</p></figure>
+<p style="font-weight: 400;">“This outlook upgrade is especially good news given that it comes just a year after the state received a rating boost from every major credit rating agency,” said Treasurer Liz Muoio. “That signals to us that the fiscal decisions we have made — namely to maintain a healthy budget surplus and continue to meet our pension obligations — are the right ones.”</p>
+<p style="font-weight: 400;">The ratings agency said New Jersey could receive a credit upgrade that would take its rating back to a high grade if it maintained a surplus equal to at least 10% of annual spending, took steps to encourage continued full pension payments, and worked to reduce long-term debts and fixed costs.</p>
+<p style="font-weight: 400;">New Jersey’s A1 credit rating is at the top of the firm’s upper middle grade tier, which suggests New Jersey’s long-term bonds carry a low credit risk and the state has a superior ability to repay short-term debt.</p>
+<p style="font-weight: 400;">The change in New Jersey’s outlook coincided with strong revenue growth in July. Treasury officials on Wednesday said New Jersey’s gross income tax collections grew by 9% over last July after excluding an extra week of tax withholdings included in the current year’s counts.</p>
+<p style="font-weight: 400;">Corporate business tax revenue rose 5.1% year-over-year, while sales tax collections remained largely static, growing just under 1%.</p>
+<p style="font-weight: 400;">“We remain laser focused in our multi-year efforts to restore the state’s fiscal standing,” Gov. Phil Murphy said in a statement.</p>
+<p style="font-weight: 400;">In awarding the improved outlook, Moody’s cited economic growth in New Jersey that had outpaced that of other mid-Atlantic states.</p>
+<p style="font-weight: 400;">The ratings agency noted that, while <a href="https://newjerseymonitor.com/2024/06/28/record-setting-56-6b-state-budget-wins-legislative-approval/" target="_blank" rel="noopener">the state budget approved in late June</a> includes a $2.4 billion structural deficit that is expected to bring New Jersey’s surplus down to roughly $6.2 billion, the state&#8217;s reserves still dwarf the razor-thin surpluses it has maintained for much of the past two decades.</p>
+<p style="font-weight: 400;">That deficit is set to expand in the fiscal year that begins July 1, 2025, when a statutory dedication will direct collections from a 2.5% surtax on businesses with more than $10 million in profit to NJ Transit.</p>
+<p style="font-weight: 400;">The tax, <a href="https://newjerseymonitor.com/2024/02/28/murphys-planned-corporate-transit-tax-to-fund-nj-transit-prompts-praise-and-jeers/" target="_blank" rel="noopener">called the corporate transit fee</a>, is forecast to raise $1 billion for the state’s general fund in the current July-to-June fiscal year and includes six months of retroactive collections applied to the first six months of 2024.</p>
+<p style="font-weight: 400;">Growth in the state’s major revenue sources — its sales and personal and business income taxes — could help close the state’s burgeoning structural deficit, but it remains to be seen whether they will grow fast enough to bridge the gap.</p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>NJ Transit will be free for a week as apology for &#8216;ugly summer,&#8217; governor says</title>
+		<link>https://newjerseymonitor.com/2024/08/15/nj-transit-will-be-free-for-a-week-as-apology-for-ugly-summer-governor-says/</link>
+		
+		<dc:creator><![CDATA[Dana DiFilippo]]></dc:creator>
+		<pubDate>Thu, 15 Aug 2024 14:45:26 +0000</pubDate>
+				<category><![CDATA[Gov + Legislature]]></category>
+		<category><![CDATA[Transportation]]></category>
+		<category><![CDATA[Gov. Phil Murphy]]></category>
+		<category><![CDATA[NJ Transit]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14319</guid>
+
+					<description><![CDATA[NJ Transit customers will get a week of free rides to compensate for a summer of service disruptions. The fare holiday will cost $19 million.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="768" src="https://newjerseymonitor.com/wp-content/uploads/2024/06/IMG_5365-1024x768.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/06/IMG_5365-1024x768.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/06/IMG_5365-300x225.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/06/IMG_5365-768x576.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/06/IMG_5365-1536x1152.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/06/IMG_5365-2048x1536.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">NJ Transit customers will get a week of free rides to compensate for a summer of service disruptions. The fare holiday will cost $19 million. (Dana DiFilippo | New Jersey Monitor)</p><p><span data-preserver-spaces="true">NJ Transit riders will get free rides for a week as an apology and token of appreciation for a summer of service suspensions and delays primarily on the system’s northeast corridor, Gov. Phil Murphy said Thursday.</span></p>
+<p><span data-preserver-spaces="true">Monthly customers will get a 25% discount on their September passes in lieu of daily customers’ weeklong “fare holiday,” which will last from Aug. 26 through Sept. 2 and apply to rail, light rail, and bus service.</span></p>
+<p><span data-preserver-spaces="true">State officials want to “end the summer on a grace note,” Murphy said on Fox 5 New York’s morning show Thursday, where he announced the fare break. This summer’s extreme heat, the system’s ancient infrastructure, and finger-pointing between NJ Transit and Amtrak have stranded thousands of rail riders — sometimes every day, sometimes for hours, and </span><a class="editor-rtfLink" href="https://www.bloomberg.com/news/articles/2024-08-02/nj-transit-train-fiasco-traps-people-for-hours-with-no-ac-in-tunnel" target="_blank" rel="noopener"><span data-preserver-spaces="true">at least once in a hot, dark tunnel</span></a><span data-preserver-spaces="true"> under the Hudson River.</span></p>
+<p><span data-preserver-spaces="true">“I&#8217;m not naive enough to think that if you&#8217;ve had the summer that our commuters have had, that one week will do it,” Murphy said. “Given the lack of service that we&#8217;ve seen over the summer, I think it&#8217;s the least we could do.”</span></p>
+<p><span data-preserver-spaces="true">The fare holiday is expected to cost the state $19 million, NJ Transit spokesman John Chartier said. It comes six weeks after the troubled transit agency hiked fares as much as 15% to cover a </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/07/25/nj-transit-approves-3b-budget-amid-outcry-over-fare-hikes/" target="_blank" rel="noopener"><span data-preserver-spaces="true">budget shortfall</span></a><span data-preserver-spaces="true"> created partly by a pandemic-related drop in ridership that hasn’t yet fully rebounded. State lawmakers in June approved a </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/06/27/lawmakers-advance-new-business-surtax-aimed-at-funding-nj-transit/" target="_blank" rel="noopener"><span data-preserver-spaces="true">new business surtax</span></a><span data-preserver-spaces="true">, which is expected to generate about $1 billion in its first year, to help the troubled transit agency.</span></p>
+<p><span data-preserver-spaces="true">“We are fixing it,” Murphy said.</span></p>
+<p><span data-preserver-spaces="true">The governor attributed “two-thirds of our delays, plus or minus” to Amtrak infrastructure. The federal rail agency has applied for $300 million in federal grants to fix the overhead catenary wires on the rail system, Murphy said. Those wires can fail on extremely hot days, and officials often blame them for summer service disruptions.</span></p>
+<p><span data-preserver-spaces="true">“I&#8217;m extremely frustrated,” Murphy said. “Again, a lot of this is out of our hands.”</span></p>
+<p><span data-preserver-spaces="true">Michele Siekerka, president and CEO of the New Jersey Business &amp; Industry Association, said in a statement Thursday that the fare holiday “smacks of unfairness to New Jersey’s business community.”</span></p>
+<p><span data-preserver-spaces="true">“Providing this fare holiday on the heels of a massive corporate tax increase to support the budget woes for NJ Transit is a frustrating message and wholly disregards the latest hit our business community just took on competitiveness,” Siekerka said.</span></p>
+<p><span data-preserver-spaces="true">Both state and federal officials continue investigating the “root causes” of the service problems, with NJ Transit staffers increasing equipment inspections on platforms and Amtrak focusing on the catenary wires, track signal systems, and northeast corridor substations, Murphy said.</span></p>
+<p><span data-preserver-spaces="true">The northeast corridor is the </span><a class="editor-rtfLink" href="https://www.fra.dot.gov/necfuture/about/facts.aspx" target="_blank" rel="noopener"><span data-preserver-spaces="true">busiest</span></a><span data-preserver-spaces="true"> rail route in the country, with about 750,000 passengers daily, according to the Federal Railroad Administration.</span></p>
+<p><span data-preserver-spaces="true">The River Line, light rail service that runs along the Delaware River between Camden and Trenton, also has come under fire in recent weeks for service cancelations and delays. NJ Transit temporarily expanded bus service along the route until the River Line’s service problems improve.</span></p>
+<p><span data-preserver-spaces="true">“It&#8217;s been a really ugly summer,” Murphy said. “Here&#8217;s the good news: The trajectory from where we were to where we are and where we&#8217;re going is very positive.”</span></p>
+<p><span data-preserver-spaces="true">Still, he acknowledged, “good luck telling that to somebody who&#8217;s stuck in a train under the Hudson River for two or three hours.”</span></p>
+<p><em><span data-preserver-spaces="true">Nikita Biryukov contributed.</span></em></p>
+<p><span data-preserver-spaces="true">    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	</span></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Senator calls for more oversight of school spending</title>
+		<link>https://newjerseymonitor.com/2024/08/15/senator-calls-for-more-oversight-of-school-spending/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Thu, 15 Aug 2024 11:01:55 +0000</pubDate>
+				<category><![CDATA[Education]]></category>
+		<category><![CDATA[O'Scanlon]]></category>
+		<category><![CDATA[School Funding]]></category>
+		<category><![CDATA[State auditor]]></category>
+		<category><![CDATA[Vin Gopal]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14309</guid>
+
+					<description><![CDATA[Recent audits in three school districts have uncovered officials awarding contracts without opening bids, purchases not supported by financial records, and other instances of waste or mismanagement.]]></description>
+																						<content:encoded><![CDATA[<img width="800" height="533" src="https://newjerseymonitor.com/wp-content/uploads/2022/05/48881284247_6719062a2b_c.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2022/05/48881284247_6719062a2b_c.jpg 800w, https://newjerseymonitor.com/wp-content/uploads/2022/05/48881284247_6719062a2b_c-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2022/05/48881284247_6719062a2b_c-768x512.jpg 768w" sizes="(max-width: 800px) 100vw, 800px" /><p style="font-size:12px;">Recent audits in three school districts have uncovered officials awarding contracts without opening bids, purchases not supported by financial records, and other instances of waste or mismanagement. (Photo by Edwin J. Torres/Governor’s Office)</p><p style="font-weight: 400;">A Republican legislator called for expanded audits of schools’ finances and tougher penalties for districts that are found to be poor stewards of taxpayer dollars.</p>
+<p style="font-weight: 400;">Sen. Declan O’Scanlon (R-Monmouth), the chamber’s GOP budget officer, said recent audits by the state auditor, a legislative office, that found procurement breakdowns and waste at multiple school districts underscore the need for enhanced oversight.</p>
+<p style="font-weight: 400;">“You&#8217;ve got to ask the question: Is it laziness? Is it incompetence? Is it nefarious? You&#8217;ve got to ask those questions, but it does exist, and it&#8217;s prevalent apparently wherever they look, so how do we combat this?” the senator said.</p>
+<p style="font-weight: 400;">The state auditor is tasked with examining finances at state agencies and school districts that post a budget with a deficit and those where state aid accounts for at least 80% of a district’s spending.</p>
+<p style="font-weight: 400;">Recent audits of school districts in <a href="https://pub.njleg.state.nj.us/publications/auditor/2024/34004022.pdf" target="_blank" rel="noopener">Plainfield</a> and <a href="https://pub.njleg.state.nj.us/publications/auditor/2024/34002522.pdf" target="_blank" rel="noopener">Salem City</a> — which draw a large percentage of their funding from state coffers — and <a href="https://pub.njleg.state.nj.us/publications/auditor/2024/34010121.pdf" target="_blank" rel="noopener">Lakewood</a>, which is running a deficit, uncovered numerous instances of waste or mismanagement.</p>
+<p style="font-weight: 400;">Salem awarded contracts without open bids to 57% of the vendors included in the auditor’s review, and Lakewood, over a period of years, paid its general counsel $2.4 million, much of which came from a retainer agreement and not for specific work the attorney undertook.</p>
+<p style="font-weight: 400;">In Plainfield, poor controls left laptops worth tens of thousands of dollars unaccounted for, contracts with debarred vendors, and roughly $281,000 in purchases that were not supported by district records.</p>
+<p style="font-weight: 400;">Though the office’s reviews regularly uncover at least some level of financial mismanagement and improper procurement, it can do little to reprimand the school districts found to have spent funds inefficiently. It performs audits at a handful of districts each year.</p>
+<p style="font-weight: 400;">O’Scanlon, who called on the attorney general to probe spending in Salem City that he said may have risen to the level of a criminal offense, suggested empowering the state Board of Education or a similar body to withhold state aid from districts found to be poor stewards of public dollars. He acknowledged the policy would have practical barriers.</p>
+<p style="font-weight: 400;">“You don&#8217;t want to punish the students, so that&#8217;s a problem,” he said. “If you claw this money back, you hamper the district&#8217;s ability to educate kids. Because the money&#8217;s already been squandered, it&#8217;s impossible to give back. You need to have a balance.”</p>
+<p style="font-weight: 400;">He suggested personal liability for administrators found to have wasted public funds could be a solution without committing to the policy.</p>
+<p style="font-weight: 400;">“You don&#8217;t want administrators to be tempted to get away with things by sending the message that nothing will ever happen because the state doesn&#8217;t want to punish the students,” O’Scanlon said. “You don&#8217;t want to invite them being dishonest, ignoring bidding rules and other financial rules.”</p>
+<p style="font-weight: 400;">He added the state auditor should probe a greater number of districts each year, perhaps including ones that fall outside its current mandate. The office has probed finances in three districts so far this year, up from one in 2023.</p>
+<p>Sen. Vin Gopal (D-Monmouth), who chairs the chamber&#8217;s education committee, agreed districts should face heightened scrutiny and more accountability.</p>
+<p style="font-weight: 400;">O&#8217;Scanlon&#8217;s call is the latest step in a long-simmering quarrel over school funding that began to be redistributed from historically overfunded districts to historically underfunded ones when lawmakers in 2018 approved a bill phasing out adjustment aid meant to keep districts whole after the state adopted its new funding formula in 2008.</p>
+<p style="font-weight: 400;">More recent spats over the funding formula have focused on steep swings to state aid spurred by unexpectedly high property valuations and shifts in enrollment in the final years of the bill’s phase-in.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>‘Perfect storm’ of crises is leading to cutbacks in abortion care, advocates say</title>
+		<link>https://newjerseymonitor.com/2024/08/15/perfect-storm-of-crises-is-leading-to-cutbacks-in-abortion-care-advocates-say/</link>
+		
+		<dc:creator><![CDATA[Kelcie Moseley-Morris]]></dc:creator>
+		<pubDate>Thu, 15 Aug 2024 10:46:12 +0000</pubDate>
+				<category><![CDATA[Abortion Policy]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14315</guid>
+
+					<description><![CDATA[Abortion fund directors nationwide have been raising the alarm for months about declining donations and their struggles to meet the needs of those seeking help.]]></description>
+																						<content:encoded><![CDATA[<img width="799" height="533" src="https://newjerseymonitor.com/wp-content/uploads/2024/04/53613857615_53fb8d6e2c_c.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/04/53613857615_53fb8d6e2c_c.jpg 799w, https://newjerseymonitor.com/wp-content/uploads/2024/04/53613857615_53fb8d6e2c_c-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/04/53613857615_53fb8d6e2c_c-768x512.jpg 768w" sizes="(max-width: 799px) 100vw, 799px" /><p style="font-size:12px;">Abortion fund directors nationwide have been raising the alarm for months about declining donations and their struggles to meet the needs of those seeking help. (Rich Hundley III/ NJ Governor’s Office)</p><p>Advocates for abortion access say compounding crises of abortion bans, rising economic costs and systemic health care issues are beginning to cause significant funding challenges and potential disruptions to reproductive care of all kinds.</p>
+<p>Several people described it as a “perfect storm” of problems with the U.S. health care system, particularly post-pandemic, and the rise of abortion bans and other reproductive care restrictions in the wake of the Dobbs v. Jackson Women’s Health Organization decision in June 2022. Many individuals must now travel hundreds or thousands of miles to seek abortion care, and the consolidation of demand at a smaller number of clinics is increasing wait times, which means pregnancies progress to a more advanced stage and the costs balloon further. According to leaders of Planned Parenthood affiliates and abortion funds, there simply aren’t enough dollars right now to support the need at any level. A <a href="https://www.newsfromthestates.com/article/telehealth-abortion-still-rise-especially-states-shield-laws-report-shows" target="_blank">recent report from #WeCount</a> showed the number of abortions nationwide started to increase in 2017 and has continued to increase post-Dobbs, with more than 102,000 abortions in January alone.</p>
+<p>Abortion fund directors nationwide have been raising the alarm for months about declining donation revenue and their struggles to meet the needs of those seeking help with the financial burdens of finding abortion care, especially those who live in one of <a href="https://www.newsfromthestates.com/see-data-reproductive-rights" target="_blank">22 states</a> with near-total bans or severely restrictive abortion laws. That includes every state in the Southeast.</p>
+<p>Planned Parenthood of Northern New England announced at the beginning of the month a projected <a href="https://mainemorningstar.com/briefs/planned-parenthood-of-northern-new-england-projects-multi-million-dollar-deficit-calls-for-state-funding/" target="_blank">funding shortfall</a> of about $8.6 million over the next three years, and Planned Parenthood of Greater New York announced just a few days later that it would pause abortion care at or beyond 20 weeks because of financial struggles that began earlier this year. The National Abortion Federation runs America’s largest financial assistance program for abortion patients and said that just in the first half of this year it has partially funded more than 60,000 people’s abortions — a total of around $6 million per month — but has now had to reduce patient grants from 50% of the cost of care to 30%.</p>
+<p>Even in areas with new abortion restrictions, such as Florida, donations have declined significantly. Stephanie Loraine Piñeiro, executive director of Florida Access Network, said during a June press conference that the month after the Dobbs decision ended federal abortion rights, the fund received $200,000 in individual donations — but after the state supreme court decision in April 2024 reduced the state’s abortion ban from 15 gestational weeks to six weeks, the fund received just $40,000 in donations.</p>
+<p>“That is a stark difference, and it has everything to do with donors feeling burnt out,” Loraine Piñeiro said.</p>
+    <h4 class="editorialSubhed">Hostile political winds </h4>
+
+	
+<p>Planned Parenthood Federation of America told States Newsroom it is meeting its fundraising goals, but the organization’s local health centers and regional affiliates are struggling to provide care in the current climate.</p>
+<p>Nicole Clegg, interim CEO of Planned Parenthood of Northern New England, told States Newsroom the affiliate has always been under-resourced and under-reimbursed for the care it provides, which includes birth control, testing for sexually transmitted diseases and routine gynecological care in addition to abortion services. But now that the region, which includes Maine, Vermont and New Hampshire, is taking on more patients from states with abortion bans, it is reaching a tipping point.</p>
+<p>“The services we provide are just not valued by the insurance industry, or Medicaid and Medicare — they have always been poorly reimbursed,” Clegg said. “Once costs really started to skyrocket, the margin we were operating with disappeared.”</p>
+<p>According to an analysis of health care spending and costs<a href="https://www.kff.org/health-policy-101-health-care-costs-and-affordability/?entry=table-of-contents-how-do-high-health-costs-affect-affordability-of-care" target="_blank"> by KFF</a>, health spending tripled between the year 2000 and 2022, from $1.4 trillion to $4.5 trillion. The pandemic accelerated that spending, but the analysis also said the aging population of the U.S., rising rates of chronic conditions, inflation, and expansions of insurance coverage have also driven up costs.</p>
+<p>A bill that would have provided nearly $3.4 million to Maine’s family planning centers got caught in<a href="https://mainemorningstar.com/2024/05/21/less-than-10-of-bills-on-the-legislatures-2024-appropriations-table-became-law/" target="_blank"> legislative wrangling</a> that affected many appropriations bills at the end of the session.</p>
+<p>In New Hampshire, which allows abortions until 24 weeks of pregnancy, the affiliate had nearly secured a multi-year grant of more than $2 million total, with the <a href="https://www.newsfromthestates.com/article/council-could-get-rejected-family-planning-contracts-fifth-time" target="_blank">support of Republican Gov. Chris Sununu</a>. However, Clegg said that when the grant went before an executive council for final approval in 2023, the members <a href="https://www.newsfromthestates.com/article/executive-council-republicans-again-reject-family-planning-contracts" target="_blank">struck it down</a>, saying they didn’t want taxpayer dollars to fund abortions. Both led to the projected $8.6 million shortfall over the next three years.</p>
+<p>“The executive council has become increasingly hostile to Planned Parenthood,” Clegg said.</p>
+<p>Planned Parenthood Great Northwest, which includes northwestern states as well as Hawaii, Alaska, Indiana and Kentucky, also said it is facing financial challenges that put access to care at risk. Lisa Humes-Schulz, vice president of policy and communications for Planned Parenthood Alliance Advocates, said in a statement that the affiliate is facing the same health care cost challenges, an underfunded federal family planning program, workforce shortages and rising labor costs. Great Northwest includes Idaho, where there is a near-total abortion ban and which was at the center of a recent U.S. Supreme Court case over whether emergency room physicians could be prosecuted under the state law for providing an abortion in the case of a medical emergency. The affiliate’s clinics in Washington have seen an influx of patients from Idaho as a result of the abortion ban over the past two years, including some emergency patients that were<a href="https://www.newsfromthestates.com/article/loss-federal-protection-idaho-spurs-pregnant-patients-plan-emergency-air-transport" target="_blank"> airlifted out of Idaho</a>.</p>
+<p>“Unlike other safety net providers, we are trying to navigate these business challenges on top of the unprecedented political attacks focused on providers of abortion care and gender-affirming care,” Humes-Schulz said.</p>
+<p>For Planned Parenthood of Greater New York, financial struggles have already prompted a change in care. After the state legislature <a href="https://www.nynmedia.com/opinion/2024/07/opinion-states-abortion-access-ecosystem-pushed-limit-two-years-after-demise-roe-v-wade/397800/" target="_blank">failed to increase Medicaid reimbursement rates</a> for medication abortion, the affiliate said it implemented executive pay cuts, consolidated job functions and closed small health centers to make up deficits. More than half of the patients that visit Planned Parenthood centers rely on Medicaid.</p>
+<p>But it took another step in temporarily stopping abortions at 20 or more weeks starting Sept. 3 because it can’t afford to cover the vendor costs for anesthesia. Only one Planned Parenthood location in New York City will offer deep sedation and abortions at 20 or more weeks for now.</p>
+    <h4 class="editorialSubhed">‘Unprecedented is not even the word anymore’</h4>
+
+	
+<p>The struggles also extend to organizations that provide more basic infrastructure for abortion clinics, such as the Abortion Care Network, which started a campaign called Keep Our Clinics to raise funds for independent abortion clinics. Independent clinics make up 55% of abortion providers, according to the network, while Planned Parenthood comprises 41%, and the remaining 4% occur at physicians’ offices and hospitals. The vast majority of clinics offering abortion care after 22 weeks — about 86% — are also independent.</p>
+<p>Erin Grant, co-executive director of the Abortion Care Network, told States Newsroom the organization’s mission is to provide grant funding for independent clinics to support infrastructure needs — such as supplies, equipment, building repair, security, and litigation support — rather than patient care. The network has supported 32 clinics, and gave out $700,000 to providers in recent months.</p>
+<p>But for the network too, donations are down by one-third. The full amount of donations to the Keep Our Clinics campaign goes to clinic members, and the organization granted nearly $5 million to clinics in 2022, but only $3.4 million in 2023. The requests for support did not go down during that time, but donations did.</p>
+<p>Grant said it’s important to support the infrastructure of independent abortion clinics because once they close, it is extremely difficult to work through the bureaucratic process again to reopen them. In areas with newly instituted six-week abortion bans, such as Florida, Iowa and South Carolina, more clinics have closed their doors.</p>
+<p>“We are in times where ‘unprecedented’ is not even the word anymore, and there is so much happening that calls for our attention. … There’s a need in this moment for us to hold multiple crises across communities,” Grant said. “… This isn’t something we get to say we did as an immediate need, because there’s decades of work ahead to build the actual infrastructure to have health care access, let alone abortion access in this country.”</p>
+<p>During a June press call, several leaders of state abortion funds discussed funding struggles. Oriaku Njoku, executive director of the National Network of Abortion Funds, said the funds provided more than $36 million in abortion funding and $10 million in logistical support in 2023.</p>
+<p>“This is not the same movement that it was five years ago, let alone 50 years ago, and yet we’re still operating and funding as if it were the same issue as it was before,” Njoku said.</p>
+<p>There are nine clinics in Ohio, where voters affirmed their desire to keep access to abortion in 2023, but it is surrounded by three states with near-total bans — Indiana, Kentucky and West Virginia. Lexis Dotson-Dufault, executive director of the Abortion Fund of Ohio, said during the press conference that her organization averaged about 100 patients per month in 2022, but now it averages more than 500.</p>
+<p>“While abortion funds have a huge increase in need, we are not seeing a huge increase in money coming in to support this need,” Dotson-Dufault said.</p>
+    <h4 class="editorialSubhed">Funding may run out by fall </h4>
+
+	
+<p>Planned Parenthood Federation of America, the national organization, did not directly address whether it would provide more support to the affiliates facing significant financial troubles.</p>
+<p>“While issues around funding are a concern, it is important to note that the reproductive health care ecosystem is straining under the weight of the post-Dobbs crisis,” a Planned Parenthood spokesperson said in a statement. “PPFA is working to support affiliates as they take action to adapt and continue to provide care.”</p>
+<p>The organization’s comments came a few days after 41 abortion funds from around the country signed on to an op-ed<a href="https://www.thenation.com/article/activism/abortion-funds-movement-crisis/" target="_blank"> in The Nation</a> saying there is a disconnect between the most visible national reproductive rights organizations, like Planned Parenthood and the National Abortion Federation, and grassroots groups working to directly support those who need care. The op-ed called out the National Abortion Federation for cutting back its financial assistance program in July, from 50% of the cost of seeking care to 30%. Signers included the Abortion Fund of Ohio and the Florida Access Network.</p>
+<p>Brittany Fonteno, CEO and president of the National Abortion Federation, called the change an “incredibly heartbreaking and difficult” decision that had to be made despite an “incredible and generous budget” that is the largest it has ever been. She said that in the first half of this year, NAF was funding at $6 million per month for abortion care, and then upwards of $200,000 per month in patient assistance funds to help with associated travel costs. These patient assistance funds are completely funded by foundation and individual donors, Fonteno said, noting that individual donations dropped nearly 40% in 2023 from the previous year after the Dobbs decision leaked.</p>
+<p>In 2023, NAF said it funded 106,865 people with an average amount of $519 per patient. So far in 2024, the hotline has funded 66,330 people at an average of $541 per patient.</p>
+<p>“We’re truly in a public health emergency right now, and unfortunately, we just can’t keep pace with the patient need,” Fonteno told States Newsroom. “We had to make this decision in order to make sure that we could stretch our funds and make sure that we could help as many people as possible for the rest of this year. If we hadn’t made this decision, then we would have run out of funding in the fall.”</p>
+<p>The changes include no longer making exceptions for those in later stages of pregnancy who face higher costs — sometimes as much as $10,000, Fonteno said — because the procedure costs more or they have to travel further to find a clinic that can provide it. That “exception budget,” which was also used for patients facing extreme circumstances like intimate partner violence, will not exist for the remainder of the year, according to Fonteno.</p>
+<p>“Of course, we’re working incredibly hard to try to fundraise, to try to get the word out and bring awareness to this issue. And if we’re able to fundraise, we may be able to consider increasing the funding that we’re able to do,” she said.</p>
+    <h4 class="editorialSubhed">Presidential election matters, director says </h4>
+
+	
+<p>Clegg, interim CEO of Planned Parenthood of Northern New England, said the problems will only get exponentially worse if the presidential election in November breaks for Republicans over Democrats. Project 2025, the <a href="https://www.newsfromthestates.com/article/states-are-already-collecting-more-abortion-data-and-hipaa-wont-always-keep-it-private" target="_blank">blueprint document produced by the Heritage Foundation</a> for the next Republican presidential administration to follow, calls for the federal government to <a href="https://static.project2025.org/2025_MandateForLeadership_FULL.pdf#page=504" target="_blank">prohibit Planned Parenthood from receiving any Medicaid funds</a> (for non-abortion reproductive health services; federal funding of abortion is <a href="https://www.kff.org/womens-health-policy/issue-brief/the-hyde-amendment-and-coverage-for-abortion-services-under-medicaid-in-the-post-roe-era/#:~:text=Since%201977%2C%20the%20Hyde%20Amendment,result%20from%20rape%20or%20incest." target="_blank">currently prohibited</a>) and issue guidance to states that says they are free to defund Planned Parenthood in their state Medicaid plans as well.</p>
+<p>Instead, it calls for the funding to be redirected to “health centers that provide real health care for women.” The anti-abortion organizations involved in crafting the document, such as Susan B. Anthony Pro-Life America, often promote funding for crisis pregnancy centers, which counsel pregnant patients against abortion and are known to spread misinformation about the procedure. A recent analysis from reproductive rights advocacy group Equity Forward showed<a href="https://www.cbsnews.com/news/abortion-states-have-spent-nearly-500-million-on-anti-abortion-counseling-centers/" target="_blank"> nearly $490 million</a> was allocated in 23 state budgets over the past two years for crisis pregnancy centers, most of which were in the same states that restrict abortion access.</p>
+<p>“It’s not just making sure the public understands that we need them to engage and partner with us to make sure we can keep providing the care; it’s also having them connect the dots to the November election and understand that who they vote for, who they put in office is going to determine our future,” Clegg said.</p>
+<p><b data-stringify-type="bold"><i data-stringify-type="italic">Correction: Oregon is not an affiliate of Planned Parenthood Great Northwest as incorrectly reported in an earlier version of this story.</i></b></p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Struggle for control of Congress intensifies as presidential contest shifts</title>
+		<link>https://newjerseymonitor.com/2024/08/15/struggle-for-control-of-congress-intensifies-as-presidential-contest-shifts/</link>
+		
+		<dc:creator><![CDATA[Jennifer Shutt]]></dc:creator>
+		<pubDate>Thu, 15 Aug 2024 10:41:36 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14312</guid>
+
+					<description><![CDATA[The 2024 battle for control of Congress centers on just a handful of Senate races and about two dozen House seats.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="692" src="https://newjerseymonitor.com/wp-content/uploads/2023/10/U.S.-Capitol-at-night-SkyNoir-Photography-by-Bill-Dickinson-Getty-2048x1385-1-1-1024x692.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/10/U.S.-Capitol-at-night-SkyNoir-Photography-by-Bill-Dickinson-Getty-2048x1385-1-1-1024x692.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/10/U.S.-Capitol-at-night-SkyNoir-Photography-by-Bill-Dickinson-Getty-2048x1385-1-1-300x203.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/10/U.S.-Capitol-at-night-SkyNoir-Photography-by-Bill-Dickinson-Getty-2048x1385-1-1-768x519.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2023/10/U.S.-Capitol-at-night-SkyNoir-Photography-by-Bill-Dickinson-Getty-2048x1385-1-1.jpg 1500w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">In this year’s battle for control of Congress, Republicans aim to increase their slim majority in the House of Representatives and flip the Senate, while Democrats are hoping to hang onto their majority in the upper chamber and regain control of the House. (Bill Dickinson/Getty Images)</p><p>WASHINGTON — The 2024 battle for control of Congress centers on just a handful of Senate races and about two dozen House seats, putting considerable pressure on those candidates to win over voters as party leaders and super PACs funnel millions of dollars into their campaigns.</p>
+<p>The incumbents representing those states and congressional districts will spend nearly all of their time campaigning between now and Election Day, with Congress in session just three weeks ahead of Nov. 5. They’ll be fighting off challengers who will be on the home front the entire time.</p>
+<p>Republicans aim to increase their slim majority in the House of Representatives and flip the Senate, while Democrats are hoping to hang onto their majority in the upper chamber and regain control of the House.</p>
+<p>Experts interviewed by States Newsroom said the outcome will be determined by multiple factors, including turnout, ticket splitting and the trajectory of the presidential campaign, which underwent an abrupt change with the exit of President Joe Biden and the nomination of Vice President Kamala Harris as the Democratic candidate.</p>
+<p>At stake is whether Harris or Donald Trump, the Republican presidential nominee, faces a Congress friendly to their ambitions or another two years of a deeply divided government in the nation’s capital. Biden has <a href="https://www.newsfromthestates.com/article/congress-limps-toward-end-disappointing-session-just-78-laws-show" target="_blank">struggled with</a> a GOP House and a Senate narrowly controlled by Democrats during the past two years.</p>
+<p>“There’s a lot of energy on both sides for these congressional races, because of just how close the margins are going to be in the House and Senate,” said Casey Burgat, assistant professor and legislative affairs program director at George Washington University.</p>
+    <h4 class="editorialSubhed">Senate GOP control?</h4>
+
+	
+<p>The Senate is trending toward a Republican majority, though that will be determined by voters in Michigan, Montana, Nevada and Ohio, all of which are considered toss-ups by the Cook Political Report with Amy Walter, a respected non-partisan publication.</p>
+<p>If the GOP picks up any one of those four seats, that would give Republicans at least a 51-seat majority in the chamber after winning the West Virginia seat that’s currently held by Joe Manchin III, thought to be nearly certain in the GOP-dominated state.</p>
+<p>Democrats maintaining those four seats as well as three others classified as “lean Democrat” by the Cook Political Report would leave control of a 50-50 Senate to the results of the presidential election, since the vice president casts tie-breaking votes in that chamber.</p>
+<p>The Senate map is highly favorable to Republicans, who are defending 11 seats in safely red states, while Democrats are trying to hold on to 23 seats, with seven of those in purple states.</p>
+<p>While the entire 435-member House of Representatives is up for reelection every two years, senators are elected to six-year terms, leaving about one-third of the chamber up for reelection in evenly numbered years.</p>
+    <h4 class="editorialSubhed">Eyes on Montana</h4>
+
+	
+<p>Robert Saldin, professor of political science at the University of Montana, said during an interview that Democratic Sen. Jon Tester will need to get voters in the state who support Trump to split their tickets if Tester is going to secure reelection.</p>
+<p>“One of the secrets to Tester’s success over the years is that he has been able to distinguish himself from stereotypes of the national Democratic Party,” Saldin said. “And that’s going to be really important again, obviously, because Trump is on the ticket, and is certainly going to carry the state by a very wide margin.”</p>
+<p>Republican challenger Tim Sheehy could potentially have a bit of an easier time getting elected this November in the deeply Republican state, he said.</p>
+<p>“All he has to do is get people who are voting for Trump to also vote for him. And in fact, he can probably lose some tens of thousands of voters and still be okay,” Saldin said.</p>
+<p>Sheehy, however, is somewhat disadvantaged by not having run in a competitive GOP primary, leaving him to move directly into a high-stakes general election.</p>
+<p>“He is a political novice,” Saldin said. “He didn’t have a practice run in the primary. And here he is fresh out of the gate in one of the most expensive, most watched, most hyped Senate elections in the country. And so he’s having to learn as he goes.”</p>
+<p>One factor that could benefit Tester over Sheehy is <a href="https://dailymontanan.com/2024/08/02/gianforte-revives-debunked-abortion-claim-for-ballot-initiative/" target="_blank">a ballot question addressing abortion access</a> in the state that is likely to go before voters in November, Saldin said.</p>
+<p>“That should give at least a little nudge in the direction of the Democrats,” Saldin said.</p>
+<p>A dozen other states have approved or could approve <a href="https://www.kff.org/womens-health-policy/dashboard/ballot-tracker-status-of-abortion-related-state-constitutional-amendment-measures/" target="_blank">abortion ballot questions</a>, including Arizona, Florida, Maryland and Nevada.</p>
+    <h4 class="editorialSubhed">In Ohio, edging away from national politics</h4>
+
+	
+<p>Paul A. Beck, academy professor of political science at The Ohio State University, said Democratic Sen. Sherrod Brown has sought to separate himself from national political figures throughout this reelection bid.</p>
+<p>“I think he really wants to make this a local contest, a statewide contest, not a national contest,” Beck said. “And so he’s going to do everything he can to not appear on the stage with the Democratic nominees for president, and everything he can to try to define himself as somebody who is above partisan politics.”</p>
+<p>Brown was elected to the House in 1992 before winning election to the Senate in 2006. He secured reelection in 2012 and 2018, though Republican candidate Bernie Moreno is looking to end that streak this year.</p>
+<p>Beck said <a href="https://ohiocapitaljournal.com/2024/08/05/who-is-funding-ohios-redistricting-amendment/" target="_blank">a ballot question about redistricting</a> could help boost turnout, potentially increasing Brown’s chances.</p>
+<p>“It’s going to energize voters and is going to produce higher turnout on the left than it will on the right, and that could be a factor in 2024,” Beck said.</p>
+    <h4 class="editorialSubhed">Incumbent clout</h4>
+
+	
+<p>Sitting members of Congress have historically held an advantage that may help the party that holds more members seeking to return to Capitol Hill for the 119th Congress.</p>
+<p>“Reelection rates in the House have never dropped below 85%, and have recently stretched to highs of 98% in 2004 and 97% in 2016,” according to <a href="https://www.opensecrets.org/news/2023/10/incumbent-politicians-enjoy-record-reelection-in-aging-congress/" target="_blank">analysis</a> from Miro Hall-Jones at OpenSecrets, a nonpartisan organization that reports on the role of money in U.S. politics. “While the Senate is more susceptible to shifts in public opinion — reelection rates dropped as low as 50% in 1980 at the dawn of the Reagan Revolution — incumbent senators have retained their seats in 88% of races since 1990.”</p>
+<p>Every single one of the 28 senators seeking reelection two years ago was able to convince voters in their home states to give them another term, marking the first time that happened in American history, according to the analysis.</p>
+<p>Michigan and Arizona Senate races could then present a bigger challenge for Democrats, since both those seats are open due to the upcoming retirements of Michigan Sen. Debbie Stabenow and Arizona independent Sen. Kyrsten Sinema.</p>
+<p>Michigan is currently rated as a toss-up by the Cook Political Report while Arizona is rated as “lean Democrat.”</p>
+<p>In the House, the 11 seats held by Republicans and considered by the Cook Political Report <a href="https://www.cookpolitical.com/ratings/house-race-ratings" target="_blank">to be toss-ups</a> all are held by an incumbent seeking reelection, while two of the Democrats’ 11 toss-up seats are open.</p>
+    <h4 class="editorialSubhed">House majority</h4>
+
+	
+<p>The contest for who controls the House after November is “razor thin,” said Burgat from George Washington University. With Republicans holding on by a slim margin, Democrats only need a net gain of four seats to capture the majority.</p>
+<p>“Whether it goes Democratic or Republican, it’s not going to be by much,” Burgat said.</p>
+<p>While Democrats and Republicans will focus much of their attention on the 22 toss-up races, they’ll also be funneling resources toward the campaigns that are rated as only leaning in their direction, as opposed to being likely or solid seats.</p>
+<p>The Cook Political Report has eight seats held by GOP lawmakers as leaning in Republicans’ favor while 14 races, all Democratic-held seats except one, are in districts that “lean Democrat.”</p>
+<p>That makes a total of about 44 competitive House races, according to the Cook Political Report’s analysis.</p>
+<p>Among the closely watched congressional districts:</p>
+<ul>
+<li>Both parties are eyeing open seats in California, Colorado, Michigan and Virginia.</li>
+</ul>
+<ul>
+<li>Michigan’s 7th and 8th districts, respectively opened by Democrats Elissa Slotkin, who is seeking the state’s open Senate seat, and the retiring Dan Kildee, are rated by the Cook Political Report as toss-ups.</li>
+</ul>
+<ul>
+<li>Virginia’s 7th Congressional District, being vacated by Democrat Abigail Spanberger, who will focus on a run for governor, is expected to lean blue.</li>
+</ul>
+<ul>
+<li>California Democratic Rep. Katie Porter’s district also leans towards Democrats. Porter decided to leave the seat for an unsuccessful Senate run.</li>
+</ul>
+<ul>
+<li>Colorado’s 3rd, abandoned by Republican Lauren Boebert, who shifted to a friendlier district, leans Republican, according to the Cook Political Report.</li>
+</ul>
+<ul>
+<li>One open seat each in Maryland and New Hampshire is rated as likely Democrat by the prognosticator.</li>
+</ul>
+    <h4 class="editorialSubhed">DCCC ads</h4>
+
+	
+<p>The Democratic Congressional Campaign Committee is throwing big money where races are competitive, zeroing in on 15 media markets including those in Arizona, Colorado, Michigan, North Carolina and Pennsylvania. The official campaign arm of House Democrats <a href="https://dccc.org/dccc-ie-reserves-28-million-in-first-round-of-tv-and-digital-ads-for-2024-cycle/" target="_blank">announced</a> a $28 million initial ad buy in June, spending double on digital ads compared to 2022, according to the organization.</p>
+<p>The DCCC maintains that House Democrats “have always had multiple paths to reclaim the majority in November — including our 27 Red to Blue candidates in districts across the country working to defeat extreme Republicans who are out-of-touch with their communities,” spokesperson Viet Shelton told States Newsroom in a written statement.</p>
+<p>Shelton said voters are “fed up with these politicians who are more interested in obeying Trump, voting for abortion bans, and giving tax breaks to billionaires and big corporations, while ignoring the needs of the middle class.”</p>
+<p>The DCCC sees pickup opportunities in the 16 districts Biden won in 2020 that are currently held by Republicans.</p>
+<p>Among them are five seats in California, four in New York, two in Arizona, and one respectively in New Jersey, Oregon, Pennsylvania and Virginia. Nebraska also saw incumbent GOP Rep. Don Bacon’s district go to Biden.</p>
+<p>The switch to Harris at the top of the Democratic ticket could boost challengers in heavily college-educated districts, according to the Cook Political Report’s latest analysis of the field.</p>
+<p>Those include Arizona’s 1st Congressional District held by GOP Rep. David Schweikert, New Jersey’s 7th occupied by freshman Thomas Kean Jr., and New York’s 17th held by Mike Lawler, also in his first term. All are rated as Republican toss-ups by the Cook Political Report.</p>
+    <h4 class="editorialSubhed">Frontline candidates</h4>
+
+	
+<p>But the DCCC campaign has vulnerable Democratic incumbents to worry about as well. The organization has identified 31 as “frontline” members, meaning their purple districts are what campaigners describe as “in play.”</p>
+<p>Among them is 40-year Democrat Marcy Kaptur, who has held Ohio’s 9th Congressional District, in the state’s northwest region, since 1983.</p>
+<p>Other vulnerable Democrats include Reps. Yadira Caraveo in Colorado’s 8th, Jared Golden in Maine’s 2nd, Don Davis in North Carolina’s 1st, Gabe Vasquez in New Mexico’s 2nd, Emilia Sykes in Ohio’s 13th, Susan Wild and Matt Cartwright in Pennsylvania’s 7th and 8th districts, and Marie Gluesenkamp Perez in Washington’s 3rd.</p>
+<p>The National Republican Congressional Committee did not respond to requests for comment, but the House GOP campaign arm <a href="https://www.nrcc.org/2024/06/27/nrcc-ie-reserves-45-7-million-in-first-round-of-ad-reservations-to-grow-the-house-majority/" target="_blank">announced</a> in late June a $45.7 million initial ad buy across 29 media markets, with large chunks going to metro areas in Los Angeles; New York City; Albuquerque, New Mexico; Anchorage, Alaska; Denver, Colorado; Detroit, Michigan; Portland, Oregon; and Omaha, Nebraska.</p>
+<p>The ad buy — an offensive to “to grow our majority,” NRCC Chair Richard Hudson said in a press release — will specifically target 13 districts currently held by Democrats.</p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Jersey City loses third bid to fire police officer for using cannabis</title>
+		<link>https://newjerseymonitor.com/briefs/jersey-city-loses-third-bid-to-fire-police-officer-for-using-cannabis/</link>
+		
+		<dc:creator><![CDATA[Sophie Nieto-Munoz]]></dc:creator>
+		<pubDate>Wed, 14 Aug 2024 22:47:07 +0000</pubDate>
+				<category><![CDATA[Courts]]></category>
+		<category><![CDATA[cannabis]]></category>
+		<category><![CDATA[Jersey City]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14310</guid>
+
+					<description><![CDATA[The state Civil Service Commission said Jersey City must rehire an officer it fired for testing positive for cannabis.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="682" src="https://newjerseymonitor.com/wp-content/uploads/2021/08/jersey-city-scaled-e1722629217310-1024x682.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2021/08/jersey-city-scaled-e1722629217310-1024x682.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2021/08/jersey-city-scaled-e1722629217310-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2021/08/jersey-city-scaled-e1722629217310-768x511.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2021/08/jersey-city-scaled-e1722629217310-1536x1023.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2021/08/jersey-city-scaled-e1722629217310-2048x1364.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">The state Civil Service Commission said Jersey City must rehire an officer it fired for testing positive for cannabis. (Terrence T. McDonald)</p><p style="font-weight: 400;">Jersey City lost another round in <a href="https://newjerseymonitor.com/2023/10/17/jersey-city-sues-new-jersey-in-bid-to-halt-cops-from-using-cannabis/">its fight to bar cops from using cannabis</a> after the state Civil Service Commission overturned the termination of a third officer who was fired for using marijuana.</p>
+<p style="font-weight: 400;">The <a href="https://newjerseymonitor.com/wp-content/uploads/2024/08/A006-REILLY-MACKENZIE.pdf">commission on Wednesday ordered the city</a> to reinstate police officer Mackenzie Reilly, who had been fired in August 2023 after testing positive for cannabis during a random drug test. Reilly should also receive back pay and benefits, the commission ruled.</p>
+<p style="font-weight: 400;">The state attorney general has said police officers cannot be disciplined for using legal cannabis while off duty, but the city has fired at least five officers for using the drug anyway. Attorneys for the city claim a federal law banning people who use cannabis from buying and owning firearms and ammunition applies to police officers.</p>
+<p style="font-weight: 400;">The Civil Service Commission has now told the city to rehire three of the five officers it fired, but the city has not done so. The city faces a daily $200 fine if two of the officers are not rehired by next week, the commission ruled last month.</p>
+<p style="font-weight: 400;">Wednesday’s decision follows a recommendation from Administrative Law Judge Matthew Miller on July 11 that Reilly get his job back. Miller noted that the judges who oversaw the cases of officers Omar Polanco and Norhan Mansour — the other two officers the city has been ordered to rehire — ruled that the state’s cannabis legalization law is not preempted by federal law.</p>
+<p style="font-weight: 400;">“I understand Jersey City’s reticence in allowing marijuana users, especially chronic marijuana users, to possess weapons,” Miller wrote, adding, “In New Jersey, that ship has sailed.”</p>
+<p style="font-weight: 400;">The details of Reilly’s case are spelled out in Wednesday’s decision: He smoked from a vape purchased at a Montclair dispensary in January 2023, was drug tested the next month, and was suspended in March after he tested positive for cannabinoids in his urine.</p>
+<p style="font-weight: 400;">One unique issue in Reilly’s case is the city’s contention that he committed misconduct by not revealing on a form given to him when he was drug tested that he was using cannabis as a form of medication. But Miller noted that the cannabis Reilly bought that day was recreational, because he did not receive a medical marijuana card until a few weeks after the drug test.</p>
+<p style="font-weight: 400;">During Wednesday’s meeting, the commissioners debated whether Reilly&#8217;s refusal to divulge this information was grounds for suspension based on misconduct and insubordination. Commissioner Daniel W. O’Mullan voted against reinstating Reilly over the drug test form issue and suggested he face a three-month suspension.</p>
+<p style="font-weight: 400;">    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+<p style="font-weight: 400;">
+<p style="font-weight: 400;">
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Group urges watchdog to ax public contracts connected to indicted power broker</title>
+		<link>https://newjerseymonitor.com/2024/08/14/group-urges-watchdog-to-ax-public-contracts-connected-to-indicted-power-broker/</link>
+		
+		<dc:creator><![CDATA[Dana DiFilippo]]></dc:creator>
+		<pubDate>Wed, 14 Aug 2024 19:45:22 +0000</pubDate>
+				<category><![CDATA[Criminal Justice]]></category>
+		<category><![CDATA[Gov + Legislature]]></category>
+		<category><![CDATA[Antoinette Miles]]></category>
+		<category><![CDATA[Dana Redd]]></category>
+		<category><![CDATA[George Norcross]]></category>
+		<category><![CDATA[Kevin D. Walsh]]></category>
+		<category><![CDATA[Philip Norcross]]></category>
+		<category><![CDATA[William Tambussi]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14278</guid>
+
+					<description><![CDATA[New Jersey Working Families on Tuesday urged the New Jersey comptroller's office to examine public funding going to George Norcross III and his co-defendants.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="683" src="https://newjerseymonitor.com/wp-content/uploads/2024/06/R6__8923-1024x683.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/06/R6__8923-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/06/R6__8923-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/06/R6__8923-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/06/R6__8923-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/06/R6__8923-2048x1365.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">New Jersey Working Families on Tuesday urged the New Jersey comptroller's office to examine public funding going to George Norcross III and his co-defendants. (Photo by Hal Brown for New Jersey Monitor)</p><p><span data-preserver-spaces="true">The New Jersey Working Families Party has asked a state watchdog to investigate and terminate any public contracts involving South Jersey Democratic power broker George Norcross and the five business associates </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/06/17/democratic-power-broker-george-norcross-indicted-on-racketeering-charges/" target="_blank" rel="noopener"><span data-preserver-spaces="true">recently indicted</span></a> <span data-preserver-spaces="true">with him for racketeering.</span></p>
+<p><span data-preserver-spaces="true">In </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/wp-content/uploads/2024/08/NJWFP-Letter-to-NJOSC.pdf" target="_blank" rel="noopener"><span data-preserver-spaces="true">a letter</span></a><span data-preserver-spaces="true"> sent Tuesday to acting state Comptroller Kevin D. Walsh, the group’s director, Antoinette Miles, said the corruption indictment should trigger “a strong enforcement response” to protect taxpayer money. She reminded Walsh that state officials, by law, can suspend and disqualify public contractors who have been indicted of any “offense indicating a lack of business integrity or honesty.”</span></p>
+<p><span data-preserver-spaces="true">“This indictment represents one of the most significant state public corruption prosecutions in New Jersey history,” Miles wrote. “These defendants hold leadership roles in institutions that continue to receive millions of dollars annually in federal, state, and local taxpayer dollars. This situation is intolerable and, if left unaddressed, will continue to erode public trust and risk taxpayer resources at the hands of an allegedly criminal enterprise.”</span></p>
+<p><span data-preserver-spaces="true">Laura Madden, a spokeswoman for Walsh’s office, declined to comment, saying: &#8220;Our policy is we can neither confirm nor deny matters like this.&#8221;</span></p>
+<p><span data-preserver-spaces="true">Attorneys for Norcross and his co-defendants didn&#8217;t respond to requests for comment.</span></p>
+<p><span data-preserver-spaces="true"></span></p>
+<figure id="attachment_10685" class="wp-caption alignleft" style="max-width:100%;width:300px;"><a href="https://newjerseymonitor.com/2023/11/21/clean-energy-bill-prompts-hours-of-impassioned-testimony-but-no-decision/img_5366_1/" rel="attachment wp-att-10685"><img decoding="async" loading="lazy" class="size-medium wp-image-10685" src="https://newjerseymonitor.com/wp-content/uploads/2023/11/IMG_5366_1-300x220.jpg" alt="" width="300" height="220" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/11/IMG_5366_1-300x220.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/11/IMG_5366_1-1024x750.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/11/IMG_5366_1-768x562.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2023/11/IMG_5366_1-1536x1124.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2023/11/IMG_5366_1-2048x1499.jpg 2048w" sizes="(max-width: 300px) 100vw, 300px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em><span data-preserver-spaces="true">Antoinette Miles, state director of New Jersey Working Families, said state officials need to dig deeper into the various entities connected to Norcross. (Dana DiFilippo | New Jersey Monitor)</span></em></p></figure>
+<p><span data-preserver-spaces="true">New Jersey Working Families Party has long lobbied state and local officials to investigate Norcross and his allies.</span></p>
+<p><span data-preserver-spaces="true">&#8220;We have known for years about the Norcross enterprise — how Norcross conducts his business dealings and how he wields influence within city government and with other business partners, as the attorney general so eloquently put it, to extort and extract from the city of Camden,&#8221; Miles told the New Jersey Monitor. &#8220;There are millions of dollars in public sector contracts at stake, and we need not only the attorney general&#8217;s investigation, but we also need to dig deeper into the various entities connected to Norcross, because the level of corruption goes a lot deeper.&#8221;</span></p>
+<p><span data-preserver-spaces="true">In June, state Attorney General Matt Platkin announced a 13-count indictment against Norcross that </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/06/18/inside-the-wild-charges-against-george-norcross/" target="_blank" rel="noopener"><span data-preserver-spaces="true">accuses him of</span></a> <span data-preserver-spaces="true">overseeing a criminal enterprise by using direct threats and intimidation to win development rights along the Camden waterfront and then benefiting from more than $1 billion in state-issued tax credits.</span></p>
+<p><span data-preserver-spaces="true">Indicted with him were his brother Philip Norcross, who is CEO of the law firm Parker McCay; George Norcross’ attorney, William M. Tambussi of the law firm Brown &amp; Connery; former Camden mayor Dana Redd; Sidney Brown, the CEO of privately owned trucking company and logistics provider NFI Industries; and John J. O’Donnell, CEO at the Michaels Organization, a residential housing developer.</span></p>
+<p><span data-preserver-spaces="true">The charges against them include racketeering, misconduct by a corporate official, official misconduct, financial facilitation of criminal activity, and conspiracy to commit theft by extortion and criminal coercion. Norcross and his co-defendants </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/07/09/democratic-power-broker-pleads-not-guilty-in-racketeering-case/" target="_blank" rel="noopener"><span data-preserver-spaces="true">pleaded not guilty</span></a><span data-preserver-spaces="true"> during their arraignments earlier this summer.</span></p>
+<p><span data-preserver-spaces="true">George and Phil Norcross, Tambussi, and Redd all hold roles in organizations that receive state and local funds that Miles said deserve the comptroller’s scrutiny:</span></p>
+<ul>
+<li><span data-preserver-spaces="true">George Norcross chairs the Cooper health system’s board of trustees, while his brother is board chair of its charitable arm, the Cooper Foundation. The hospital receives tens of millions of dollars a year through Medicaid, and the comptroller’s office serves as the state’s watchdog against Medicaid fraud. Cooper Health </span><a class="editor-rtfLink" href="https://www.cooperhealthcape.org/news/releases/it-s-official-cape-regional-is-now-part-of-cooper-university-health-care/" target="_blank" rel="noopener"><span data-preserver-spaces="true">acquired</span></a><span data-preserver-spaces="true"> Cape Regional Health System this summer, an expansion of Cooper’s footprint that makes watchdog scrutiny more urgent, Miles added.</span></li>
+<li><span data-preserver-spaces="true">Philip Norcross’ and Tambussi’s law firms have contracts with hundreds of public entities statewide. Tambussi’s firm also represents the South Jersey Transportation Authority, and Platkin’s office </span><a class="editor-rtfLink" href="https://www.njoag.gov/two-south-jersey-transportation-authority-board-members-charged-after-allegedly-withholding-payment-from-contractor-as-political-retribution/" target="_blank" rel="noopener"><span data-preserver-spaces="true">charged</span></a><span data-preserver-spaces="true"> two commissioners at that authority with misconduct the week before the Norcross indictment.</span></li>
+<li><span data-preserver-spaces="true">Redd heads the Camden Community Partnership, the taxpayer-funded nonprofit at the center of the indictment. Just this week, Camden City Council passed an ordinance to lift a cap on how much taxpayer money can be used to cover the legal expenses of current and past city officials, the Philadelphia Inquirer </span><a class="editor-rtfLink" href="https://www.inquirer.com/news/camden-city-council-legal-fees-cap-dana-redd-norcross-20240814.html" target="_blank" rel="noopener"><span data-preserver-spaces="true">reported.</span></a></li>
+<li><span data-preserver-spaces="true">Conner Strong &amp; Buckelew, the insurance brokerage George Norcross helmed until he took a leave of absence a few weeks after the indictment, provides insurance and risk management services to hundreds of state, county, and local government entities.</span></li>
+</ul>
+
+<p><span data-preserver-spaces="true">Beyond contracts, Miles’ group urged Walsh to investigate all permit applications, approvals, and waivers or determinations that involved Norcross, his co-defendants, and the organizations where they work or hold leadership roles.</span></p>
+<p><span data-preserver-spaces="true">“The public deserves to have a full accounting of the amount of taxpayer money going to entities controlled by these individuals,” Miles said.</span></p>
+<p><span data-preserver-spaces="true">    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	</span></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>2020 lawsuit targeting county-line ballots appears to near settlement talks</title>
+		<link>https://newjerseymonitor.com/2024/08/14/2020-lawsuit-targeting-county-line-ballots-appears-to-near-settlement-talks/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Wed, 14 Aug 2024 10:42:21 +0000</pubDate>
+				<category><![CDATA[Courts]]></category>
+		<category><![CDATA[Politics]]></category>
+		<category><![CDATA[Andy Kim]]></category>
+		<category><![CDATA[Brett Pugach]]></category>
+		<category><![CDATA[Carolyn Rush]]></category>
+		<category><![CDATA[Christine Hanlon]]></category>
+		<category><![CDATA[Sarah Schoengood]]></category>
+		<category><![CDATA[Tonianne Bongiovanni]]></category>
+		<category><![CDATA[Zahid Quraishi]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14288</guid>
+
+					<description><![CDATA[The judge overseeing a challenge to New Jersey's county-line ballots requested proposed settlement terms last week, signaling a resolution after four years of pretrial proceedings.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="725" src="https://newjerseymonitor.com/wp-content/uploads/2022/10/heminghaus_early-voting_003-1024x725.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2022/10/heminghaus_early-voting_003-1024x725.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2022/10/heminghaus_early-voting_003-300x213.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2022/10/heminghaus_early-voting_003-768x544.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2022/10/heminghaus_early-voting_003-1536x1088.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2022/10/heminghaus_early-voting_003-2048x1451.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">The judge overseeing a challenge to New Jersey's county-line ballots requested proposed settlement terms last week, signaling a resolution after four years of pretrial proceedings. (Daniella Heminghaus for New Jersey Monitor)</p><p><span data-preserver-spaces="true">A lawsuit targeting </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/briefs/lawsuit-targeting-disputed-ballot-design-as-unconstitutional-can-proceed-judge-says/" target="_blank" rel="noopener"><span data-preserver-spaces="true">New Jersey’s unique system of county-line</span></a><span data-preserver-spaces="true"> ballots that has languished in pretrial proceedings for more than four years appears to be approaching settlement talks.</span></p>
+<p><span data-preserver-spaces="true">U.S. Magistrate Judge Tonianne Bongiovanni last week asked attorneys for plaintiff Christine Conforti and other former congressional candidates to relay information on their proposed settlement, adding the court would “assess the format for efficient settlement discussions.”</span></p>
+<p><span data-preserver-spaces="true">Monmouth County Clerk Christine Hanlon, one of the defendants in the case, confirmed to the New Jersey Monitor that she is interested in settling.</span></p>
+<p><span data-preserver-spaces="true">“And we have made that clear to the plaintiffs because, number one, we can&#8217;t go into another election cycle — which is coming up before you know it — with the uncertainty,” Hanlon said.</span></p>
+<p><span data-preserver-spaces="true">The suit, lodged in July 2020 after Conforti lost a Democratic primary for the 4th District House seat, seeks to end New Jersey’s system of county lines, a unique ballot design that groups candidates by slogan rather than by office sought. The disputed design allows party-backed candidates to appear in a single line — a row or column — on ballots, and it has been criticized as one that hands party insiders and their preferred candidates a nearly insurmountable advantage at the polls.</span></p>
+<p><span data-preserver-spaces="true">Brett Pugach, </span><span data-preserver-spaces="true">who is among</span><span data-preserver-spaces="true"> the attorneys representing the plaintiffs, declined to comment on settlement discussions but said his clients are willing to explore “any means necessary to secure a just resolution of the constitutional concerns raised” by the suit.</span></p>
+<p><span data-preserver-spaces="true">“I can say that Plaintiffs strongly believe that the writing is on the wall in this case, and county clerks that continue to defend the county line do so with complete disregard for taxpayer money,” he said.</span></p>
+<p><span data-preserver-spaces="true">Pugach noted that U.S. District Court Judge Zahid Quraishi has </span><span data-preserver-spaces="true">found that plaintiffs in a separate lawsuit challenging county-line ballots were likely to succeed in their push to have them declared unconstitutional.</span><span data-preserver-spaces="true"> Quraishi in March </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/03/29/judge-bars-county-line-in-junes-primaries-a-blow-to-new-jerseys-party-leaders/" target="_blank" rel="noopener"><span data-preserver-spaces="true">issued a preliminary injunction</span></a><span data-preserver-spaces="true"> barring the use of the </span><span data-preserver-spaces="true">ballots</span><span data-preserver-spaces="true"> in June’s Democratic primary, a ruling </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/04/03/appeals-court-wont-block-order-that-halts-use-of-county-line-in-junes-dem-primaries/" target="_blank" rel="noopener"><span data-preserver-spaces="true">upheld by a federal appellate panel</span></a><span data-preserver-spaces="true">.</span></p>
+<p><span data-preserver-spaces="true">In that case, the plaintiffs, including Rep. Andy Kim (D-03), argued that county-line ballots </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/03/19/court-hearing-exposes-silliness-behind-fight-to-protect-the-county-line/" target="_blank" rel="noopener"><span data-preserver-spaces="true">violate associational freedoms</span></a><span data-preserver-spaces="true"> granted by the First Amendment and other protections afforded by the elections clause of the U.S. Constitution.</span></p>
+<p><span data-preserver-spaces="true">Conforti’s suit, argued by the same attorneys in the Kim case, likewise claims the practice unconstitutionally impedes associational freedoms because candidates who do not bracket with office seekers at the top of a ticket cannot secure the top-ballot position in some counties.</span></p>
+<p><span data-preserver-spaces="true">County clerks named </span><span data-preserver-spaces="true">as</span><span data-preserver-spaces="true"> defendants in both suits had mostly opposed them on procedural grounds, charging the cases were untimely and, in Kim’s case, would create chaos as election officials scrambled to design new ballots </span><span data-preserver-spaces="true">in time</span><span data-preserver-spaces="true"> to meet election deadlines.</span><span data-preserver-spaces="true"> When Kim filed his suit, he was one of multiple candidates seeking the Democratic nomination for U.S. Senate (he subsequently </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/06/04/rep-andy-kim-projected-to-win-democratic-nod-for-u-s-senate/" target="_blank" rel="noopener"><span data-preserver-spaces="true">won the party’s nod</span></a><span data-preserver-spaces="true">).</span></p>
+<p><span data-preserver-spaces="true">The clerks’ fears about electoral chaos proved to be unfounded. After Quraishi issued his order, they printed ballots that had no county line </span><span data-preserver-spaces="true">and </span><span data-preserver-spaces="true">were</span><span data-preserver-spaces="true"> used</span><span data-preserver-spaces="true"> in June’s Democratic primaries without incident.</span></p>
+<p><span data-preserver-spaces="true">Much about the future of the Conforti case remains </span><span data-preserver-spaces="true">unclear</span><span data-preserver-spaces="true">, and the sheer number of parties involved could complicate settlement talks or leave the case ongoing even after claims against some parties </span><span data-preserver-spaces="true">are resolved</span><span data-preserver-spaces="true">.</span></p>
+<p><span data-preserver-spaces="true">Conforti’s suit includes more than 25 parties, including two county party committees. Hanlon said there was a suggestion the plaintiffs sought only to settle with Burlington County, but Pugach indicated that is not the case.</span></p>
+<p><span data-preserver-spaces="true">“We want this issue to </span><span data-preserver-spaces="true">be fixed</span><span data-preserver-spaces="true"> across the state, and so it kind of doesn&#8217;t make a </span><span data-preserver-spaces="true">whole</span><span data-preserver-spaces="true"> lot of sense to think that we&#8217;re only interested in resolving with some parties and not with others,” Pugach said.</span></p>
+<p><span data-preserver-spaces="true">There&#8217;s no indication Kim&#8217;s case is moving toward settlement, though an agreement in the Conforti matter could </span><span data-preserver-spaces="true">make that case</span><span data-preserver-spaces="true"> moot.</span></p>
+<p><span data-preserver-spaces="true">It’s also unclear how unanimous clerks </span><span data-preserver-spaces="true">are in wanting</span><span data-preserver-spaces="true"> to end the case through settlement.</span></p>
+<p><span data-preserver-spaces="true">“I don&#8217;t want to speak for the others. </span><span data-preserver-spaces="true">I would say the clerks, generally speaking, will follow the law that is set forth by the court or the Legislature because that&#8217;s what we do.</span><span data-preserver-spaces="true"> We have to rely on the law to prepare the ballots,” Hanlon said.</span></p>
+<p><span data-preserver-spaces="true">    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	</span></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Hundreds of thousands of parents died from drugs. Their kids need more help, advocates say.</title>
+		<link>https://newjerseymonitor.com/2024/08/14/hundreds-of-thousands-of-parents-died-from-drugs-their-kids-need-more-help-advocates-say/</link>
+		
+		<dc:creator><![CDATA[Nada Hassanein]]></dc:creator>
+		<pubDate>Wed, 14 Aug 2024 10:14:04 +0000</pubDate>
+				<category><![CDATA[Health]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14297</guid>
+
+					<description><![CDATA[More than 321,000 children in the U.S. lost a parent to a drug overdose in the decade between 2011 and 2021, according to a federal study.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="700" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/opioids-children.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/opioids-children.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/opioids-children-300x205.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/opioids-children-768x525.jpg 768w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">PLANTSVILLE, CT - MARCH 06:  Cameron Comparone, 2 1/2 places a stone on the grave of his father Benjamin Comparone, 27, as friends and family gathered on March 6, 2016 in Plantsville, Connecticut to commemorate the first anniversary of Benjamin's death from heroin overdose. The nationwide heroin epidemic has overwhelmed many small towns and suburban communities, with heroin overdose deaths quadrupling, according to the Centers of Disease Control. The victims' families, many of them facing stigma themselves, are increasingly going public to lobby for greater access to recovery programs and bring awareness of addiciton as a disease, not a moral failing. The CDC says that of first time heroin users, some 90 percent are white and 75 percent had used prescription pain killers before turning to heroin.  (Photo by John Moore/Getty Images)</p><p>Every day, 8-year-old Emma sits in a small garden outside her grandmother’s home in Salem, Ohio, writing letters to her mom and sometimes singing songs her mother used to sing to her.</p>
+<p>Emma’s mom, Danielle Stanley, died of an overdose last year. She was 34, and had struggled with addiction since she was a teenager, said Brenda “Nina” Hamilton, Danielle’s mother and Emma’s grandmother.</p>
+<p>“We built a memorial for Emma so that she could visit her mom, and she’ll go out and talk to her, tell her about her day,” Hamilton said.</p>
+<p>Lush with hibiscus and sunflowers, lavender and a plum tree, the space is a small oasis where she also can “cry and be angry,” Emma told Stateline.</p>
+<p>Hundreds of thousands of other kids are in a similar situation: More than 321,000 children in the U.S. lost a parent to a drug overdose in the decade between 2011 and 2021, according to a <a href="https://jamanetwork.com/journals/jamapsychiatry/fullarticle/2818228?utm_campaign=articlePDF&amp;utm_medium=articlePDFlink&amp;utm_source=articlePDF&amp;utm_content=jamapsychiatry.2024.0810#yoi240018r27" target="_blank">study</a> by federal health researchers that was published in JAMA Psychiatry in May.<i></i></p>
+<p>In recent years, opioid manufacturers, distributors and retailers have paid states billions of dollars to settle lawsuits accusing them of contributing to the overdose epidemic. Some experts and advocates want states to use some of that money to help these children cope with the loss of their parents. Others want more support for caregivers, and special mental health programs to help the kids work through their long-term trauma — and to break a pattern of addiction that often cycles through generations.</p>
+
+<div class=" newsroomBlockQuoteContainer  ">
+	<div class="newsroomBlockQuoteSVGContainer">
+		<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12.81 9">
+			<g>
+				<path d="M2.7,0A3,3,0,0,0,.7.8,2.64,2.64,0,0,0,0,2.7,2.14,2.14,0,0,0,.8,4.4a2.84,2.84,0,0,0,1.7.7,1.45,1.45,0,0,0,.7-.2,1.45,1.45,0,0,1,.7-.2q.3,0,.3.6A3.47,3.47,0,0,1,3,7.6a4.21,4.21,0,0,1-2.6,1V9a5.51,5.51,0,0,0,4-1.6A5.06,5.06,0,0,0,6,3.7a3.92,3.92,0,0,0-.9-2.6A3.19,3.19,0,0,0,2.7,0Z"/>
+				<path d="M11.8,1.1A2.84,2.84,0,0,0,9.5,0a2.79,2.79,0,0,0-2,.8,2.64,2.64,0,0,0-.7,1.9,2.06,2.06,0,0,0,.7,1.7,2.41,2.41,0,0,0,1.8.7,1.85,1.85,0,0,0,.7-.2,1.45,1.45,0,0,1,.7-.2q.3,0,.3.6A2.94,2.94,0,0,1,9.8,7.6a4.21,4.21,0,0,1-2.6,1V9a5.51,5.51,0,0,0,4-1.6,4.6,4.6,0,0,0,1.6-3.8A3.47,3.47,0,0,0,11.8,1.1Z"/>
+			</g>
+		</svg>
+	</div>
+	<div class="newsroomBlockQuoteQuoteContainer">
+		<p class="newsroomBlockQuote ">Children of loss are left out of the conversation.</p>
+	</div>
+		<div class="newsroomBlockQuoteAuthorContainer">
+		<p style="font-size:13px"><b>– AmandaLynn Reese, chief program officer at Harm Reduction Ohio</b></p>
+	</div>
+	</div>
+
+	
+<p>The rate of children who lost parents to drug overdoses more than doubled during the decade included in the study, surging from 27 kids per 100,000 in 2011 to 63 per 100,000 in 2021.</p>
+<p>Nearly three-quarters of the 649,599 adults between ages 18 and 64 who died during that period were white.</p>
+<p>The children of American Indians and Alaska Natives lost a parent at a rate of 187 per 100,000, more than double the rate among the children of non-Hispanic white parents and Black parents (76.5 and 73.2 per 100,000, respectively). Children of young Black parents between ages 18 and 25 saw the greatest loss increase per year, according to the researchers, at a rate of almost 24%. The study did not include overdose victims who were homeless, incarcerated or living in institutions.</p>
+<p>The data included deaths from illicit drugs, such as cocaine, heroin or hallucinogens; prescription opioids, including pain relievers; and stimulants, sedatives and tranquilizers. Danielle Stanley, Emma’s mother, had a combination of drugs in her system when she died.</p>
+<figure id="attachment_14295" class="wp-caption alignleft" style="max-width:100%;width:147px;"><a href="https://newjerseymonitor.com/opioids-emma/"><img decoding="async" loading="lazy" class="size-medium wp-image-14295" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/opioids-Emma-147x300.jpg" alt="" width="147" height="300" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/opioids-Emma-147x300.jpg 147w, https://newjerseymonitor.com/wp-content/uploads/2024/08/opioids-Emma.jpg 494w" sizes="(max-width: 147px) 100vw, 147px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Danielle Stanley is pictured holding her daughter, Emma. Last year, Stanley died of a drug overdose. (Courtesy of Brenda Hamilton)</em></p></figure>
+<h4>    <h4 class="editorialSubhed">At-risk children</h4>
+
+	</h4>
+<p>Children need help to get through their immediate grief, but they also need longer-term support, said Chad Shearer, senior vice president for policy at the United Hospital Fund of New York and former deputy director at the Robert Wood Johnson Foundation’s State Health Reform Assistance Network.</p>
+<p>An <a href="https://media.uhfnyc.org/filer_public/6e/80/6e80760f-d579-46a3-998d-1aa816ab06f6/uhf_ripple_effect_national_and_state_estimates_chartbook.pdf" target="_blank">estimated 2.2 million</a> U.S. children were affected by the opioid epidemic in 2017, according to the hospital fund, meaning they were living with a parent with opioid use disorder, were in foster care because of a parent’s opioid use, or had a parent incarcerated due to opioids.</p>
+<blockquote><p>&nbsp;</p></blockquote>
+<p>“This is a uniquely at-risk subpopulation of children, and they need kind of coordinated and ongoing services and support that takes into account: What does the remaining family actually look like, and what are the supports that those kids do or don’t have access to?” Shearer said.</p>
+<p>Ron Browder, president of the Ohio Federation for Health Equity and Social Justice, an advocacy group, said “respecting the cultural traditions of families” is essential to supporting them effectively. The state has one of the 10 highest overdose death rates in the nation and the fifth-highest number of deaths, <a href="https://www.cdc.gov/nchs/pressroom/sosmap/drug_poisoning_mortality/drug_poisoning.htm" target="_blank">according</a> to 2022 data from the U.S. Centers for Disease Control and Prevention.</p>
+<p>The goal, Browder said, should be to keep kids in the care of a family member whenever possible.</p>
+<p>“We just want to make sure children are not sitting somewhere in a strange room,” said Browder, the former chief for child and adult protection, adoption and kinship at the Ohio Department of Job and Family Services and executive director of the Children’s Defense Fund of Ohio.</p>
+<p>“The child has gone through trauma from losing their parent to the overdose, and now you put them in a stranger’s home, and then you retraumatize them.”</p>
+<p>This is a particular concern for Indigenous children, who have suffered disproportionate removal from their families and forced cultural assimilation over generations.</p>
+<p>“What hits me and hurts my heart the most is that we have another generation of children that potentially are not going to be connected to their culture,” said Danica Love Brown, a behavioral health specialist and member of the Choctaw Nation of Oklahoma. Brown is vice president of behavioral health transformation at Kauffman and Associates, a national tribal health consulting firm.</p>
+<p>“We do know that culture is healing, and when people are connected to their culture … when they’re connected to their land and their community, they’re connected to their cultural activities, the healthier they are,” she said.</p>
+<p>Ana Beltran, an attorney at Generations United, which supports kin caregivers and grandfamilies, said large families still often need money and counseling to take care of orphaned children. (UNICEF defines an orphan as a child who has lost at least one parent.) She noted that multigenerational households are common in Black, Latino and Indigenous families.</p>
+<p>“It can look like they have a lot of support because they have these huge networks, and that’s such a powerful component of their culture and such a cultural strength. But on the other hand, service providers shouldn’t just walk away because, ‘Oh, they’re good,’” she said.</p>
+<p>Counties with higher overdose death rates were more likely to have children with grandparents as the primary caregiver, according to a 2023 <a href="https://www.frontiersin.org/journals/public-health/articles/10.3389/fpubh.2023.1035564/full" target="_blank">study</a> from East Tennessee State University. This was particularly true for counties across states in the Appalachian region. Tennessee has the third-highest drug overdose death <a href="https://www.cdc.gov/nchs/pressroom/sosmap/drug_poisoning_mortality/drug_poisoning.htm" target="_blank">rate</a> in the nation, following the District of Columbia and West Virginia.</p>
+<figure id="attachment_14294" class="wp-caption aligncenter" style="max-width:100%;width:540px;"><a href="https://newjerseymonitor.com/orphans-garden-cropped/"><img decoding="async" loading="lazy" class="wp-image-14294 size-full" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/orphans-garden-cropped.jpeg" alt="" width="540" height="336" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/orphans-garden-cropped.jpeg 540w, https://newjerseymonitor.com/wp-content/uploads/2024/08/orphans-garden-cropped-300x187.jpeg 300w" sizes="(max-width: 540px) 100vw, 540px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Eight-year-old Emma often spends time alone in the memorial garden for her mother outside her grandmother’s Salem, Ohio, home. (Courtesy of Brenda Hamilton)</em></p></figure>
+<h4>    <h4 class="editorialSubhed">‘Get well’</h4>
+
+	</h4>
+<p>AmandaLynn Reese, chief program officer at Harm Reduction Ohio, a nonprofit that distributes kits of the opioid-overdose antidote naloxone, lost her parents to the drug epidemic and struggled with addiction herself.</p>
+<p><span style="font-size: 16px;">Her mother died from an overdose 10 years ago, when Reese was in her mid-20s, and she lost her dad when she was 8. Her mom was a waitress and cleaned houses, and her dad was an autoworker. Both struggled with prescription opioids, specifically painkillers, as well as illicit drugs.</span></p>
+<p>“Maybe we couldn’t save our mama, but, you know, somebody else’s mama is out there,” Reese said. “Children of loss are left out of the conversation. … This is bigger than the way we were seeing it, and it has long-lasting effects.”</p>
+<p>In Ohio, Emma’s grandmother started a small shop called Nina’s Closet, where caregivers or those battling addiction can come by and collect clothing donations and naloxone.</p>
+<p><i></i>Emma, who helps fill donation boxes, tells her grandmother she misses the scent of her mom’s hair. She couldn’t describe it, Hamilton said — just that “it had a special smell.”</p>
+<p>And in an interview with Stateline, Emma said she wants kids like her to have hobbies — “something they really, really like to do” — to distract them from the sadness.</p>
+<p>She likes to think of her mom as smiling, remembering how fun she was and how she liked to play pranks on Emma’s grandfather.</p>
+<p>“This is what I would say to the users: ‘Get treatment, get well,’” Emma said.</p>
+<p><em><a href="https://stateline.org" target="_blank">Stateline</a> is part of States Newsroom, a nonprofit news network supported by grants and a coalition of donors as a 501c(3) public charity. Stateline maintains editorial independence. Contact Editor Scott S. Greenberger for questions: <a href="mailto:info@stateline.org">info@stateline.org</a>. Follow Stateline on <a href="https://facebook.com/statelinenewsroom" target="_blank">Facebook</a> and <a href="https://x.com/stateline_news" target="_blank">X</a>.</em></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Walz in first solo speech as VP candidate touts Dem ticket’s labor union ties</title>
+		<link>https://newjerseymonitor.com/2024/08/13/walz-in-first-solo-speech-as-vp-candidate-touts-dem-tickets-labor-union-ties/</link>
+		
+		<dc:creator><![CDATA[Jacob Fischler]]></dc:creator>
+		<pubDate>Tue, 13 Aug 2024 23:34:42 +0000</pubDate>
+				<category><![CDATA[DC Bureau]]></category>
+		<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Donald Trump]]></category>
+		<category><![CDATA[J.D. Vance]]></category>
+		<category><![CDATA[Kamala Harris]]></category>
+		<category><![CDATA[Tim Walz]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14292</guid>
+
+					<description><![CDATA[Minnesota Gov. Tim Walz appeared to tailor most of his 20-minute speech to the audience of public-sector workers.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="726" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/TimWalzAugust13-scaled-1-1024x726.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/TimWalzAugust13-scaled-1-1024x726.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/08/TimWalzAugust13-scaled-1-300x213.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/TimWalzAugust13-scaled-1-768x545.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/08/TimWalzAugust13-scaled-1-1536x1090.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/08/TimWalzAugust13-scaled-1-2048x1453.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">LOS ANGELES, CALIFORNIA - AUGUST 13: Democratic vice presidential candidate Minnesota Governor Tim Walz speaks at the 46th International Convention of the American Federation of State, County and Municipal Employees (AFSCME) at the Los Angeles Convention Center on August 13, 2024 in Los Angeles, California. Walz made his first solo appearance as the running mate for Democratic presidential candidate, U.S. Vice President Kamala Harris at the event. AFSCME is a union representing 1.4 million public service workers nationwide.  (Photo by Mario Tama/Getty Images)</p><p>Minnesota Gov. Tim Walz made his first solo campaign appearance as the Democratic vice presidential candidate Tuesday, telling a union audience in Los Angeles that the Democratic ticket led by Vice President Kamala Harris would prioritize worker-friendly policies.</p>
+<p>Walz appeared to tailor most of his 20-minute speech to the audience of members of the American Federation of State, County and Municipal Employees, a 1.4-million-member union of public-sector workers.</p>
+<p>Walz, who was a union member as a public school teacher in southern Minnesota before he won a U.S. House seat in 2006, praised the policies Harris championed as part of President Joe Biden’s administration, and those he pushed as Minnesota governor.</p>
+<p>Walz and Harris come from working-class backgrounds, he said, noting that Harris worked at McDonald’s as a student.</p>
+<p>“Vice President Harris took that work ethic, goes to work every single day to make sure families don’t just get by, but they get ahead,” he said.</p>
+<p>Harris led the administration’s work to eliminate barriers to organizing and cast the tiebreaking vote in the U.S. Senate to pass the $1.9 trillion COVID-19 relief bill in 2021 that Walz said kept public-sector workers employed during the pandemic.</p>
+<p>As governor, Walz said he made it easier to form unions, strengthened worker protections and banned “those damn captive audience meetings for good,” referring to meetings employers can mandate workers attend ahead of union votes to discourage support for organizing.</p>
+<p>Both Walz and Harris have walked on picket lines with striking workers, he said.</p>
+<p>Walz is the second person who has been a union member to appear on a presidential ticket since Ronald Reagan, who led the Screen Actors Guild before a career in politics, in 1984. Unlike the two-term Republican president, who engaged in a high-profile standoff with the federal air traffic controllers’ union, Walz told the audience he would not “lose (his) way” once elected.</p>
+<p>Trump was also a member of SAG-AFTRA, the successor organization to the Screen Actors Guild, when he ran for president in 2016 and 2020. Trump, who was nominated by Republicans in July as their presidential candidate, is no longer a member.</p>
+<p>Walz called on the union audience to get involved in campaign organizing, saying that if the group could mobilize friends and neighbors, it could make a difference in an election that could be decided by tens of thousands of votes in a few key states.</p>
+<p>“This is going to be a close, tough race,” he said. “But if each of us does an extra shift, an extra hour, a little bit more, we get to wake up on that morning after the election and know that the work we did transformed the lives for millions, transformed generations, impacted the world.”</p>
+<p>He closed with a campaign slogan Harris has been using, leading the crowd in a chant of, “When we fight, we win.”</p>
+    <h4 class="editorialSubhed">Attack on GOP</h4>
+
+	
+<p>Walz asked for organized labor to help turn out Democratic voters in November.</p>
+<p>“I know I’m preaching to the choir a little bit today,” he said. “But the choir needs to sing.”</p>
+<p>Former President Donald Trump, the Republican nominee for president, and his running mate, Sen. J.D. Vance of Ohio, were “not in the choir” of union supporters, Walz said.</p>
+<p>Trump has said he supports “right-to-work” laws that make union organizing difficult, Walz said.</p>
+<p>Walz related a conversation he’d had with United Autoworkers President Shawn Fain in which the labor leader called Trump a derisive name for an anti-union worker over his position on such laws.</p>
+<p>“I saw our friend Shawn Fain at the UAW had a name for that, he called him a scab,” Walz said. “That’s not name-calling, it’s an observation in fact, just to be clear.”</p>
+    <h4 class="editorialSubhed">Project 2025</h4>
+
+	
+<p>A second Trump administration would work to “put the screws to working people,” Walz said, noting that sections of the “Project 2025 to-do list” call for restricting union organizing and reducing overtime.</p>
+<p>Project 2025 is a list of policy goals developed by the Heritage Foundation, a conservative think tank, with input from former Trump administration officials. Democrats have worked to tie Trump to the document they describe as radically conservative.</p>
+<p>Trump has denied any involvement in its drafting and has not committed to working toward it if elected.</p>
+<p>Walz, a former high school football coach, said Trump was “playing dumb” about the contents of Project 2025.</p>
+<p>“I’m a football coach at heart,” he said. “I’ll tell you one thing I know for sure is, if you’re going to take the time to draw up a playbook, you’re damn sure going to use it.”</p>
+    <h4 class="editorialSubhed">Broader message </h4>
+
+	
+<p>Walz also peppered his remarks with messages seemingly meant for a broader general-election audience, advocating for reproductive rights and criticizing restrictions on book bans some Republican states have led against gender or race-based content and Trump’s position on cutting taxes for the wealthy.</p>
+<p>Highlighting the campaign’s theme of freedom, Walz said the government should not be involved in “personal choices” about how to start a family, what books to read or whether to join a union.</p>
+<p>“This country is great because we have a golden rule that makes things work. We mind our own damn business on those things,” he said.</p>
+<p>He also defended against criticisms of his record in the Army National Guard that has come under scrutiny from Republicans, including Vance, who is a Marine Corps veteran. They have said Walz exaggerated his role and left his unit months before it was deployed to Iraq in 2005.</p>
+<p>Walz said he was proud of his 24 years of service in the National Guard, which only ended in 2005 so he could run for Congress, where he joined the House Veterans’ Affairs Committee.</p>
+<p>“I’m proud of my service to this country,” he said. “And I firmly believe you should never denigrate another person’s service record. Anyone brave enough to put on that uniform for our great country, including my opponent, I just have a few simple words: Thank you for your service and sacrifice.”</p>
+<p><em>An earlier version of this report said Walz was the first former union member since Ronald Reagan to appear on a presidential ticket, after he said during his speech he was the first union member since Reagan. He is at least the second person who has been a union member to be on a presidential ticket since 1984</em></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>With one week until Sen. Menendez leaves the Senate, no word on his replacement</title>
+		<link>https://newjerseymonitor.com/2024/08/13/with-one-week-until-sen-menendez-leaves-the-senate-no-word-on-his-replacement/</link>
+		
+		<dc:creator><![CDATA[Sophie Nieto-Munoz]]></dc:creator>
+		<pubDate>Tue, 13 Aug 2024 20:51:50 +0000</pubDate>
+				<category><![CDATA[Election 2024]]></category>
+		<category><![CDATA[Politics]]></category>
+		<category><![CDATA[Andy Kim]]></category>
+		<category><![CDATA[Bob Menendez]]></category>
+		<category><![CDATA[Curtis Bashaw]]></category>
+		<category><![CDATA[Luis Velez]]></category>
+		<category><![CDATA[Patricia Campos-Medina]]></category>
+		<category><![CDATA[Phil Murphy]]></category>
+		<category><![CDATA[Tammy Murphy]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14290</guid>
+
+					<description><![CDATA[Gov. Phil Murphy said Tuesday he is in the "final stages" of choosing an interim replacement for Sen. Bob Mendendez, who is resigning next week.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="682" src="https://newjerseymonitor.com/wp-content/uploads/2024/07/GettyImages-2161390521.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/07/GettyImages-2161390521.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/07/GettyImages-2161390521-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/07/GettyImages-2161390521-768x512.jpg 768w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">Gov. Phil Murphy said Tuesday he is in the "final stages" of choosing an interim replacement for Sen. Bob Mendendez, who is resigning next week. (Photo by Michael M. Santiago/Getty Images)</p><p><span data-preserver-spaces="true">Sen. Bob Menendez, convicted of </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/07/16/sen-menendez-convicted-of-bribery-other-charges-in-corruption-trial/" target="_blank" rel="noopener"><span data-preserver-spaces="true">bribery and acting as a foreign agent</span></a><span data-preserver-spaces="true"> last month, is scheduled to resign in one week, and Gov. Phil Murphy has not divulged who he will name to take the senior senator’s place. </span></p>
+<p><span data-preserver-spaces="true">In a CNN interview Tuesday morning, Murphy said he’s in the “final stages” of selecting Menendez’s interim successor, who would replace the senator until his term ends Jan. 3. Murphy said he will choose “somebody who’s got Jersey first in everything they do.”</span></p>
+<p><span data-preserver-spaces="true">“I promise, folks, it’ll be someone who will stand up for New Jersey’s values and interests, and do a heck of a job,” he said.</span></p>
+<p><span data-preserver-spaces="true">Menendez announced last month that he will </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/07/23/sen-menendez-to-resign-ending-storied-career-capped-by-bribery-conviction/" target="_blank" rel="noopener"><span data-preserver-spaces="true">resign from the Senate effective Aug. 20</span></a><span data-preserver-spaces="true">. The senator, who was found guilty of taking bribes in exchange for wielding his influence in foreign matters and domestic criminal cases, has maintained his innocence but said he does not want his legal battle to detract from the Senate’s work.</span></p>
+<p><span data-preserver-spaces="true">Murphy noted Tuesday that first lady Tammy Murphy — who waged <a href="https://newjerseymonitor.com/2024/03/27/tammy-murphy-calls-for-democratic-unity-after-ending-senate-bid-but-offers-no-endorsement-yet/" target="_blank" rel="noopener">a brief campaign to win election to the Senate</a> earlier this year — has said she does not want to be considered for the appointment. </span></p>
+<p><span data-preserver-spaces="true">“Beyond that, I’m going to have to leave you hanging,” the governor told CNN News Central host Kate Bolduan. </span></p>
+<p><span data-preserver-spaces="true">U.S. Rep. Andy Kim (D-03) and Republican Curtis Bashaw will <a href="https://newjerseymonitor.com/2024/06/04/rep-andy-kim-projected-to-win-democratic-nod-for-u-s-senate/" target="_blank" rel="noopener">face off in November</a> for the chance to represent New Jersey in the Senate starting next year. As of Tuesday, Menendez is also running in November’s election as an independent candidate. The deadline for him to withdraw is Friday. </span></p>
+<p><span data-preserver-spaces="true">Republicans have urged Murphy </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/briefs/gop-wants-governor-to-name-caretaker-not-rep-kim-to-replace-sen-menendez/" target="_blank" rel="noopener"><span data-preserver-spaces="true">not to appoint Kim</span></a><span data-preserver-spaces="true"> and instead pick a caretaker who is not interested in the job beyond the temporary appointment.</span></p>
+<figure id="attachment_11720" class="wp-caption alignleft" style="max-width:100%;width:300px;"><a href="https://newjerseymonitor.com/2024/02/09/advocates-fear-would-be-successors-to-sen-bob-menendez-lack-his-commitment-to-immigrants/pcmilrmay2019/" rel="attachment wp-att-11720"><img decoding="async" loading="lazy" class="size-medium wp-image-11720" src="https://newjerseymonitor.com/wp-content/uploads/2024/02/PCMILRMay2019-300x200.jpg" alt="" width="300" height="200" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/02/PCMILRMay2019-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/02/PCMILRMay2019-1024x683.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2024/02/PCMILRMay2019-768x512.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2024/02/PCMILRMay2019-1536x1024.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2024/02/PCMILRMay2019-2048x1366.jpg 2048w" sizes="(max-width: 300px) 100vw, 300px" /></a><figcaption class="wp-caption-text"><i class="fas fa-camera"></i>  <em>Patricia Campos-Medina (Courtesy of the Campos-Medina campaign)</em></p></figure>
+<p><span data-preserver-spaces="true">Some Democrats are </span><a class="editor-rtfLink" href="https://www.insidernj.com/allies-ask-governor-murphy-to-consider-campos-medina-for-senate-seat/" target="_blank" rel="noopener"><span data-preserver-spaces="true">urging Murphy to choose Patricia Campos-Medina</span></a><span data-preserver-spaces="true">, a progressive labor leader who opposed Kim for the Democratic nomination for Senate in June. About four dozen people sent a letter to Murphy last week saying he should use his appointment power “to recognize the importance of the Latino community.” Menendez was revered by the community.</span></p>
+<p><span data-preserver-spaces="true">Paterson Councilman Luis Velez is among those who signed the letter. He said Campos-Medina would “bring the peace that the Democratic Party needs at this time.” </span></p>
+<p><span data-preserver-spaces="true">“I think she deserves to be there. She’s a hard-working woman, and she will represent the community quite well,” he said. </span></p>
+<p><span data-preserver-spaces="true">Velez noted that Campos-Medina finished second in June’s primary behind Kim, garnering about 16% of the vote. </span></p>
+<p><span data-preserver-spaces="true">If appointed to the seat, Campos-Medina would become the first woman, and the first Latina, to represent New Jersey in the U.S. Senate. </span></p>
+<p><span data-preserver-spaces="true">Campos-Medina said she’s honored by the groundswell of community leaders’ support for to be named to the Senate. </span></p>
+<p><span data-preserver-spaces="true">“This is the Governor’s choice to make, but of course, I am ready to serve if asked to give stability to this critical position at this critical time in our politics,” she said in a statement. “I ran for office to make sure women and New Jersey working families had a voice in this election. I will continue doing so as an active public servant and leader.”</span></p>
+<blockquote class="wp-embedded-content" data-secret="hTAtJQuLoY"><p><a href="https://newjerseymonitor.com/2024/07/22/close-the-chapter-move-on-latinos-say-after-sen-menendezs-bribery-conviction/">&#8216;Close the chapter, move on,&#8217; Latinos say after Sen. Menendez&#8217;s bribery conviction</a></p></blockquote>
+<p><iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted" title="&#8220;&#8216;Close the chapter, move on,&#8217; Latinos say after Sen. Menendez&#8217;s bribery conviction&#8221; &#8212; New Jersey Monitor" src="https://newjerseymonitor.com/2024/07/22/close-the-chapter-move-on-latinos-say-after-sen-menendezs-bribery-conviction/embed/#?secret=7DmOM6CvGZ#?secret=hTAtJQuLoY" data-secret="hTAtJQuLoY" width="500" height="282" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe></p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Governor Murphy signs bills intended to boost student literacy</title>
+		<link>https://newjerseymonitor.com/briefs/governor-murphy-signs-bills-intended-to-boost-student-literacy/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Tue, 13 Aug 2024 16:26:08 +0000</pubDate>
+				<category><![CDATA[Education]]></category>
+		<category><![CDATA[Craig Coughlin]]></category>
+		<category><![CDATA[Learning loss]]></category>
+		<category><![CDATA[Phil Murphy]]></category>
+		<category><![CDATA[Teresa Ruiz]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?post_type=briefs&#038;p=14286</guid>
+
+					<description><![CDATA[The new law requires semi-annual literacy screenings for students through the third grade and mandated intervention for those falling behind.]]></description>
+																						<content:encoded><![CDATA[<img width="800" height="544" src="https://newjerseymonitor.com/wp-content/uploads/2022/03/42712297215_30935ab2e2_c.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2022/03/42712297215_30935ab2e2_c.jpg 800w, https://newjerseymonitor.com/wp-content/uploads/2022/03/42712297215_30935ab2e2_c-300x204.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2022/03/42712297215_30935ab2e2_c-768x522.jpg 768w" sizes="(max-width: 800px) 100vw, 800px" /><p style="font-size:12px;">The new law requires semi-annual literacy screenings for students through the third grade and mandated intervention for those falling behind. (Courtesy of the New Jersey Governor's Office)</p><p><span data-preserver-spaces="true">Gov. Phil Murphy signed a bill Tuesday that will require the state’s youngest students to be screened for literacy in what supporters said is a bid to claw back from pandemic learning losses.</span></p>
+<p><a class="editor-rtfLink" href="https://pub.njleg.state.nj.us/Bills/2024/S3000/2644_U1.PDF" target="_blank" rel="noopener"><span data-preserver-spaces="true">The bill</span></a><span data-preserver-spaces="true">, which won unanimous support in both chambers of the Legislature, will require students in kindergarten through third grade to be screened for literacy at least twice a year beginning in the 2025-26 school year, with parental notifications and mandated intervention for those falling behind their peers.</span></p>
+<p><span data-preserver-spaces="true">“Recent years have brought forth many challenges for our schools and our children. Understanding that strong reading skills have the potential to open countless doors for young learners, we must work together to support accelerated literacy learning in communities across the state,” Murphy said at a bill signing ceremony at Newark’s Park Elementary School.</span></p>
+<p><span data-preserver-spaces="true">The bill further requires the Department of Education to create a literacy training program for teachers and librarians serving students through the sixth grade.</span></p>
+<p><span data-preserver-spaces="true">A working group on student literacy created by the bill will be responsible for drafting recommendations on the literacy screening process and creating materials to enhance students’ reading skills.</span></p>
+
+<p><span data-preserver-spaces="true">“You look at the numbers in the state of New Jersey — third and fourth graders, more than half of the general population are not meeting great expectations in reading,” said bill sponsor Sen. Teresa Ruiz (D-Essex). “From birth to third grade, you are learning to read … From third grade and beyond, you are reading to learn.”</span></p>
+<p><span data-preserver-spaces="true">A </span><a class="editor-rtfLink" href="https://pub.njleg.state.nj.us/Bills/2024/A2500/2288_U1.PDF" target="_blank" rel="noopener"><span data-preserver-spaces="true">separate bill</span></a><span data-preserver-spaces="true"> signed Tuesday will create an office within the Department of Education that will be tasked with implementing policies to boost literacy and study how to close student achievement gaps.</span></p>
+<p><span data-preserver-spaces="true">“We have the most dedicated professionals and teachers. When they&#8217;re given the resources they need to serve students, they open up a world of possibilities for everybody,” said Assembly Speaker Craig Coughlin (D-Middlesex).</span></p>
+<p><span data-preserver-spaces="true">    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	</span></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>N.J. panel to hear new case of cop fired for using cannabis</title>
+		<link>https://newjerseymonitor.com/2024/08/13/n-j-panel-to-to-hear-new-case-of-cop-fired-for-using-cannabis/</link>
+		
+		<dc:creator><![CDATA[Sophie Nieto-Munoz]]></dc:creator>
+		<pubDate>Tue, 13 Aug 2024 11:14:32 +0000</pubDate>
+				<category><![CDATA[Civil Rights + Immigration]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14283</guid>
+
+					<description><![CDATA[The meeting comes nearly two weeks after a federal judge declined to weigh in on whether federal law bars cops from using cannabis off duty.]]></description>
+																						<content:encoded><![CDATA[<img width="800" height="536" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/marijuana2520plastic2520bag2520is2520tt1667977115.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/marijuana2520plastic2520bag2520is2520tt1667977115.jpg 800w, https://newjerseymonitor.com/wp-content/uploads/2024/08/marijuana2520plastic2520bag2520is2520tt1667977115-300x201.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/marijuana2520plastic2520bag2520is2520tt1667977115-768x515.jpg 768w" sizes="(max-width: 800px) 100vw, 800px" /><p style="font-size:12px;">The meeting comes nearly two weeks after a federal judge declined to weigh in on whether federal law bars cops from using cannabis off duty. (Getty Images/iStockphoto)</p><p style="font-weight: 400;">Nearly two weeks after a federal judge said he wouldn’t weigh in yet on <a href="https://newjerseymonitor.com/2024/08/02/judge-wont-decide-whether-new-jersey-cops-can-use-cannabis-off-duty/">whether it’s legal for New Jersey cops to use marijuana</a>, the Civil Service Commission is set to decide the fate of another police officer who was terminated for ingesting cannabis.</p>
+<p style="font-weight: 400;">On Wednesday, the commission is expected to hear the case of Mackenzie Reilly, a Jersey City police officer fired in August 2023 after a drug test showed his urine tested positive for cannabis.</p>
+<p style="font-weight: 400;">Reilly is one of five Jersey City police officers fighting their terminations for cannabis use and seeking to dismiss <a href="https://newjerseymonitor.com/2023/10/17/jersey-city-sues-new-jersey-in-bid-to-halt-cops-from-using-cannabis/">a lawsuit Jersey City filed against the state</a> in October that argues the federal ban on cannabis preempts the state law legalizing the substance.</p>
+<p style="font-weight: 400;">An administrative law judge has recommended the commission reverse Reilly’s termination.</p>
+<p style="font-weight: 400;">New Jersey legalized cannabis in 2021, and after the marijuana legalization act went into effect, the state attorney general said police officers cannot be disciplined for using marijuana legally and off duty.</p>
+<p style="font-weight: 400;">When the state issued that memo, Jersey City Mayor Steve Fulop announced the city would defy the state and continue<a href="https://newjerseymonitor.com/2023/08/28/new-jersey-cops-are-winning-fight-to-use-cannabis-while-off-duty/"> to bar its officers from using cannabis</a>. Fulop is seeking the Democratic nomination for governor in 2025.</p>
+<p style="font-weight: 400;">Reilly, Omar Polanco, Norhan Mansour, Montavious Patten, and Richie Lopez are the five cops named as defendants in the lawsuit, arguing they should be able to consume legal cannabis and hold their jobs as cops. The Civil Service Commission has already ordered the city to reinstate Mansour and Polanco, though it is unclear if the city has hired them back to their posts.</p>
+<p style="font-weight: 400;">In its lawsuit against New Jersey, attorneys for the city have argued that police officers are subject to a federal law that bans people from possessing firearms and ammunition if they use cannabis. That federal law, they say, preempts the state’s marijuana legalization law. But the Civil Service Commission and administrative law judges have repeatedly found otherwise.</p>
+<p style="font-weight: 400;">The five officers and the Jersey City Police Officers Benevolent Association maintain the city has no standing to sue and claim the city filed in federal court only because they have been losing in the state employment proceedings.</p>
+<p style="font-weight: 400;">The judge overseeing the lawsuit on Aug. 2 declined to step in, staying his findings at least until all the officers fighting their terminations have had their cases heard by the Civil Service Commission.</p>
+<p style="font-weight: 400;">    <a href="https://newjerseymonitor.com/donate" style="text-decoration:none;">
+    <div class="donateContainer">
+        <div class="donateTextContainer">
+            <p>SUPPORT NEWS YOU TRUST.</p>
+        </div>
+        <div class="donateButtonContainer">
+            <button>DONATE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Mass deportations would be a moral, logistical and economic disaster</title>
+		<link>https://newjerseymonitor.com/2024/08/13/mass-deportations-would-be-a-moral-logistical-and-economic-disaster/</link>
+		
+		<dc:creator><![CDATA[Alliyah Lusuegro]]></dc:creator>
+		<pubDate>Tue, 13 Aug 2024 11:03:33 +0000</pubDate>
+				<category><![CDATA[Commentary]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14280</guid>
+
+					<description><![CDATA[Mass deportation would be a logistical disaster, taking decades and costing billions. This country would suffer, too.]]></description>
+																						<content:encoded><![CDATA[<img width="800" height="534" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/mass-deportation-now-sign1722254609.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/mass-deportation-now-sign1722254609.jpg 800w, https://newjerseymonitor.com/wp-content/uploads/2024/08/mass-deportation-now-sign1722254609-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2024/08/mass-deportation-now-sign1722254609-768x513.jpg 768w" sizes="(max-width: 800px) 100vw, 800px" /><p style="font-size:12px;">A person holds a sign that reads "Mass Deportation Now" on the third day of the Republican National Convention at the Fiserv Forum on July 17, 2024 in Milwaukee, Wisconsin. (Leon Neal/Getty Images)</p><p>There’s an image that’s stayed with me for weeks: A sea of people holding up “Mass Deportation Now” signs at the Republican National Convention.</p>
+<p>Since then, I’ve been plagued with nightmares of mass raids by the military and police across the country. I see millions of families being torn apart, including families with citizen children. And I see DACA recipients — like me — carried away from the only life we’ve ever known.</p>
+<p>Mass deportation wasn’t just a rallying cry at the GOP convention. It’s a <a href="https://americasvoice.org/blog/project-2025-immigration/" target="_blank">key plank of Project 2025</a>, a radical document written by white nationalists listing conservative policy priorities for the next administration.</p>
+<p>And it would be a disaster — not just for immigrants, but for our whole country.</p>
+<p>I moved to the United States when I was six. Until my teenage years, I didn’t know I was undocumented — I only knew I was from the Philippines. I grew up in Chicago with my twin brother. Our parents worked hard, volunteered at my elementary school, and ensured we always had food on the table. They raised us to do well and be good people.</p>
+<p>But when my twin and I learned that we were undocumented, we realized that living our dreams was going to be complicated — on top of the lasting fear of being deported.</p>
+<p>Everything changed right before I entered high school in 2012: The Obama administration announced the <a href="https://www.uscis.gov/DACA" target="_blank">Deferred Actions for Childhood Arrivals</a> policy, or DACA. The program was designed to protect young people like my twin and me who arrived in the U.S. at a young age with limited or no knowledge of our life before. We’re two of the <a href="https://www.migrationpolicy.org/programs/data-hub/deferred-action-childhood-arrivals-daca-profiles" target="_blank">600,000 DACA recipients</a> today.</p>
+<p>DACA opened many doors for us. It’s allowed us to drive, attend college, and have jobs. And we’re temporarily exempt from deportation, a status we have to renew every two years.</p>
+<p>DACA helped me set my sights high on my studies and career. Although I couldn’t apply for federal aid, with DACA I became eligible for a program called QuestBridge that granted me a full-ride scholarship to college. Today I work in public policy in the nation’s capital, with dreams of furthering my career through graduate school.</p>
+<p>But if hardliners eliminate DACA and carry out their mass deportations, those dreams could be swept away. And it would be ugly — mass deportation would be <a href="https://www.nytimes.com/2024/07/17/us/trump-immigration-republicans-explained.html" target="_blank">a logistical disaster, taking decades and costing billions</a>.</p>
+<p>Imagine your friends, neighbors, colleagues, peers, and caretakers being dragged away from their homes. For me, it would mean being forced back to the Philippines, a place I haven’t seen in two decades. My partner, my friends, my work — all I’ve ever known is here, in the country I call home.</p>
+<p>This country would suffer, too.</p>
+<p>An estimated<a href="https://www.dhs.gov/sites/default/files/2024-05/2024_0418_ohss_estimates-of-the-unauthorized-immigrant-population-residing-in-the-united-states-january-2018%E2%80%93january-2022.pdf" target="_blank"> 11 million undocumented people live here</a>. We’re doctors, chefs, librarians, construction workers, lawyers, drivers, scientists, and business owners. We fill labor shortages and help keep inflation down. We contribute <a href="https://itep.org/study-undocumented-immigrants-contribute-nearly-100-billion-in-taxes-a-year/" target="_blank">nearly $100 billion each year</a> to federal, state, and local taxes.</p>
+<p>Fear-mongering politicians want you to believe we’re criminals, or that we’re voting illegally. But again and again, studies find that immigrants <a href="https://www.nytimes.com/2024/07/18/briefing/the-myth-of-migrant-crime.html#:~:text=When%20an%20undocumented%20immigrant%20does,local%20residents%20were%20often%20hostile." target="_blank">commit many fewer crimes</a> than U.S.-born Americans. And though some of us have been long-time residents of this country, we cannot vote in state or federal elections.</p>
+<p>Despite all the divisive rhetoric, the American people agree with immigration advocates: Our country needs to offer immigrants a path to legalization and citizenship. According to a Gallup poll last year, <a href="https://news.gallup.com/poll/508520/americans-value-immigration-concerns.aspx" target="_blank">68 percent of Americans support this</a>.</p>
+<p>My dark dreams of mass deportations are, thankfully, just nightmares for now. And my dreams of a secure future for my family and all people in this country outweigh my fears. We must do everything possible to keep <i>all</i> families together.</p>
+<p><em>This commentary was originally published by <a href="https://otherwords.org/mass-deportations-would-be-a-nightmare/" target="_blank">Otherwords.org</a>. </em></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>State council can&#8217;t shield records from disclosure during disputes, court rules</title>
+		<link>https://newjerseymonitor.com/2024/08/12/state-council-cant-shield-records-from-disclosure-during-disputes-court-rules/</link>
+		
+		<dc:creator><![CDATA[Nikita Biryukov]]></dc:creator>
+		<pubDate>Mon, 12 Aug 2024 15:28:55 +0000</pubDate>
+				<category><![CDATA[Courts]]></category>
+		<category><![CDATA[CJ Griffin]]></category>
+		<category><![CDATA[Francis Vernoia]]></category>
+		<category><![CDATA[Government Records Council]]></category>
+		<category><![CDATA[John Paff]]></category>
+		<category><![CDATA[Libertarians for Transparent Government]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14276</guid>
+
+					<description><![CDATA[A Government Records Council rule that kept records dispute submissions confidential has no basis in law and no public purpose, judges rule.]]></description>
+																						<content:encoded><![CDATA[<img width="1024" height="684" src="https://newjerseymonitor.com/wp-content/uploads/2023/12/GettyImages-1130500593-1024x684.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2023/12/GettyImages-1130500593-1024x684.jpg 1024w, https://newjerseymonitor.com/wp-content/uploads/2023/12/GettyImages-1130500593-300x200.jpg 300w, https://newjerseymonitor.com/wp-content/uploads/2023/12/GettyImages-1130500593-768x513.jpg 768w, https://newjerseymonitor.com/wp-content/uploads/2023/12/GettyImages-1130500593-1536x1026.jpg 1536w, https://newjerseymonitor.com/wp-content/uploads/2023/12/GettyImages-1130500593-2048x1368.jpg 2048w" sizes="(max-width: 1024px) 100vw, 1024px" /><p style="font-size:12px;">A Government Records Council rule that kept records dispute submissions confidential has no basis in law and no public purpose, judges rule. (Getty Images)</p><p><span data-preserver-spaces="true">A New Jersey appellate panel struck down a regulation Monday that shields from disclosure documents submitted to the state body that oversees public record disputes, finding the rule has no basis in law and runs counter to the transparency legislation the Government Records Council is tasked with enforcing.</span></p>
+<p><span data-preserver-spaces="true">The </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2023/09/20/transparency-watchdog-fights-new-rule-that-keeps-disputes-over-public-records-a-secret/" target="_blank" rel="noopener"><span data-preserver-spaces="true">disputed 2022 rule</span></a><span data-preserver-spaces="true"> requires all documents submitted to it as part of a dispute under the Open Public Records Act to be kept confidential until the council reaches a decision in a given case. The council </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2022/07/26/n-j-s-lag-in-public-record-disputes-undermines-transparency-watchdog-says/" target="_blank" rel="noopener"><span data-preserver-spaces="true">takes nearly two years</span></a><span data-preserver-spaces="true"> to resolve the average records dispute.</span></p>
+<p><span data-preserver-spaces="true">“The regulation violates OPRA&#8217;s plainly stated requirements, finds no basis in OPRA, and is inconsistent with the well-established legislative mandate that the citizens of this state are entitled to prompt and full public access to government records under OPRA,” Judge Francis Vernoia </span><a class="editor-rtfLink" href="https://www.njcourts.gov/system/files/court-opinions/2024/a0963-22.pdf" target="_blank" rel="noopener"><span data-preserver-spaces="true">wrote for the court</span></a><span data-preserver-spaces="true">.</span></p>
+<p><span data-preserver-spaces="true">The regulation, the judges added, essentially allows the Government Records Council to substitute its own timeline for the mandatory seven-day response period provided by the public records law. The regulation represents an effective exemption in the Open Public Records Act that does not exist in the law, they added.</span></p>
+<p><span data-preserver-spaces="true">“In its ruling today, the Appellate Division has shown us that the judicial branch continues to uphold government transparency, even if the legislative and executive branches do not,” plaintiff John Paff, executive director of Libertarian for Transparent Government, said in a statement.</span></p>
+<p><span data-preserver-spaces="true">The Government Records Council argued that the rule is needed to shield their languorous proceedings from undue influence and to prevent personal information from being disclosed.</span></p>
+<p><span data-preserver-spaces="true">But the judges noted the Open Public Records Act already has provisions to protect requestors’ privacy. There is no reasonable expectation that records requests would remain private, they added. Requests made under the law are also considered public records.</span></p>
+<p><span data-preserver-spaces="true">Other GRC regulations allow requestors to file records disputes anonymously, the judges said, and those regulations require the challenger to show that unmasking them would create a threat of physical harm or reveal private information, among other things.</span></p>
+<p><span data-preserver-spaces="true">Shielding public records disputes would also harm the rights of any person or group that would intervene in a public records dispute, the judges ruled. Because the regulation “drapes all pending denial-of-access cases in a cloak of secrecy until final disposition,” potential intervenors would be unaware of pending cases until they are no longer pending, the court found.</span></p>
+<p><span data-preserver-spaces="true">They said the regulation “does nothing more than hide from public view the performance of the GRC&#8217;s essential function of adjudicating denial-of-access complaints.”</span></p>
+<p><span data-preserver-spaces="true">“Today’s decision ensures that these cases are not litigated in complete secrecy as the GRC desired, without reporters being able to track their progress and report about the types of violations agencies are committing,” said CJ Griffin, who represented Libertarians for Transparent Government.</span></p>
+<p><span data-preserver-spaces="true">Griffin has represented the New Jersey Monitor in numerous legal matters. The Government Records Council did not immediately return a request for comment.</span></p>
+<p><span data-preserver-spaces="true">The court’s Monday decision comes months after the Legislature passed and Gov. Phil Murphy </span><a class="editor-rtfLink" href="https://newjerseymonitor.com/2024/06/07/the-open-public-records-act-once-touted-as-a-major-reform-dies-at-22/" target="_blank" rel="noopener"><span data-preserver-spaces="true">signed a bill weakening public records disclosure in New Jersey</span></a><span data-preserver-spaces="true">.</span></p>
+<p><span data-preserver-spaces="true">That law, due to take effect in early September, exempts numerous new documents from disclosure, ends mandatory fee-shifting that has formed the basis of enforcement of the law in the courts, and allows commercial requestors to pay to have their requests filled before others, among numerous other things.</span></p>
+<p><span data-preserver-spaces="true">“With the Legislature’s decision to gut OPRA over the will of the people, we know for certain that agencies will deny more requests or impose insane service charges to keep records from people. We’re already seeing it happen,” Griffin said.</span></p>
+]]></content:encoded>
+					
+		
+		
+			</item>
+		<item>
+		<title>Unfair labor laws are cheating farmworkers, lawsuit claims</title>
+		<link>https://newjerseymonitor.com/2024/08/12/unfair-labor-laws-are-cheating-farmworkers-lawsuit-claims/</link>
+		
+		<dc:creator><![CDATA[Sophie Nieto-Munoz]]></dc:creator>
+		<pubDate>Mon, 12 Aug 2024 11:11:44 +0000</pubDate>
+				<category><![CDATA[Courts]]></category>
+		<category><![CDATA[Economy]]></category>
+		<guid isPermaLink="false">https://newjerseymonitor.com/?p=14272</guid>
+
+					<description><![CDATA[The plaintiffs want farmworkers to receive the same minimum wage and overtime requirements that most other workers get.]]></description>
+																						<content:encoded><![CDATA[<img width="600" height="400" src="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1002326500_300x200.jpg" class="attachment-large size-large wp-post-image" alt="" decoding="async" style="margin-bottom: 10px;" loading="lazy" srcset="https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1002326500_300x200.jpg 600w, https://newjerseymonitor.com/wp-content/uploads/2024/08/GettyImages-1002326500_300x200-300x200.jpg 300w" sizes="(max-width: 600px) 100vw, 600px" /><p style="font-size:12px;">The plaintiffs want farmworkers to receive the same minimum wage and overtime requirements that most other workers get. (Courtesy of the New Jersey Department of Agriculture)</p><p><span data-preserver-spaces="true">At age 14, Edgar Aquino-Huerta began working on the farms of New Jersey, picking produce and carrying heavy crates to help his family earn a living. But it wasn’t until he left the fields for community college and started working in a factory that he learned about overtime pay. </span></p>
+<p><span data-preserver-spaces="true">He discovered that after 40 hours at his job stacking boxes of avocados, he’d be paid nearly $12, up from his roughly $8 hourly wage at the time. </span></p>
+<p><span data-preserver-spaces="true">“I started asking my family members who also worked in agriculture, ‘Do you guys get paid overtime?’ and they don’t. Then I was like, ‘You guys work over 12 hours a day in the fields. This isn’t making any sense that you don’t qualify for overtime,’” said Aquino-Huerta. </span></p>
+<p><span data-preserver-spaces="true">Aquino-Huerta is a member of El Comité de Apoyo a los Trabajadores Agrícolas, or CATA, a South Jersey-based nonprofit organization supporting agricultural workers in the Garden State. </span></p>
+<p><a class="editor-rtfLink" href="https://newjerseymonitor.com/wp-content/uploads/2024/08/202487_cata_complaint_final_redacted.pdf" target="_blank" rel="noopener"><span data-preserver-spaces="true">The group filed a complaint</span></a><span data-preserver-spaces="true"> in state Superior Court in Mercer County last week accusing the state of discriminating against farmworkers by excluding them from the same provisions as most other workers covered by the state’s Wage and Hour Law. CATA is seeking a permanent injunction to prevent the state from enforcing what they say are discriminatory exclusions. </span></p>
+<p><span data-preserver-spaces="true">“It would just mean that farmworkers would be treated just like every other worker that’s entitled to the overtime and minimum wage provisions of New Jersey law,” said Jenny-Brooke Condon, a professor of law at Seton Hall Law School who directs the school’s Equal Justice Clinic. </span></p>
+<p><span data-preserver-spaces="true">The Seton Hall Law School Center for Social Justice, the American Civil Liberties Union of New Jersey, and the ACLU Immigrants’ Rights Project filed the complaint, naming state Attorney General Matthew Platkin, state Labor Commissioner Rob Asaro-Angelo, and state Secretary of Agriculture Edward Wengryn as defendants. </span></p>
+<p><span data-preserver-spaces="true">In 2019, Gov. Phil Murphy signed a law that raised the minimum wage in phases over five years until it reached $15 per hour. Currently, the state’s minimum wage is $15.13 an hour for most workers. But the law carves out farmworkers, who earn $12.81 an hour, from the same increases. </span></p>
+<p><span data-preserver-spaces="true">They won’t reach $15 an hour until Jan. 1, 2027, three years later than the rest of the state. The slower approach to $15 an hour also applies to some seasonal employers and businesses with fewer than six employees. </span></p>
+<p><span data-preserver-spaces="true">The minimum wage rises annually because of a constitutional amendment voters approved in 2013. That means the wage floor for agricultural workers and most other workers won’t converge until 2030, Condon said, making farmworkers’ wage increases unfairly come “lower and slower” than the rest of the state.  </span></p>
+<p><span data-preserver-spaces="true">The complaint claims that by denying farmworkers equal pay and overtime violates farmworkers’ right to safety under the New Jersey Constitution, and the current wage laws extend “favoritism and immunity from fair labor obligations to the farm industry at the expense of vulnerable workers.” These violations also run afoul of the New Jersey Civil Rights Act, the complaint says. </span></p>
+<p><span data-preserver-spaces="true">Farmers and agricultural lobbyists have </span><a class="editor-rtfLink" href="https://www.northcountrypublicradio.org/news/story/27317/20150130/farm-bureau-fights-minimum-wage-hike-supports-more-conservation" target="_blank" rel="noopener"><span data-preserver-spaces="true">fought against mandated minimum wage increases</span></a><span data-preserver-spaces="true"> across the country, arguing that they would be </span><a class="editor-rtfLink" href="https://investigatemidwest.org/2024/02/28/why-the-oklahoma-farm-bureau-is-fighting-an-effort-to-increase-the-states-minimum-wage/" target="_blank" rel="noopener"><span data-preserver-spaces="true">too expensive for small farms</span></a><span data-preserver-spaces="true"> with thin profit margins. </span></p>
+<p><span data-preserver-spaces="true">Roughly 25,000 farm laborers work in New Jersey. It’s a strenuous job that’s done in all kinds of weather, from pouring rain to 100-degree heat. They spend their days bent over picking food and carrying heavy loads, most of the time with few breaks or access to shade, CATA members say in the complaint. </span></p>
+
+<p><span data-preserver-spaces="true">These workers often don’t speak English and can’t vote in New Jersey due to their immigration status or because they don’t live in New Jersey year-round.  Because of that, they’re effectively politically muted, said Condon. </span></p>
+<p><span data-preserver-spaces="true">This is the reason they’re taking the issue to the courts instead of seeking a legislative fix, she said. </span></p>
+<p><span data-preserver-spaces="true">The New Jersey Supreme Court has recognized farmworkers warrant special judicial protections because they’re among the state’s most marginalized residents. They are economically disadvantaged, live in rural areas far from legal resources or community organizations, don’t speak English, and lack union representation, the complaint states. </span></p>
+<p><span data-preserver-spaces="true">“That’s a sort of core and fundamental principle of equal protection that we can’t just leave to the legislative process when people are historically and consistently being discriminated against in the laws, which is the case for farmworkers, who have little political power to overturn that discriminatory treatment through the legislative process,” Condon said. </span></p>
+<p><span data-preserver-spaces="true">Manuel Guzman, lead organizer at CATA, said providing farmworkers with overtime pay and minimum wage requirements that most other workers receive would be life-changing. Food, rent, and transportation prices have surged in the last few years, and since farmworkers earn an average of $25,000 to $29,999 nationwide annually, any extra money would alleviate their financial burden, he said. </span></p>
+<p><span data-preserver-spaces="true">“Families who are dealing with health problems, with children who need school, to have the basics of food — as one says, bread from heaven,” he said in an interview translated from Spanish. </span></p>
+<p><span data-preserver-spaces="true">A change could also allow some workers to stay in New Jersey beyond the short farming season, Guzman added. Some agricultural workers live in houses near the farms, which are often cinder block housing filled with bunk beds or cots and shared bathrooms, rarely with air conditioning, the complaint says.   </span></p>
+<p><span data-preserver-spaces="true">“Who wants to live in a house like that? But they have no other choice because they’re not even getting paid that much,” Aquino-Huerta said. “So if farmworkers were included, you would actually be able to afford rent.” </span></p>
+    <a href="https://newjerseymonitor.com/subscribe" style="text-decoration:none;">
+    <div class="subscribeShortcodeContainer">
+        <div class="subscribeTextContainer">
+			<i class="fas fa-envelope"></i>
+            <p>GET THE MORNING HEADLINES DELIVERED TO YOUR INBOX</p>
+        </div>
+        <div class="subscribeButtonContainer">
+            <button>SUBSCRIBE</button>
+        </div>
+    </div>
+    </a>
+	
+]]></content:encoded>
+					
+		
+		
+			</item>
+	</channel>
+</rss>

--- a/test/gluttony_test.exs
+++ b/test/gluttony_test.exs
@@ -9,8 +9,9 @@ defmodule GluttonyTest do
     xml2 = File.read!("test/fixtures/other/atom1_the_next_web.rss")
     xml3 = File.read!("test/fixtures/other/rss2_jovem_nerd.rss")
     xml4 = File.read!("test/fixtures/other/rss2_techcrunch.rss")
+    xml5 = File.read!("test/fixtures/other/rss2_njmonitor.rss")
 
-    {:ok, [xml1: xml1, xml2: xml2, xml3: xml3, xml4: xml4]}
+    {:ok, [xml1: xml1, xml2: xml2, xml3: xml3, xml4: xml4, xml5: xml5]}
   end
 
   describe "atom 1.0" do
@@ -37,7 +38,20 @@ defmodule GluttonyTest do
     test "TechCrunch", %{xml4: xml} do
       assert {:ok, %{feed: feed, entries: entries}} = Gluttony.parse_string(xml)
       assert feed.title == "TechCrunch"
+      # dc:creator element test, agnostic to item list order, either first and last items' authors can match
+      assert List.first(entries).author in ["Amanda Siberling", "Sarah Perez"]
       assert Enum.count(entries) == 20
+    end
+
+    test "NJ Monitor (Ghost)", %{xml5: xml} do
+      assert {:ok, %{feed: feed, entries: entries}} = Gluttony.parse_string(xml)
+      assert feed.title == "New Jersey Monitor"
+      assert Enum.count(entries) == 100
+
+      # content:encoded element test, should be full text much longer than the item description
+      entry = List.first(entries)
+      assert String.length(entry.content) > 1000
+      assert String.length(entry.content) > String.length(entry.description)
     end
   end
 


### PR DESCRIPTION
Updated PR that adds new functionality into specific namespace handlers

    Support dc:creator and content:encoded elements

    Adding support by adding the appropriate namespace handlers

    <dc:creator>

    The <author> element is spec'ed to be the author's email address. In practice,
    this is undesirable so many feeds use the <dc:creator> element which is just
    the author's name instead. Technically, an item should not have both an
    <author> and a <dc:creator> element. If it does, last value will overwrite and
    win.

    <content:encoded>

    This element is the RSS equivalent to Atom's content. Some feeds provide the
    full text of the post. In RSS, there is an optional element called
    content:encoded that roughly parallels Atom's content element, except that Atom
    does not prescribe HTML encoding of the text. This adds support for the
    content:encoded element.

